### PR TITLE
[REVIEW] Allow generic reductions for the map then reduce op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 - PR #65: Adding cuml prims that break circular dependency between cuml and cumlprims projects
 - PR #93: Incorporate Date/Nagi implementation of Hungarian Algorithm
+- PR #94: Allow generic reductions for the map then reduce op
 
 ## Improvements
 - PR #73: Move DistanceType enum from cuML to RAFT

--- a/cpp/test/linalg/map_then_reduce.cu
+++ b/cpp/test/linalg/map_then_reduce.cu
@@ -24,21 +24,21 @@
 namespace raft {
 namespace linalg {
 
-template <typename Type, typename MapOp>
-__global__ void naiveMapReduceKernel(Type *out, const Type *in, size_t len,
+template <typename InType, typename OutType, typename MapOp>
+__global__ void naiveMapReduceKernel(OutType *out, const InType *in, size_t len,
                                      MapOp map) {
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
   if (idx < len) {
-    raft::myAtomicAdd(out, map(in[idx]));
+    raft::myAtomicAdd(out, (OutType)map(in[idx]));
   }
 }
 
-template <typename Type, typename MapOp>
-void naiveMapReduce(Type *out, const Type *in, size_t len, MapOp map,
+template <typename InType, typename OutType, typename MapOp>
+void naiveMapReduce(OutType *out, const InType *in, size_t len, MapOp map,
                     cudaStream_t stream) {
   static const int TPB = 64;
   int nblks = raft::ceildiv(len, (size_t)TPB);
-  naiveMapReduceKernel<Type, MapOp>
+  naiveMapReduceKernel<InType, OutType, MapOp>
     <<<nblks, TPB, 0, stream>>>(out, in, len, map);
   CUDA_CHECK(cudaPeekAtLastError());
 }
@@ -58,19 +58,19 @@ template <typename T>
 // Or else, we get the following compilation error
 // for an extended __device__ lambda cannot have private or protected access
 // within its class
-template <typename T>
-void mapReduceLaunch(T *out_ref, T *out, const T *in, size_t len,
-                     cudaStream_t stream) {
-  auto op = [] __device__(T in) { return in; };
+template <typename InType, typename OutType>
+void mapReduceLaunch(OutType *out_ref, OutType *out, const InType *in,
+                     size_t len, cudaStream_t stream) {
+  auto op = [] __device__(InType in) { return in; };
   naiveMapReduce(out_ref, in, len, op, stream);
   mapThenSumReduce(out, len, op, 0, in);
 }
 
-template <typename T>
-class MapReduceTest : public ::testing::TestWithParam<MapReduceInputs<T>> {
+template <typename InType, typename OutType>
+class MapReduceTest : public ::testing::TestWithParam<MapReduceInputs<InType>> {
  protected:
   void SetUp() override {
-    params = ::testing::TestWithParam<MapReduceInputs<T>>::GetParam();
+    params = ::testing::TestWithParam<MapReduceInputs<InType>>::GetParam();
     raft::random::Rng r(params.seed);
     auto len = params.len;
 
@@ -79,7 +79,7 @@ class MapReduceTest : public ::testing::TestWithParam<MapReduceInputs<T>> {
     allocate(in, len);
     allocate(out_ref, len);
     allocate(out, len);
-    r.uniform(in, len, T(-1.0), T(1.0), stream);
+    r.uniform(in, len, InType(-1.0), InType(1.0), stream);
     mapReduceLaunch(out_ref, out, in, len, stream);
     CUDA_CHECK(cudaStreamDestroy(stream));
   }
@@ -91,32 +91,44 @@ class MapReduceTest : public ::testing::TestWithParam<MapReduceInputs<T>> {
   }
 
  protected:
-  MapReduceInputs<T> params;
-  T *in, *out_ref, *out;
+  MapReduceInputs<InType> params;
+  InType *in;
+  OutType *out_ref, *out;
 };
 
 const std::vector<MapReduceInputs<float>> inputsf = {
   {0.001f, 1024 * 1024, 1234ULL}};
-typedef MapReduceTest<float> MapReduceTestF;
-TEST_P(MapReduceTestF, Result) {
+typedef MapReduceTest<float, float> MapReduceTestFF;
+TEST_P(MapReduceTestFF, Result) {
   ASSERT_TRUE(devArrMatch(out_ref, out, params.len,
                           CompareApprox<float>(params.tolerance)));
 }
-INSTANTIATE_TEST_SUITE_P(MapReduceTests, MapReduceTestF,
+INSTANTIATE_TEST_SUITE_P(MapReduceTests, MapReduceTestFF,
+                         ::testing::ValuesIn(inputsf));
+
+typedef MapReduceTest<float, double> MapReduceTestFD;
+TEST_P(MapReduceTestFD, Result) {
+  ASSERT_TRUE(devArrMatch(out_ref, out, params.len,
+                          CompareApprox<double>(params.tolerance)));
+}
+INSTANTIATE_TEST_SUITE_P(MapReduceTests, MapReduceTestFD,
                          ::testing::ValuesIn(inputsf));
 
 const std::vector<MapReduceInputs<double>> inputsd = {
   {0.000001, 1024 * 1024, 1234ULL}};
-typedef MapReduceTest<double> MapReduceTestD;
-TEST_P(MapReduceTestD, Result) {
+typedef MapReduceTest<double, double> MapReduceTestDD;
+TEST_P(MapReduceTestDD, Result) {
   ASSERT_TRUE(devArrMatch(out_ref, out, params.len,
                           CompareApprox<double>(params.tolerance)));
 }
-INSTANTIATE_TEST_SUITE_P(MapReduceTests, MapReduceTestD,
+INSTANTIATE_TEST_SUITE_P(MapReduceTests, MapReduceTestDD,
                          ::testing::ValuesIn(inputsd));
 
-template <typename math_t>
+template <typename T>
 class MapGenericReduceTest : public ::testing::Test {
+  using InType = typename T::first_type;
+  using OutType = typename T::second_type;
+
  protected:
   MapGenericReduceTest()
     : allocator(handle.get_device_allocator()),
@@ -130,30 +142,30 @@ class MapGenericReduceTest : public ::testing::Test {
   void TearDown() override { CUDA_CHECK(cudaStreamDestroy(stream)); }
 
  public:
-  void initInput(math_t *input, int n, cudaStream_t stream) {
+  void initInput(InType *input, int n, cudaStream_t stream) {
     raft::random::Rng r(137);
-    r.uniform(input, n, math_t(2), math_t(3), stream);
-    math_t val = 1;
+    r.uniform(input, n, InType(2), InType(3), stream);
+    InType val = 1;
     raft::update_device(input + 42, &val, 1, stream);
     val = 5;
     raft::update_device(input + 337, &val, 1, stream);
   }
 
   void testMin() {
-    auto op = [] __device__(math_t in) { return in; };
-    const math_t neutral = std::numeric_limits<math_t>::max();
+    auto op = [] __device__(InType in) { return in; };
+    const InType neutral = std::numeric_limits<InType>::max();
     mapThenReduce(output.data(), input.size(), neutral, op, cub::Min(), stream,
                   input.data());
-    EXPECT_TRUE(
-      raft::devArrMatch(math_t(1), output.data(), 1, raft::Compare<math_t>()));
+    EXPECT_TRUE(raft::devArrMatch(OutType(1), output.data(), 1,
+                                  raft::Compare<OutType>()));
   }
   void testMax() {
-    auto op = [] __device__(math_t in) { return in; };
-    const math_t neutral = std::numeric_limits<math_t>::min();
+    auto op = [] __device__(InType in) { return in; };
+    const InType neutral = std::numeric_limits<InType>::min();
     mapThenReduce(output.data(), input.size(), neutral, op, cub::Max(), stream,
                   input.data());
-    EXPECT_TRUE(
-      raft::devArrMatch(math_t(5), output.data(), 1, raft::Compare<math_t>()));
+    EXPECT_TRUE(raft::devArrMatch(OutType(5), output.data(), 1,
+                                  raft::Compare<OutType>()));
   }
 
  protected:
@@ -161,13 +173,15 @@ class MapGenericReduceTest : public ::testing::Test {
   raft::handle_t handle;
   cudaStream_t stream;
   std::shared_ptr<raft::mr::device::allocator> allocator;
-  raft::mr::device::buffer<math_t> input;
-  raft::mr::device::buffer<math_t> output;
+  raft::mr::device::buffer<InType> input;
+  raft::mr::device::buffer<OutType> output;
 };
 
-typedef ::testing::Types<float, double> FloatTypes;
+using IoTypePair =
+  ::testing::Types<std::pair<float, float>, std::pair<float, double>,
+                   std::pair<double, double>>;
 
-TYPED_TEST_CASE(MapGenericReduceTest, FloatTypes);
+TYPED_TEST_CASE(MapGenericReduceTest, IoTypePair);
 TYPED_TEST(MapGenericReduceTest, min) { this->testMin(); }
 TYPED_TEST(MapGenericReduceTest, max) { this->testMax(); }
 }  // end namespace linalg

--- a/cpp/test/linalg/map_then_reduce.cu
+++ b/cpp/test/linalg/map_then_reduce.cu
@@ -153,7 +153,7 @@ class MapGenericReduceTest : public ::testing::Test {
 
   void testMin() {
     auto op = [] __device__(InType in) { return in; };
-    const InType neutral = std::numeric_limits<InType>::max();
+    const OutType neutral = std::numeric_limits<InType>::max();
     mapThenReduce(output.data(), input.size(), neutral, op, cub::Min(), stream,
                   input.data());
     EXPECT_TRUE(raft::devArrMatch(OutType(1), output.data(), 1,
@@ -161,7 +161,7 @@ class MapGenericReduceTest : public ::testing::Test {
   }
   void testMax() {
     auto op = [] __device__(InType in) { return in; };
-    const InType neutral = std::numeric_limits<InType>::min();
+    const OutType neutral = std::numeric_limits<InType>::min();
     mapThenReduce(output.data(), input.size(), neutral, op, cub::Max(), stream,
                   input.data());
     EXPECT_TRUE(raft::devArrMatch(OutType(5), output.data(), 1,


### PR DESCRIPTION
This PR adds a mapThenReduce prim, analogous to mapThenSumReduce.