### PR TITLE
[REVIEW] commSplit Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## New Features
 - PR #7: Migrating cuml comms -> raft comms_t
+- PR #18: Adding commsplit to cuml communicator
 
 ## Improvements
 - PR #13: Add RMM_INCLUDE and RMM_LIBRARY options to allow linking to non-conda RMM

--- a/cpp/include/raft/comms/comms.hpp
+++ b/cpp/include/raft/comms/comms.hpp
@@ -89,8 +89,6 @@ constexpr datatype_t get_type<double>() {
 
 class comms_iface {
  public:
-  virtual ~comms_iface();
-
   virtual int get_size() const = 0;
   virtual int get_rank() const = 0;
 
@@ -322,8 +320,6 @@ class comms_t {
  private:
   std::unique_ptr<comms_iface> impl_;
 };
-
-comms_iface::~comms_iface() {}
 
 }  // namespace comms
 }  // namespace raft

--- a/cpp/include/raft/comms/helper.hpp
+++ b/cpp/include/raft/comms/helper.hpp
@@ -16,12 +16,13 @@
 
 #pragma once
 
-#include <nccl.h>
-#include <ucp/api/ucp.h>
-#include <iostream>
 #include <raft/comms/std_comms.hpp>
 #include <raft/handle.hpp>
 #include <raft/mr/device/buffer.hpp>
