### PR TITLE
[REVIEW] removing nccl.h from error.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - PR #25: Fix bug in handle_t::get_internal_streams
 - PR #26: Fix bug in RAFT_EXPECTS (add parentheses surrounding cond)
 - PR #34 Fix issue with incorrect docker image being used in local build script
+- PR #35: Remove #include <nccl.h> from `raft/error.hpp`
 
 # RAFT 0.14.0 (Date TBD)
 

--- a/cpp/include/raft/error.hpp
+++ b/cpp/include/raft/error.hpp
@@ -20,7 +20,6 @@
 #include <cuda_runtime_api.h>
 #include <curand.h>
 #include <cusparse_v2.h>
-#include <nccl.h>
 
 #include <execinfo.h>
 #include <iostream>


### PR DESCRIPTION
The include mentioned in the title seemed unnecessary as we aim to support Single-GPU builds in cuML.