### PR TITLE
[REVIEW] Fix incorrect streams being returned from `get_internal_streams()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Bug Fixes
 - PR #17: Make destructor inline to avoid redeclaration error
+- PR #25: Fix bug in handle_t::get_internal_streams
 
 # RAFT 0.14.0 (Date TBD)
 

--- a/cpp/include/raft/handle.hpp
+++ b/cpp/include/raft/handle.hpp
@@ -128,7 +128,7 @@ class handle_t {
   cudaStream_t get_internal_stream(int sid) const { return streams_[sid]; }
   int get_num_internal_streams() const { return num_streams_; }
   std::vector<cudaStream_t> get_internal_streams() const {
-    std::vector<cudaStream_t> int_streams_vec(num_streams_);
+    std::vector<cudaStream_t> int_streams_vec;
     for (auto s : streams_) {
       int_streams_vec.push_back(s);
     }

--- a/cpp/test/handle.cpp
+++ b/cpp/test/handle.cpp
@@ -43,4 +43,10 @@ TEST(Raft, Handle) {
   CUDA_CHECK(cudaStreamDestroy(stream));
 }
 
+TEST(Raft, GetInternalStreams) {
+  handle_t h(4);
+  auto streams = h.get_internal_streams();
+  ASSERT_EQ(4U, streams.size());
+}
+
 }  // namespace raft


### PR DESCRIPTION
Current implementation of `handle_t::get_internal_streams()` used to return 2x the number of internal streams, which was incorrect. This PR fixes this bug and adds a small unit-test to verify the same.