### PR TITLE
[REVIEW] BUG Temporarily expose internal NCCL communicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - PR #69: Updates for RMM being header only
 - PR #74: Fix std_comms::comm_split bug
 - PR #79: remove debug print statements
+- PR #81: temporarily expose internal NCCL communicator
 
 # RAFT 0.15.0 (Date TBD)
 

--- a/cpp/include/raft/comms/comms.hpp
+++ b/cpp/include/raft/comms/comms.hpp
@@ -17,6 +17,10 @@
 #pragma once
 
 #include <raft/cudart_utils.h>
+
+// FIXME: for get_nccl_comm(), should be removed
+#include <nccl.h>
+
 #include <memory>
 
 namespace raft {
@@ -92,6 +96,9 @@ class comms_iface {
   virtual int get_size() const = 0;
   virtual int get_rank() const = 0;
 
+  // FIXME: a temporary hack, should be removed
+  virtual ncclComm_t get_nccl_comm() const = 0;
+
   virtual std::unique_ptr<comms_iface> comm_split(int color, int key) const = 0;
   virtual void barrier() const = 0;
 
@@ -149,6 +156,9 @@ class comms_t {
    * Returns the local rank
    */
   int get_rank() const { return impl_->get_rank(); }
+
+  // FIXME: a temporary hack, should be removed
+  ncclComm_t get_nccl_comm() const { return impl_->get_nccl_comm(); }
 
   /**
    * Splits the current communicator clique into sub-cliques matching

--- a/cpp/include/raft/comms/mpi_comms.hpp
+++ b/cpp/include/raft/comms/mpi_comms.hpp
@@ -133,6 +133,9 @@ class mpi_comms : public comms_iface {
 
   int get_rank() const { return rank_; }
 
+  // FIXME: a temporary hack, should be removed
+  ncclComm_t get_nccl_comm() const { return nccl_comm_; }
+
   std::unique_ptr<comms_iface> comm_split(int color, int key) const {
     MPI_Comm new_comm;
     MPI_TRY(MPI_Comm_split(mpi_comm_, color, key, &new_comm));

--- a/cpp/include/raft/comms/std_comms.hpp
+++ b/cpp/include/raft/comms/std_comms.hpp
@@ -112,6 +112,9 @@ class std_comms : public comms_iface {
 
   int get_rank() const { return rank_; }
 
+  // FIXME: a temporary hack, should be removed
+  ncclComm_t get_nccl_comm() const { return nccl_comm_; }
+
   std::unique_ptr<comms_iface> comm_split(int color, int key) const {
     mr::device::buffer<int> d_colors(device_allocator_, stream_, get_size());
     mr::device::buffer<int> d_keys(device_allocator_, stream_, get_size());


### PR DESCRIPTION
This is a temporary hack to work around a UCX isend/irecv issue, we need to discuss a more proper way to support P2P communication for device data in the future; this hack is a temporary solution and this code should be removed once we have a proper solution.