### PR TITLE
[REVIEW] BUG Bug fix in RAFT comm_split in std_comms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #66: Fixing typo `get_stream` to `getStream` in `handle.pyx`
 - PR #68: Change the type of recvcounts & displs in allgatherv from size_t[] to size_t* and int[] to size_t*, respectively.
 - PR #69: Updates for RMM being header only
+- PR #74: Fix std_comms::comm_split bug
 
 # RAFT 0.15.0 (Date TBD)
 

--- a/cpp/include/raft/comms/std_comms.hpp
+++ b/cpp/include/raft/comms/std_comms.hpp
@@ -159,6 +159,7 @@ class std_comms : public comms_iface {
       irecv(&id, sizeof(ncclUniqueId), subcomm_ranks[0], color, &request);
       waitall(1, &request);
     }
+    // FIXME: this seems unnecessary, do more testing and remove this
     barrier();
 
     ncclComm_t nccl_comm;


### PR DESCRIPTION
Current comm_split implementation set min_rank based on user provide keys,

https://github.com/rapidsai/raft/blob/branch-0.16/cpp/include/raft/comms/std_comms.hpp#L171
```
if (keys_host[i] < min_rank) min_rank = keys_host[i];
```

provide this as the root id in calling scatter_nccluniqueid,

https://github.com/rapidsai/raft/blob/branch-0.16/cpp/include/raft/comms/std_comms.hpp#L178
```
scatter_nccluniqueid(id, color, key, min_rank, ranks_with_color.size(),
                         colors_host);
```

and use this root id for irecv
https://github.com/rapidsai/raft/blob/branch-0.16/cpp/include/raft/comms/std_comms.hpp#L135
```
    irecv(&id, sizeof(ncclUniqueId), root, color,
          requests.data() + request_idx);
```

This works only if user sets keys to ranks in the original (un-splitted) communicator.

But if users set keys to ranks in the original communicator, ncclCommInitRank fails.

https://github.com/rapidsai/raft/blob/branch-0.16/cpp/include/raft/comms/std_comms.hpp#L182
```
    NCCL_TRY(ncclCommInitRank(&nccl_comm, ranks_with_color.size(), id,
                              keys_host[get_rank()]));
```

ncclCommInitRank (https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api/comms.html#ncclcomminitrank) expects
```
rank must be between 0 and nranks-1 
```
To satisfy this, users should provide keys to have values from 0 to subcommunicator_size - 1 (not the rank in the original communicator).

This PR fixes the bug.

