### PR TITLE
[REVIEW] Move DistanceType enum to RAFT from cuML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## New Features
 
+- PR #73: Move DistanceType enum from cuML to RAFT
 - PR #63: Adding MPI comms implementation
 
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #73: Move DistanceType enum from cuML to RAFT
 
 ## Bug Fixes
 - PR #77: Fixing CUB include for CUDA < 11
@@ -11,7 +12,6 @@
 
 ## New Features
 
-- PR #73: Move DistanceType enum from cuML to RAFT
 - PR #63: Adding MPI comms implementation
 - PR #70: Adding CUB to RAFT cmake
 

--- a/cpp/include/raft/linalg/distance_type.h
+++ b/cpp/include/raft/linalg/distance_type.h
@@ -35,5 +35,5 @@ enum DistanceType : unsigned short {
   EucUnexpandedL2Sqrt = 5,
 };
 
-};  // end namespace linalg
+};  // namespace distance
 };  // end namespace raft

--- a/cpp/include/raft/linalg/distance_type.h
+++ b/cpp/include/raft/linalg/distance_type.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace raft {
+namespace linalg {
+
+/** enum to tell how to compute euclidean distance */
+enum DistanceType : unsigned short {
+  /** evaluate as dist_ij = sum(x_ik^2) + sum(y_ij)^2 - 2*sum(x_ik * y_jk) */
+  EucExpandedL2 = 0,
+  /** same as above, but inside the epilogue, perform square root operation */
+  EucExpandedL2Sqrt = 1,
+  /** cosine distance */
+  EucExpandedCosine = 2,
+  /** L1 distance */
+  EucUnexpandedL1 = 3,
+  /** evaluate as dist_ij += (x_ik - y-jk)^2 */
+  EucUnexpandedL2 = 4,
+  /** same as above, but inside the epilogue, perform square root operation */
+  EucUnexpandedL2Sqrt = 5,
+};
+
+};  // end namespace linalg
+};  // end namespace raft

--- a/cpp/include/raft/linalg/distance_type.h
+++ b/cpp/include/raft/linalg/distance_type.h
@@ -17,7 +17,7 @@
 #pragma once
 
 namespace raft {
-namespace linalg {
+namespace distance {
 
 /** enum to tell how to compute euclidean distance */
 enum DistanceType : unsigned short {


### PR DESCRIPTION
Transfer DistanceType enum to RAFT for use across cuML, prims, and Cython code