### PR TITLE
[REVIEW] Update CI scripts to remove references to master [skip ci] 

### DIFF
--- a/ci/checks/black_lists.sh
+++ b/ci/checks/black_lists.sh
@@ -6,7 +6,6 @@
 
 # PR_TARGET_BRANCH is set by the CI enviroment
 
-# Checkout master for comparison
 git checkout --quiet $PR_TARGET_BRANCH
 
 # Switch back to tip of PR branch

--- a/ci/checks/changelog.sh
+++ b/ci/checks/changelog.sh
@@ -4,8 +4,8 @@
 # cuML CHANGELOG Tester #
 #########################
 
-# Checkout master for comparison
-git checkout --quiet master
+# Checkout main for comparison
+git checkout --quiet main
 
 # Switch back to tip of PR branch
 git checkout --quiet current-pr-branch
@@ -14,7 +14,7 @@ git checkout --quiet current-pr-branch
 set +e
 
 # Get list of modified files between matster and PR branch
-CHANGELOG=`git diff --name-only master...current-pr-branch | grep CHANGELOG.md`
+CHANGELOG=`git diff --name-only main...current-pr-branch | grep CHANGELOG.md`
 # Check if CHANGELOG has PR ID
 PRNUM=`cat CHANGELOG.md | grep "$PR_ID"`
 RETVAL=0


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.