### PR TITLE
[REVIEW] Change the type of recvcounts & displs in allgatherv from size_t[] & int[] to size_t* & size_t*, respectively.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - PR #56: Fix compiler warnings.
 - PR #64: Remove `cublas_try` from `cusolver_wrappers.h`
 - PR #66: Fixing typo `get_stream` to `getStream` in `handle.pyx`
-- PR #68: Change the type of displs in allgatherv from int[] to size_t[]
+- PR #68: Change the type of recvcounts & displs in allgatherv from size_t[] to size_t* and int[] to size_t*, respectively.
 
 # RAFT 0.15.0 (Date TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #56: Fix compiler warnings.
 - PR #64: Remove `cublas_try` from `cusolver_wrappers.h`
 - PR #66: Fixing typo `get_stream` to `getStream` in `handle.pyx`
+- PR #68: Change the type of displs in allgatherv from int[] to size_t[]
 
 # RAFT 0.15.0 (Date TBD)
 

--- a/cpp/include/raft/comms/comms.hpp
+++ b/cpp/include/raft/comms/comms.hpp
@@ -120,7 +120,7 @@ class comms_iface {
                          datatype_t datatype, cudaStream_t stream) const = 0;
 
   virtual void allgatherv(const void* sendbuf, void* recvbuf,
-                          const size_t recvcounts[], const int displs[],
+                          const size_t recvcounts[], const size_t displs[],
                           datatype_t datatype, cudaStream_t stream) const = 0;
 
   virtual void reducescatter(const void* sendbuff, void* recvbuff,
@@ -299,7 +299,7 @@ class comms_t {
    */
   template <typename value_t>
   void allgatherv(const value_t* sendbuf, value_t* recvbuf,
-                  const size_t recvcounts[], const int displs[],
+                  const size_t recvcounts[], const size_t displs[],
                   cudaStream_t stream) const {
     impl_->allgatherv(static_cast<const void*>(sendbuf),
                       static_cast<void*>(recvbuf), recvcounts, displs,

--- a/cpp/include/raft/comms/comms.hpp
+++ b/cpp/include/raft/comms/comms.hpp
@@ -120,7 +120,7 @@ class comms_iface {
                          datatype_t datatype, cudaStream_t stream) const = 0;
 
   virtual void allgatherv(const void* sendbuf, void* recvbuf,
-                          const size_t recvcounts[], const size_t displs[],
+                          const size_t* recvcounts, const size_t* displs,
                           datatype_t datatype, cudaStream_t stream) const = 0;
 
   virtual void reducescatter(const void* sendbuff, void* recvbuff,
@@ -291,15 +291,15 @@ class comms_t {
    * @param value_t datatype of underlying buffers
    * @param sendbuff buffer containing data to send
    * @param recvbuff buffer containing data to receive
-   * @param recvcounts array (of length num_ranks size) containing the number of elements
-   * 		that are to be received from each rank
-   * @param displs array (of length num_ranks size) to specify the displacement (relative to recvbuf)
-   * 		at which to place the incoming data from each rank
+   * @param recvcounts pointer to an array (of length num_ranks size) containing the number of
+   *                   elements that are to be received from each rank
+   * @param displs pointer to an array (of length num_ranks size) to specify the displacement
+   *               (relative to recvbuf) at which to place the incoming data from each rank
    * @param stream CUDA stream to synchronize operation
    */
   template <typename value_t>
   void allgatherv(const value_t* sendbuf, value_t* recvbuf,
-                  const size_t recvcounts[], const size_t displs[],
+                  const size_t* recvcounts, const size_t* displs,
                   cudaStream_t stream) const {
     impl_->allgatherv(static_cast<const void*>(sendbuf),
                       static_cast<void*>(recvbuf), recvcounts, displs,

--- a/cpp/include/raft/comms/mpi_comms.hpp
+++ b/cpp/include/raft/comms/mpi_comms.hpp
@@ -215,8 +215,8 @@ class mpi_comms : public comms_iface {
                            get_nccl_datatype(datatype), nccl_comm_, stream));
   }
 
-  void allgatherv(const void* sendbuf, void* recvbuf, const size_t recvcounts[],
-                  const size_t displs[], datatype_t datatype,
+  void allgatherv(const void* sendbuf, void* recvbuf, const size_t* recvcounts,
+                  const size_t* displs, datatype_t datatype,
                   cudaStream_t stream) const {
     //From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" - https://arxiv.org/pdf/1812.05964.pdf
     //Listing 1 on page 4.

--- a/cpp/include/raft/comms/mpi_comms.hpp
+++ b/cpp/include/raft/comms/mpi_comms.hpp
@@ -216,7 +216,7 @@ class mpi_comms : public comms_iface {
   }
 
   void allgatherv(const void* sendbuf, void* recvbuf, const size_t recvcounts[],
-                  const int displs[], datatype_t datatype,
+                  const size_t displs[], datatype_t datatype,
                   cudaStream_t stream) const {
     //From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" - https://arxiv.org/pdf/1812.05964.pdf
     //Listing 1 on page 4.

--- a/cpp/include/raft/comms/std_comms.hpp
+++ b/cpp/include/raft/comms/std_comms.hpp
@@ -348,7 +348,7 @@ class std_comms : public comms_iface {
   }
 
   void allgatherv(const void *sendbuf, void *recvbuf, const size_t recvcounts[],
-                  const int displs[], datatype_t datatype,
+                  const size_t displs[], datatype_t datatype,
                   cudaStream_t stream) const {
     //From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" - https://arxiv.org/pdf/1812.05964.pdf
     //Listing 1 on page 4.

--- a/cpp/include/raft/comms/std_comms.hpp
+++ b/cpp/include/raft/comms/std_comms.hpp
@@ -347,8 +347,8 @@ class std_comms : public comms_iface {
                            get_nccl_datatype(datatype), nccl_comm_, stream));
   }
 
-  void allgatherv(const void *sendbuf, void *recvbuf, const size_t recvcounts[],
-                  const size_t displs[], datatype_t datatype,
+  void allgatherv(const void *sendbuf, void *recvbuf, const size_t *recvcounts,
+                  const size_t *displs, datatype_t datatype,
                   cudaStream_t stream) const {
     //From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" - https://arxiv.org/pdf/1812.05964.pdf
     //Listing 1 on page 4.


### PR DESCRIPTION
Close https://github.com/rapidsai/raft/issues/21
