### PR TITLE
[REVIEW] missing headers for newly moved prims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug Fixes
 - PR #77: Fixing CUB include for CUDA < 11
+- PR #86: Missing headers for newly moved prims
 
 # RAFT 0.16.0 (Date TBD)
 

--- a/cpp/include/raft/cuda_utils.cuh
+++ b/cpp/include/raft/cuda_utils.cuh
@@ -19,6 +19,8 @@
 #include <math_constants.h>
 #include <stdint.h>
 
+#include <raft/cudart_utils.h>
+
 #ifndef ENABLE_MEMCPY_ASYNC
 // enable memcpy_async interface by default for newer GPUs
 #if __CUDA_ARCH__ >= 800


### PR DESCRIPTION
Some prims, when included in cuML, complain about certain missing declarations, so trying to resolve with adding more headers to these prims