+
+#include <nccl.h>
+#include <ucp/api/ucp.h>
+#include <iostream>
 
 namespace raft {
 namespace comms {
@@ -39,11 +40,8 @@ void build_comms_nccl_only(handle_t *handle, ncclComm_t nccl_comm,
                            int num_ranks, int rank) {
   auto d_alloc = handle->get_device_allocator();
   cudaStream_t stream = handle->get_stream();
-  comms_iface *raft_comm =
-    new raft::comms::std_comms(nccl_comm, num_ranks, rank, d_alloc, stream);
-
-  auto communicator =
-    std::make_shared<comms_t>(std::unique_ptr<comms_iface>(raft_comm));
+  auto communicator = std::make_shared<comms_t>(std::unique_ptr<comms_iface>(
+    new raft::comms::std_comms(nccl_comm, num_ranks, rank, d_alloc, stream)));
   handle->set_comms(communicator);
 }
 
@@ -84,11 +82,9 @@ void build_comms_nccl_ucx(handle_t *handle, ncclComm_t nccl_comm,
   auto d_alloc = handle->get_device_allocator();
   cudaStream_t stream = handle->get_stream();
 
-  auto *raft_comm =
+  auto communicator = std::make_shared<comms_t>(std::unique_ptr<comms_iface>(
     new raft::comms::std_comms(nccl_comm, (ucp_worker_h)ucp_worker, eps_sp,
-                               num_ranks, rank, d_alloc, stream);
-  auto communicator =
-    std::make_shared<comms_t>(std::unique_ptr<comms_iface>(raft_comm));
+                               num_ranks, rank, d_alloc, stream)));
   handle->set_comms(communicator);
 }
 

--- a/cpp/include/raft/comms/std_comms.hpp
+++ b/cpp/include/raft/comms/std_comms.hpp
@@ -227,7 +227,6 @@ class std_comms : public comms_iface {
 
     allgather(color_buf.data(), colors.data(), 1, datatype_t::INT32, stream_);
     allgather(key_buf.data(), keys.data(), 1, datatype_t::INT32, stream_);
-
     this->sync_stream(stream_);
 
     // find all ranks with same color and lowest key of that color
@@ -247,9 +246,7 @@ class std_comms : public comms_iface {
         ranks_with_color.push_back(keys_host[i]);
         if (keys_host[i] < min_rank) min_rank = keys_host[i];
 
-        if (ucp_worker_ != nullptr) {
-          new_ucx_ptrs.push_back((*ucp_eps_)[i]);
-        }
+        if (ucp_worker_ != nullptr) new_ucx_ptrs.push_back((*ucp_eps_)[i]);
       }
     }
 
@@ -258,8 +255,6 @@ class std_comms : public comms_iface {
                          colors_host);
 
     ncclComm_t nccl_comm;
-
-    // create new nccl comm
     NCCL_CHECK(ncclCommInitRank(&nccl_comm, ranks_with_color.size(), id,
                                 keys_host[get_rank()]));
 

--- a/cpp/include/raft/comms/std_comms.hpp
+++ b/cpp/include/raft/comms/std_comms.hpp
@@ -46,7 +46,6 @@
 #include <memory>
 #include <thread>
 
-
 namespace raft {
 
 /**

--- a/cpp/include/raft/comms/test.hpp
+++ b/cpp/include/raft/comms/test.hpp
@@ -31,9 +31,9 @@ namespace comms {
  *        initialized comms instance.
  */
 bool test_collective_allreduce(const handle_t &handle, int root) {
-  const comms_t &communicator = handle.get_comms();
+  comms_t const &communicator = handle.get_comms();
 
-  const int send = 1;
+  int const send = 1;
 
   cudaStream_t stream = handle.get_stream();
 
@@ -63,9 +63,9 @@ bool test_collective_allreduce(const handle_t &handle, int root) {
  *        initialized comms instance.
  */
 bool test_collective_broadcast(const handle_t &handle, int root) {
-  const comms_t &communicator = handle.get_comms();
+  comms_t const &communicator = handle.get_comms();
 
-  const int send = root;
+  int const send = root;
 
   cudaStream_t stream = handle.get_stream();
 
@@ -91,9 +91,9 @@ bool test_collective_broadcast(const handle_t &handle, int root) {
 }
 
 bool test_collective_reduce(const handle_t &handle, int root) {
-  const comms_t &communicator = handle.get_comms();
+  comms_t const &communicator = handle.get_comms();
 
-  const int send = root;
+  int const send = root;
 
   cudaStream_t stream = handle.get_stream();
 
@@ -121,9 +121,9 @@ bool test_collective_reduce(const handle_t &handle, int root) {
 }
 
 bool test_collective_allgather(const handle_t &handle, int root) {
-  const comms_t &communicator = handle.get_comms();
+  comms_t const &communicator = handle.get_comms();
 
-  const int send = communicator.get_rank();
+  int const send = communicator.get_rank();
 
   cudaStream_t stream = handle.get_stream();
 
@@ -156,9 +156,9 @@ bool test_collective_allgather(const handle_t &handle, int root) {
 }
 
 bool test_collective_reducescatter(const handle_t &handle, int root) {
-  const comms_t &communicator = handle.get_comms();
+  comms_t const &communicator = handle.get_comms();
 
-  const int send = 1;
+  int const send = 1;
 
   cudaStream_t stream = handle.get_stream();
 
@@ -193,8 +193,8 @@ bool test_collective_reducescatter(const handle_t &handle, int root) {
  * @param number of iterations of all-to-all messaging to perform
  */
 bool test_pointToPoint_simple_send_recv(const handle_t &h, int numTrials) {
-  const comms_t &communicator = h.get_comms();
-  const int rank = communicator.get_rank();
+  comms_t const &communicator = h.get_comms();
+  int const rank = communicator.get_rank();
 
   bool ret = true;
   for (int i = 0; i < numTrials; i++) {
@@ -255,19 +255,18 @@ bool test_pointToPoint_simple_send_recv(const handle_t &h, int numTrials) {
  *
  * @param the raft handle to use. This is expected to already have an
  *        initialized comms instance.
+ * @param n_colors number of different colors to test
  */
 bool test_commsplit(const handle_t &h, int n_colors) {
-  const comms_t &communicator = h.get_comms();
-  const int rank = communicator.get_rank();
-  const int size = communicator.get_size();
+  comms_t const &communicator = h.get_comms();
+  int const rank = communicator.get_rank();
+  int const size = communicator.get_size();
 
   if (n_colors > size) n_colors = size;
 
-  int n_ranks_per_color = communicator.get_size() / n_colors;
-
   // first we need to assign to a color, then assign the rank within the color
   int color = rank % n_colors;
-  int key = rank % n_ranks_per_color;
+  int key = rank / n_colors;
 
   handle_t new_handle(1);
   auto shared_comm =

--- a/cpp/include/raft/comms/test.hpp
+++ b/cpp/include/raft/comms/test.hpp
@@ -250,7 +250,6 @@ bool test_pointToPoint_simple_send_recv(const handle_t &h, int numTrials) {
   return ret;
 }
 
-
 /**
  * A simple test that the comms can be split into 2 separate subcommunicators
  *
@@ -262,8 +261,7 @@ bool test_commsplit(const handle_t &h, int n_colors) {
   const int rank = communicator.get_rank();
   const int size = communicator.get_size();
 
-  if(n_colors > size)
-	  n_colors = size;
+  if (n_colors > size) n_colors = size;
 
   int n_ranks_per_color = communicator.get_size() / n_colors;
 
@@ -272,15 +270,12 @@ bool test_commsplit(const handle_t &h, int n_colors) {
   int key = rank % n_ranks_per_color;
 
   handle_t new_handle(1);
-  auto shared_comm = std::make_shared<comms_t>(communicator.comm_split(color, key));
+  auto shared_comm =
+    std::make_shared<comms_t>(communicator.comm_split(color, key));
   new_handle.set_comms(shared_comm);
 
-  const comms_t  &newcomms = new_handle.get_comms();
-  bool result = test_collective_allreduce(new_handle, 0);
-
-  return result;
+  return test_collective_allreduce(new_handle, 0);
 }
-
 
 }  // namespace comms
 };  // namespace raft

--- a/cpp/include/raft/comms/ucp_helper.hpp
+++ b/cpp/include/raft/comms/ucp_helper.hpp
@@ -164,6 +164,7 @@ class comms_ucp_handler {
   void free_ucp_request(ucp_request *request) const {
     if (request->needs_release) {
       request->req->completed = 0;
+      std::cout << "FREEING REQUEST" << std::endl;
       (*(req_free_func))(request->req);
     }
     free(request);
@@ -179,6 +180,9 @@ class comms_ucp_handler {
     ucs_status_ptr_t send_result = (*(send_func))(
       ep_ptr, buf, size, ucp_dt_make_contig(1), ucp_tag, send_callback);
     struct ucx_context *ucp_req = (struct ucx_context *)send_result;
+
+    std::cout << "REQ: " << ucp_req << std::endl;
+
     if (UCS_PTR_IS_ERR(send_result)) {
       ASSERT(!UCS_PTR_IS_ERR(send_result),
              "unable to send UCX data message (%d)\n",
@@ -221,6 +225,8 @@ class comms_ucp_handler {
     req->needs_release = true;
     req->is_send_request = false;
     req->other_rank = sender_rank;
+
+    std::cout << "REQ: " << ucp_req << std::endl;
 
     ASSERT(!UCS_PTR_IS_ERR(recv_result),
            "unable to receive UCX data message (%d)\n",

--- a/python/raft/dask/common/__init__.py
+++ b/python/raft/dask/common/__init__.py
@@ -24,3 +24,4 @@ from .comms_utils import perform_test_comms_allgather
 from .comms_utils import perform_test_comms_bcast
 from .comms_utils import perform_test_comms_reduce
 from .comms_utils import perform_test_comms_reducescatter
+from .comms_utils import perform_test_comm_split

--- a/python/raft/dask/common/__init__.py
+++ b/python/raft/dask/common/__init__.py
@@ -25,3 +25,5 @@ from .comms_utils import perform_test_comms_bcast
 from .comms_utils import perform_test_comms_reduce
 from .comms_utils import perform_test_comms_reducescatter
 from .comms_utils import perform_test_comm_split
+
+from .ucx import UCX

--- a/python/raft/dask/common/comms.py
+++ b/python/raft/dask/common/comms.py
@@ -375,9 +375,6 @@ async def _func_ucp_create_endpoints(sessionId, worker_info):
     worker_info : dict
                   Maps worker addresses to NCCL ranks & UCX ports
     """
-    dask_worker = get_worker()
-    local_address = dask_worker.address
-
     eps = [None] * len(worker_info)
     count = 1
 

--- a/python/raft/dask/common/comms.py
+++ b/python/raft/dask/common/comms.py
@@ -382,14 +382,12 @@ async def _func_ucp_create_endpoints(sessionId, worker_info):
     count = 1
 
     for k in worker_info:
-        if str(k) != str(local_address):
+        ip, port = parse_host_port(k)
 
-            ip, port = parse_host_port(k)
+        ep = await get_ucx().get_endpoint(ip, worker_info[k]["port"])
 
-            ep = await get_ucx().get_endpoint(ip, worker_info[k]["port"])
-
-            eps[worker_info[k]["rank"]] = ep
-            count += 1
+        eps[worker_info[k]["rank"]] = ep
+        count += 1
 
     worker_state(sessionId)["ucp_eps"] = eps
 

--- a/python/raft/dask/common/comms_utils.pyx
+++ b/python/raft/dask/common/comms_utils.pyx
@@ -145,16 +145,16 @@ def perform_test_comms_send_recv(handle, n_trials):
 
 
 def perform_test_comm_split(handle, n_colors):
-        """
-        Performs a p2p send/recv on the current worker
+    """
+    Performs a p2p send/recv on the current worker
 
-        Parameters
-        ----------
-        handle : raft.common.Handle
-                 handle containing comms_t to use
-        """
-        cdef const handle_t * h = < handle_t * > < size_t > handle.getHandle()
-        return test_commsplit(deref(h), < int > n_colors)
+    Parameters
+    ----------
+    handle : raft.common.Handle
+             handle containing comms_t to use
+    """
+    cdef const handle_t * h = < handle_t * > < size_t > handle.getHandle()
+    return test_commsplit(deref(h), < int > n_colors)
 
 
 def inject_comms_on_handle_coll_only(handle, nccl_inst, size, rank, verbose):

--- a/python/raft/dask/common/comms_utils.pyx
+++ b/python/raft/dask/common/comms_utils.pyx
@@ -31,7 +31,6 @@ cdef extern from "nccl.h":
     cdef struct ncclComm
     ctypedef ncclComm *ncclComm_t
 
-
 cdef extern from "raft/handle.hpp" namespace "raft":
     cdef cppclass handle_t:
         handle_t() except +
@@ -64,6 +63,7 @@ cdef extern from "raft/comms/test.hpp" namespace "raft::comms":
     bool test_collective_reducescatter(const handle_t &h, int root) except +
     bool test_pointToPoint_simple_send_recv(const handle_t &h,
                                             int numTrials) except +
+    bool test_commsplit(const handle_t &h, int n_colors) except +
 
 
 def perform_test_comms_allreduce(handle, root):
@@ -142,6 +142,19 @@ def perform_test_comms_send_recv(handle, n_trials):
     """
     cdef const handle_t *h = <handle_t*><size_t>handle.getHandle()
     return test_pointToPoint_simple_send_recv(deref(h), <int>n_trials)
+
+
+def perform_test_comm_split(handle, n_colors):
+        """
+        Performs a p2p send/recv on the current worker
+
+        Parameters
+        ----------
+        handle : raft.common.Handle
+                 handle containing comms_t to use
+        """
+        cdef const handle_t * h = < handle_t * > < size_t > handle.getHandle()
+        return test_commsplit(deref(h), < int > n_colors)
 
 
 def inject_comms_on_handle_coll_only(handle, nccl_inst, size, rank, verbose):

--- a/python/raft/dask/common/ucx.py
+++ b/python/raft/dask/common/ucx.py
@@ -68,6 +68,10 @@ class UCX:
 
         return ep
 
+    async def close_endpoints(self):
+        for k, ep in self._endpoints.items():
+            await ep.close()
+
     def __del__(self):
         for ip_port, ep in self._endpoints.items():
             if not ep.closed():

--- a/python/raft/test/conftest.py
+++ b/python/raft/test/conftest.py
@@ -5,6 +5,10 @@ from dask.distributed import Client
 from dask_cuda import initialize
 from dask_cuda import LocalCUDACluster
 
+import os
+os.environ["UCX_LOG_LEVEL"] = "error"
+
+
 enable_tcp_over_ucx = True
 enable_nvlink = False
 enable_infiniband = False
@@ -12,12 +16,9 @@ enable_infiniband = False
 
 @pytest.fixture(scope="session")
 def cluster():
-
-    print("Created Cluster")
     cluster = LocalCUDACluster(protocol="tcp", scheduler_port=0)
     yield cluster
     cluster.close()
-    print("Closed cluster")
 
 
 @pytest.fixture(scope="session")

--- a/python/raft/test/conftest.py
+++ b/python/raft/test/conftest.py
@@ -17,7 +17,7 @@ def cluster():
     cluster.close()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def ucx_cluster():
     initialize.initialize(create_cuda_context=True,
                           enable_tcp_over_ucx=enable_tcp_over_ucx,
@@ -26,8 +26,7 @@ def ucx_cluster():
     cluster = LocalCUDACluster(protocol="ucx",
                                enable_tcp_over_ucx=enable_tcp_over_ucx,
                                enable_nvlink=enable_nvlink,
-                               enable_infiniband=enable_infiniband,
-                               ucx_net_devices="auto")
+                               enable_infiniband=enable_infiniband)
     yield cluster
     cluster.close()
 

--- a/python/raft/test/conftest.py
+++ b/python/raft/test/conftest.py
@@ -10,11 +10,14 @@ enable_nvlink = False
 enable_infiniband = False
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def cluster():
+
+    print("Created Cluster")
     cluster = LocalCUDACluster(protocol="tcp", scheduler_port=0)
     yield cluster
     cluster.close()
+    print("Closed cluster")
 
 
 @pytest.fixture(scope="session")
@@ -31,7 +34,7 @@ def ucx_cluster():
     cluster.close()
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def client(cluster):
     client = Client(cluster)
     yield client

--- a/python/raft/test/test_comms.py
+++ b/python/raft/test/test_comms.py
@@ -119,41 +119,32 @@ def test_comm_split(client):
     cb = Comms(comms_p2p=True, verbose=True)
     cb.init()
 
-    for k, v in cb.worker_info(cb.worker_addresses).items():
+    dfs = [client.submit(func_test_comm_split,
+                         cb.sessionId,
+                         3,
+                         pure=False,
+                         workers=[w])
+           for w in cb.worker_addresses]
 
-        dfs = [client.submit(func_test_comm_split,
-                             cb.sessionId,
-                             3,
-                             pure=False,
-                             workers=[w])
-               for w in cb.worker_addresses]
-        wait(dfs, timeout=5)
+    wait(dfs, timeout=5)
 
-        assert all([x.result() for x in dfs])
+    assert all([x.result() for x in dfs])
 
 
 @pytest.mark.ucx
 @pytest.mark.parametrize("n_trials", [1, 5])
-def test_send_recv(n_trials, ucx_cluster):
+def test_send_recv(n_trials, client):
 
-    client = Client(ucx_cluster)
+    cb = Comms(comms_p2p=True, verbose=True)
+    cb.init()
 
-    try:
+    dfs = [client.submit(func_test_send_recv,
+                         cb.sessionId,
+                         n_trials,
+                         pure=False,
+                         workers=[w])
+           for w in cb.worker_addresses]
 
-        cb = Comms(comms_p2p=True, verbose=True)
-        cb.init()
+    wait(dfs, timeout=5)
 
-        dfs = [client.submit(func_test_send_recv,
-                             cb.sessionId,
-                             n_trials,
-                             pure=False,
-                             workers=[w])
-               for w in cb.worker_addresses]
-
-        wait(dfs, timeout=5)
-
-        assert(list(map(lambda x: x.result(), dfs)))
-
-    finally:
-        cb.destroy()
-        client.close()
+    assert(list(map(lambda x: x.result(), dfs)))


### PR DESCRIPTION
A simple commSplit implementation with associated end-to-end pytest that creates subcommunicators and performs separate allreduces on the subcommunicators. 