### PR TITLE
[REVIEW] Fix for bug on cuda toolkit version selection mechanism select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PR #34: Fix issue with incorrect docker image being used in local build script
 - PR #35: Remove #include <nccl.h> from `raft/error.hpp`
 - PR #40: Preemptively fixed future CUDA 11 related errors.
+- PR #43: Fixed CUDA version selection mechanism for SpMV.
 
 # RAFT 0.14.0 (Date TBD)
 

--- a/cpp/include/raft/spectral/matrix_wrappers.hpp
+++ b/cpp/include/raft/spectral/matrix_wrappers.hpp
@@ -33,6 +33,19 @@
 // Get index of matrix entry
 #define IDX(i, j, lda) ((i) + (j) * (lda))
 
+//Notes:
+//(1.) CUDA_VER_SELECT aggregates all the CUDA version selection logic;
+//(2.) to enforce a lower version,
+//
+//`#define CUDA_ENFORCE_LOWER
+// #include <raft/spectral/matrix_wrappers.hpp>`
+//
+// (i.e., before including this header)
+//
+#define CUDA_VER_SELECT         \
+  (__CUDACC_VER_MAJOR__ > 10 or \
+   (__CUDACC_VER_MAJOR__ >= 10 and __CUDACC_VER_MINOR__ > 0))
+
 namespace raft {
 namespace matrix {
 
@@ -176,7 +189,7 @@ struct sparse_matrix_t {
       transpose ? CUSPARSE_OPERATION_TRANSPOSE :  // transpose
         CUSPARSE_OPERATION_NON_TRANSPOSE;         //non-transpose
 
-#if __CUDACC_VER_MAJOR__ >= 10 and __CUDACC_VER_MINOR__ > 0
+#if not defined CUDA_ENFORCE_LOWER and CUDA_VER_SELECT
     auto size_x = transpose ? nrows_ : ncols_;
     auto size_y = transpose ? ncols_ : nrows_;
 
@@ -240,7 +253,7 @@ struct sparse_matrix_t {
 
   handle_t const& get_handle(void) const { return handle_; }
 
-#if __CUDACC_VER_MAJOR__ >= 10 and __CUDACC_VER_MINOR__ > 0
+#if not defined CUDA_ENFORCE_LOWER and CUDA_VER_SELECT
   cusparseSpMVAlg_t translate_algorithm(sparse_mv_alg_t alg) const {
     switch (alg) {
       case sparse_mv_alg_t::SPARSE_MV_ALG1:


### PR DESCRIPTION
This fixes the bug of selecting cuda_minors > 0 even for cuda_majors >=11 (which would have bypassed 11.0). This affected SpMV() algorithm selection.

Also added a mechanism (for debugging) to enforce lower than 10.1 versions of SpMV(). 