### PR TITLE
FIX Small build script corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 
 
 ## Bug Fixes
+- PR #5: Small build.sh fixes

--- a/build.sh
+++ b/build.sh
@@ -158,7 +158,7 @@ fi
 
 
 # Build and (optionally) install the cuml Python package
-if (( ${NUMARGS} == 0 )) || hasArg cuml; then
+if (( ${NUMARGS} == 0 )) || hasArg pyraft; then
 
     cd ${REPODIR}/python
     if [[ ${INSTALL_TARGET} != "" ]]; then

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -115,4 +115,4 @@ cd $WORKSPACE/cpp/build
 logger "Python pytest for cuml..."
 cd $WORKSPACE/python
 
-python -m pytest pytest --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v -s
+python -m pytest --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v -s

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -84,7 +84,7 @@ logger "Adding ${CONDA_PREFIX}/lib to LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH_CACHED=$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 
-logger "Build libcuml, cuml, prims and bench targets..."
+logger "Build C++ and Python targets..."
 $WORKSPACE/build.sh cppraft pyraft -v
 
 logger "Resetting LD_LIBRARY_PATH..."
@@ -92,9 +92,6 @@ logger "Resetting LD_LIBRARY_PATH..."
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_CACHED
 export LD_LIBRARY_PATH_CACHED=""
 
-logger "Build treelite for GPU testing..."
-
-cd $WORKSPACE
 
 
 ################################################################################
@@ -111,10 +108,12 @@ nvidia-smi
 
 logger "GoogleTest for raft..."
 cd $WORKSPACE/cpp/build
-GTEST_OUTPUT="xml:${WORKSPACE}/test-results/raft_cpp/" ./test/ml
+# Googletests haven't been moved over/integrated yet
+# GTEST_OUTPUT="xml:${WORKSPACE}/test-results/raft_cpp/" ./test/ml
+# running simple tests meanwhile
+./test_raft
 
 logger "Python pytest for cuml..."
 cd $WORKSPACE/python
 
-pytest --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v -s
-
+python -m pytest pytest --cache-clear --junitxml=${WORKSPACE}/junit-cuml.xml -v -s

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -109,9 +109,8 @@ nvidia-smi
 logger "GoogleTest for raft..."
 cd $WORKSPACE/cpp/build
 # Googletests haven't been moved over/integrated yet
-# GTEST_OUTPUT="xml:${WORKSPACE}/test-results/raft_cpp/" ./test/ml
+# GTEST_OUTPUT="xml:${WORKSPACE}/test-results/raft_cpp/" ./test_raft
 # running simple tests meanwhile
-./test_raft
 
 logger "Python pytest for cuml..."
 cd $WORKSPACE/python

--- a/cpp/include/raft.hpp
+++ b/cpp/include/raft.hpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 #include <string>
 
 namespace raft {
@@ -22,10 +21,9 @@ namespace raft {
 /* Function for testing RAFT include
  *
  * @return message indicating RAFT has been included succesfully*/
-inline std::string test_raft()
-{
-    std::string status = "RAFT Setup succesfully";
-    return status;
+inline std::string test_raft() {
+  std::string status = "RAFT Setup succesfully";
+  return status;
 }
 
 } // namespace raft

--- a/cpp/test/test.cpp
+++ b/cpp/test/test.cpp
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-
-#include <raft.hpp>
 #include <iostream>
+#include <raft.hpp>
 
-int main(){
-    std::string result = raft::test_raft();
-    std::cout << result;
+int main() {
+  std::string result = raft::test_raft();
+  std::cout << result;
 }

--- a/python/.flake8.cython
+++ b/python/.flake8.cython
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[flake8]
+filename = *.pyx, *.pxd
+exclude = *.egg, build, docs, .git
+ignore = E999, E225, E226, E227, W503, W504
+
+# Rules ignored:
+# E999: invalid syntax (works for Python, not Cython)
+# E225: Missing whitespace around operators (breaks cython casting syntax like <int>)
+# E226: Missing whitespace around arithmetic operators (breaks cython pointer syntax like int*)
+# E227: Missing whitespace around bitwise or shift operator (Can also break casting syntax)
+# W503: line break before binary operator (breaks lines that start with a pointer)
+# W504: line break after binary operator (breaks lines that end with a pointer)

--- a/python/setup.py
+++ b/python/setup.py
@@ -74,7 +74,7 @@ if clean_artifacts:
         clean_folder(setup_file_path + '/raft')
         shutil.rmtree(setup_file_path + '/build')
 
-    except IOError as e:
+    except IOError:
         pass
 
     # need to terminate script so cythonizing doesn't get triggered after


### PR DESCRIPTION
Small corrections for build scripts for CI tests. 

- Googletests have not been ported/checked in so commenting them for now
- Pytests need to be run with `python -m pytest...` to accomodate imports of raft (at least for now)