### PR TITLE
[REVIEW] set to OrderedDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Improvements
 - PR #13: Add RMM_INCLUDE and RMM_LIBRARY options to allow linking to non-conda RMM
+- PR #22: Preserve order in comms workers for rank initialization
 
 ## Bug Fixes
 - PR #17: Make destructor inline to avoid redeclaration error

--- a/python/raft/dask/common/comms.py
+++ b/python/raft/dask/common/comms.py
@@ -28,6 +28,7 @@ import warnings
 
 import time
 import uuid
+from collections import OrderedDict
 
 
 class Comms:
@@ -137,7 +138,7 @@ class Comms:
                   Unique collection of workers for initializing comms.
         """
 
-        self.worker_addresses = list(set(
+        self.worker_addresses = list(OrderedDict.fromkeys(
             self.client.scheduler_info()["workers"].keys()
             if workers is None else workers))
 


### PR DESCRIPTION
--> Set to OrderedDict
Cugraph opg algorithm currently requires that the worker ranks be initialized according to the partition they hold i.e. in the same order as the worker's key. While initializing comms, the worker_addresses are passed in this certain order which needs to be preserved for rank initialization. 