### PR TITLE
[REVIEW] Adding CUB to RAFT cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 - PR #63: Adding MPI comms implementation
+- PR #70: Adding CUB to RAFT cmake
 
 ## Improvements
 - PR #59: Adding csrgemm2 to cusparse_wrappers.h

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -168,6 +168,13 @@ set(CMAKE_CUDA_FLAGS
 include(cmake/Dependencies.cmake)
 include(cmake/comms.cmake)
 
+# CUDA 11 onwards cub ships with CTK
+if((CUDA_VERSION_MAJOR EQUAL 11) OR (CUDA_VERSION_MAJOR GREATER 11))
+  set(CUB_IS_PART_OF_CTK ON)
+else()
+  set(CUB_IS_PART_OF_CTK OFF)
+endif()
+
 ###################################################################################################
 # - RMM -------------------------------------------------------------------------------------------
 
@@ -190,6 +197,10 @@ set(RAFT_INCLUDE_DIRECTORIES
   ${RAFT_INCLUDE_DIR}
   ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
   ${RMM_INCLUDE_DIRS})
+
+if(NOT CUB_IS_PART_OF_CTK)
+  list(APPEND RAFT_INCLUDE_DIRECTORIES ${CUB_DIR}/src/cub)
+endif(NOT CUB_IS_PART_OF_CTK)
 
 if(DEFINED ENV{CONDA_PREFIX})
   message(STATUS "Using RMM installation from $ENV{CONDA_PREFIX}")


### PR DESCRIPTION
This PR adds CUB to RAFT, to allow for the first of cuML prims to move to RAFT