### PR TITLE
[REVIEW] Adding CUB in dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 ## Bug Fixes
+- PR #77: Fixing CUB include for CUDA < 11
 
 # RAFT 0.16.0 (Date TBD)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -165,15 +165,15 @@ set(CMAKE_CUDA_FLAGS
 ##############################################################################
 # - dependencies -------------------------------------------------------------
 
-include(cmake/Dependencies.cmake)
-include(cmake/comms.cmake)
-
 # CUDA 11 onwards cub ships with CTK
 if((CUDA_VERSION_MAJOR EQUAL 11) OR (CUDA_VERSION_MAJOR GREATER 11))
   set(CUB_IS_PART_OF_CTK ON)
 else()
   set(CUB_IS_PART_OF_CTK OFF)
 endif()
+
+include(cmake/Dependencies.cmake)
+include(cmake/comms.cmake)
 
 ###################################################################################################
 # - RMM -------------------------------------------------------------------------------------------

--- a/cpp/cmake/Dependencies.cmake
+++ b/cpp/cmake/Dependencies.cmake
@@ -17,6 +17,20 @@
 include(ExternalProject)
 
 ##############################################################################
+# - cub - (header only) ------------------------------------------------------
+
+if(NOT CUB_IS_PART_OF_CTK)
+  set(CUB_DIR ${CMAKE_CURRENT_BINARY_DIR}/cub CACHE STRING "Path to cub repo")
+  ExternalProject_Add(cub
+    GIT_REPOSITORY    https://github.com/thrust/cub.git
+    GIT_TAG           1.8.0
+    PREFIX            ${CUB_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   "")
+endif(NOT CUB_IS_PART_OF_CTK)
+
+##############################################################################
 # - googletest ---------------------------------------------------------------
 
 if(BUILD_GTEST)
@@ -48,3 +62,7 @@ else()
   find_package(GTest REQUIRED)
 
 endif(BUILD_GTEST)
+
+if(NOT CUB_IS_PART_OF_CTK)
+  add_dependencies(GTest::GTest cub)
+endif(NOT CUB_IS_PART_OF_CTK) 


### PR DESCRIPTION
In my previous PR, I made a mistake and forgot to add CUB to `Dependencies.cmake`. This means, it was only installing CUB as a dependency for CUDA 11 onwards, where it is included as part of cudatoolkit