### PR TITLE
[REVIEW] Cholesky rank one update prim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 - PR #65: Adding cuml prims that break circular dependency between cuml and cumlprims projects
 - PR #93: Incorporate Date/Nagi implementation of Hungarian Algorithm
+- RP #95: Cholesky rank one update prim
 
 ## Improvements
 - PR #73: Move DistanceType enum from cuML to RAFT

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -238,6 +238,7 @@ if(BUILD_RAFT_TESTS)
     test/lap/lap.cu
     test/linalg/add.cu
     test/linalg/binary_op.cu
+    test/linalg/cholesky_r1.cu
     test/linalg/coalesced_reduction.cu
     test/linalg/divide.cu
     test/linalg/eig.cu

--- a/cpp/include/raft/linalg/cholesky_r1_update.cuh
+++ b/cpp/include/raft/linalg/cholesky_r1_update.cuh
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/linalg/cublas_wrappers.h>
+#include <raft/linalg/cusolver_wrappers.h>
+#include <raft/cuda_utils.cuh>
+#include <raft/handle.hpp>
+#include <raft/linalg/binary_op.cuh>
+
+namespace raft {
+namespace linalg {
+
+/**
+ * @brief Rank 1 update of Cholesky decomposition.
+ *
+ * This method is useful if an algorithm iteratively builds up matrix A, and
+ * the Cholesky decomposition of A is required at each step.
+ *
+ * On entry, L is the Cholesky decomposition of matrix A, where both A and L
+ * have size n-1 x n-1. We are interested in the Cholesky decomposition of a new
+ * matrix A', which we get by adding a row and column to A. In Python notation:
+ * - A'[0:n-1, 0:n-1] = A;
+ * - A'[:,n-1] = A[n-1,:] = A_new
+ *
+ * On entry, the new column A_new, is stored as the n-th column of L if uplo ==
+ * CUBLAS_FILL_MODE_UPPER, else A_new is stored as the n-th row of L.
+ *
+ * On exit L contains the Cholesky decomposition of A'. In practice the elements
+ * of A_new are overwritten with new row/column of the L matrix.
+ *
+ * The uplo paramater is used to select the matrix layout.
+ * If (uplo != CUBLAS_FILL_MODE_UPPER) then the input arg L stores the
+ * lower triangular matrix L, so that A = L * L.T. Otherwise the input arg L
+ * stores an upper triangular matrix U: A = U.T * U.
+ *
+ * On exit L will be updated to store the Cholesky decomposition of A'.
+ *
+ * Examples:
+ *
+ * - Lower triangular factorization:
+ * @code{.cpp}
+ * // Initialize arrays
+ * int ld_L = n_rows;
+ * device_buffer<math_t> L(allocator, stream, ld_L * n_rows);
+ * MLCommon::LinAlg::choleskyRank1Update(handle, L, n_rows, ld_L, nullptr,
+ *                                       &n_bytes, CUBLAS_FILL_MODE_LOWER,
+ *                                       stream);
+ * device_buffer<char> workspace(allocator, stream, n_bytes);
+ *
+ * for (n=1; n<=n_rows; rank++) {
+ *   // Calculate a new row/column of matrix A into A_new
+ *   // ...
+ *   // Copy new row to L[rank-1,:]
+ *   CUBLAS_CHECK(cublasCopy(handle.get_cublas_handle(), n - 1, A_new, 1,
+ *                           L + n - 1, ld_L, stream));
+ *   // Update Cholesky factorization
+ *   MLCommon::LinAlg::choleskyRank1Update(
+ *       handle, L, rank, ld_L, workspace, &n_bytes, CUBLAS_FILL_MODE_LOWER,
+ *       stream);
+ * }
+ * Now L stores the Cholesky decomposition of A: A = L * L.T
+ * @endcode
+ *
+ * - Upper triangular factorization:
+ * @code{.cpp}
+ * // Initialize arrays
+ * int ld_U = n_rows;
+ * device_buffer<math_t> U(allocator, stream, ld_U * n_rows);
+ * MLCommon::LinAlg::choleskyRank1Update(handle, L, n_rows, ld_U, nullptr,
+ *                                       &n_bytes, CUBLAS_FILL_MODE_UPPER,
+ *                                       stream);
+ * device_buffer<char> workspace(allocator, stream, n_bytes);
+ *
+ * for (n=1; n<=n_rows; n++) {
+ *   // Calculate a new row/column of matrix A into array A_new
+ *   // ...
+ *   // Copy new row to U[:,n-1] (column major layout)
+ *   raft::copy(U + ld_U * (n-1), A_new, n-1, stream);
+ *   //
+ *   // Update Cholesky factorization
+ *   MLCommon::LinAlg::choleskyRank1Update(
+ *       handle, U, n, ld_U, workspace, &n_bytes, CUBLAS_FILL_MODE_UPPER,
+ *       stream);
+ * }
+ * // Now U stores the Cholesky decomposition of A: A = U.T * U
+ * @endcode
+ *
+ * @param handle RAFT handle (used to retrive cuBLAS handles).
+ * @param L device array for to store the triangular matrix L, and the new
+ *     column of A in column major format, size [n*n]
+ * @param n number of elements in the new row.
+ * @param ld stride of colums in L
+ * @param workspace device pointer to workspace shall be nullptr ar an array
+ *    of size [n_bytes].
+ * @param n_bytes size of workspace is returned here if workspace==nullptr.
+ * @param stream CUDA stream
+ * @param uplo indicates whether L is stored as an upper or lower triangular
+ *    matrix (CUBLAS_FILL_MODE_UPPER or CUBLAS_FILL_MODE_LOWER)
+ */
+template <typename math_t>
+void choleskyRank1Update(const raft::handle_t &handle, math_t *L, int n, int ld,
+                         void *workspace, int *n_bytes, cublasFillMode_t uplo,
+                         cudaStream_t stream) {
+  // The matrix A' is defined as:
+  // A' = [[A_11, A_12]
+  //       [A_21, A_22]]
+  // where:
+  // - A_11 = A, matrix of size (n-1)x(n-1)
+  // - A_21[j] = A_12.T[j] = A_new[j] j=0..n-2, vector with (n-1) elements
+  // - A_22 = A_new[n-1] scalar.
+  //
+  // Instead of caclulating the Cholelsky decomposition of A' from scratch,
+  // we just update L with the new row. The new Cholesky decomposition will be
+  // calculated as:
+  // L' = [[L_11,    0]
+  //       [L_12, L_22]]
+  // where L_11 is the Cholesky decomposition of A (size [n-1 x n-1]), and
+  // L_12 and L_22 are the new quantities that we need to calculate.
+
+  // We need a workspace in device memory to store a scalar. Additionally, in
+  // CUBLAS_FILL_MODE_LOWER we need space for n-1 floats.
+  const int align = 256;
+  int offset = (uplo == CUBLAS_FILL_MODE_LOWER)
+                 ? raft::alignTo<int>(sizeof(math_t) * (n - 1), align)
+                 : 0;
+  if (workspace == nullptr) {
+    *n_bytes = offset + 1 * sizeof(math_t);
+    return;
+  }
+  math_t *s = reinterpret_cast<math_t *>(((char *)workspace) + offset);
+  math_t *L_22 = L + (n - 1) * ld + n - 1;
+
+  math_t *A_new;
+  math_t *A_row;
+  if (uplo == CUBLAS_FILL_MODE_UPPER) {
+    // A_new is stored as the n-1 th column of L
+    A_new = L + (n - 1) * ld;
+  } else {
+    // If the input is lower triangular, then the new elements of A are stored
+    // as the n-th row of L. Since the matrix is column major, this is non
+    // contiguous. We copy elements from A_row to a contiguous workspace A_new.
+    A_row = L + n - 1;
+    A_new = reinterpret_cast<math_t *>(workspace);
+    CUBLAS_CHECK(raft::linalg::cublasCopy(handle.get_cublas_handle(), n - 1,
+                                          A_row, ld, A_new, 1, stream));
+  }
+  cublasOperation_t op =
+    (uplo == CUBLAS_FILL_MODE_UPPER) ? CUBLAS_OP_T : CUBLAS_OP_N;
+  if (n > 1) {
+    // Calculate L_12 = x by solving equation L_11 x = A_12
+    math_t alpha = 1;
+    CUBLAS_CHECK(raft::linalg::cublastrsm(
+      handle.get_cublas_handle(), CUBLAS_SIDE_LEFT, uplo, op,
+      CUBLAS_DIAG_NON_UNIT, n - 1, 1, &alpha, L, ld, A_new, n - 1, stream));
+
+    // A_new now stores L_12, we calculate s = L_12 * L_12
+    CUBLAS_CHECK(raft::linalg::cublasdot(handle.get_cublas_handle(), n - 1,
+                                         A_new, 1, A_new, 1, s, stream));
+
+    if (uplo == CUBLAS_FILL_MODE_LOWER) {
+      // Copy back the L_12 elements as the n-th row of L
+      CUBLAS_CHECK(raft::linalg::cublasCopy(handle.get_cublas_handle(), n - 1,
+                                            A_new, 1, A_row, ld, stream));
+    }
+  } else {  // n == 1 case
+    CUDA_CHECK(cudaMemsetAsync(s, 0, sizeof(math_t), stream));
+  }
+
+  // L_22 = sqrt(A_22 - L_12 * L_12)
+  raft::linalg::binaryOp(
+    L_22, s, L_22, 1, [] __device__(math_t s, math_t l) { return sqrt(l - s); },
+    stream);
+
+  // Check for numeric error: the above sqrt can have negative argument if the
+  // matrix is not positive definite or very ill conditioned.
+  math_t L_22_host;
+  raft::update_host(&L_22_host, L_22, 1, stream);
+  CUDA_CHECK(cudaStreamSynchronize(stream));
+  if (std::isnan(L_22_host)) {
+    THROW("Error during Cholesky rank one update");
+  }
+}
+};  // namespace linalg
+};  // namespace raft

--- a/cpp/include/raft/linalg/cholesky_r1_update.cuh
+++ b/cpp/include/raft/linalg/cholesky_r1_update.cuh
@@ -191,9 +191,7 @@ void choleskyRank1Update(const raft::handle_t &handle, math_t *L, int n, int ld,
   math_t L_22_host;
   raft::update_host(&L_22_host, L_22, 1, stream);
   CUDA_CHECK(cudaStreamSynchronize(stream));
-  if (std::isnan(L_22_host)) {
-    THROW("Error during Cholesky rank one update");
-  }
+  ASSERT(!std::isnan(L_22_host), "Error during Cholesky rank one update");
 }
 };  // namespace linalg
 };  // namespace raft

--- a/cpp/include/raft/linalg/cublas_wrappers.h
+++ b/cpp/include/raft/linalg/cublas_wrappers.h
@@ -129,6 +129,56 @@ inline cublasStatus_t cublasaxpy(cublasHandle_t handle, int n,
 /** @} */
 
 /**
+ * @defgroup cublas swap operations
+ * @{
+ */
+template <typename T>
+cublasStatus_t cublasSwap(cublasHandle_t handle, int n, T *x, int incx, T *y,
+                          int incy, cudaStream_t stream);
+
+template <>
+inline cublasStatus_t cublasSwap(cublasHandle_t handle, int n, float *x,
+                                 int incx, float *y, int incy,
+                                 cudaStream_t stream) {
+  CUBLAS_CHECK(cublasSetStream(handle, stream));
+  return cublasSswap(handle, n, x, incx, y, incy);
+}
+
+template <>
+inline cublasStatus_t cublasSwap(cublasHandle_t handle, int n, double *x,
+                                 int incx, double *y, int incy,
+                                 cudaStream_t stream) {
+  CUBLAS_CHECK(cublasSetStream(handle, stream));
+  return cublasDswap(handle, n, x, incx, y, incy);
+}
+
+/** @} */
+
+/**
+ * @defgroup cublas copy operations
+ * @{
+ */
+template <typename T>
+cublasStatus_t cublasCopy(cublasHandle_t handle, int n, const T *x, int incx,
+                          T *y, int incy, cudaStream_t stream);
+
+template <>
+inline cublasStatus_t cublasCopy(cublasHandle_t handle, int n, const float *x,
+                                 int incx, float *y, int incy,
+                                 cudaStream_t stream) {
+  CUBLAS_CHECK(cublasSetStream(handle, stream));
+  return cublasScopy(handle, n, x, incx, y, incy);
+}
+template <>
+inline cublasStatus_t cublasCopy(cublasHandle_t handle, int n, const double *x,
+                                 int incx, double *y, int incy,
+                                 cudaStream_t stream) {
+  CUBLAS_CHECK(cublasSetStream(handle, stream));
+  return cublasDcopy(handle, n, x, incx, y, incy);
+}
+/** @} */
+
+/**
  * @defgroup gemv cublas gemv calls
  * @{
  */

--- a/cpp/test/linalg/cholesky_r1.cu
+++ b/cpp/test/linalg/cholesky_r1.cu
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <raft/cudart_utils.h>
+#include <raft/linalg/cusolver_wrappers.h>
+#include <raft/handle.hpp>
+#include <raft/linalg/cholesky_r1_update.cuh>
+#include <raft/mr/device/allocator.hpp>
+#include <raft/mr/device/buffer.hpp>
+#include <sstream>
+#include <vector>
+#include "../test_utils.h"
+namespace raft {
+namespace linalg {
+
+template <typename math_t>
+class CholeskyR1Test : public ::testing::Test {
+ protected:
+  CholeskyR1Test()
+    : allocator(handle.get_device_allocator()),
+      G(allocator, handle.get_stream(), n_rows * n_rows),
+      L(allocator, handle.get_stream(), n_rows * n_rows),
+      L_exp(allocator, handle.get_stream(), n_rows * n_rows),
+      devInfo(allocator, handle.get_stream(), 1),
+      workspace(allocator, handle.get_stream()) {
+    CUDA_CHECK(cudaStreamCreate(&stream));
+    handle.set_stream(stream);
+    raft::update_device(G.data(), G_host, n_rows * n_rows, stream);
+
+    // Allocate workspace
+    solver_handle = handle.get_cusolver_dn_handle();
+    CUSOLVER_CHECK(raft::linalg::cusolverDnpotrf_bufferSize(
+      solver_handle, CUBLAS_FILL_MODE_LOWER, n_rows, L.data(), n_rows, &Lwork));
+    int n_bytes = 0;
+    // Initializing in CUBLAS_FILL_MODE_LOWER, because that has larger workspace
+    // requirements.
+    raft::linalg::choleskyRank1Update(handle, L.data(), n_rows, n_rows, nullptr,
+                                      &n_bytes, CUBLAS_FILL_MODE_LOWER, stream);
+    Lwork = std::max(Lwork * sizeof(math_t), (size_t)n_bytes);
+    workspace.resize(Lwork, stream);
+  }
+
+  void TearDown() override { CUDA_CHECK(cudaStreamDestroy(stream)); }
+
+  void testR1Update() {
+    int n = n_rows * n_rows;
+    std::vector<cublasFillMode_t> fillmode{CUBLAS_FILL_MODE_LOWER,
+                                           CUBLAS_FILL_MODE_UPPER};
+    for (auto uplo : fillmode) {
+      raft::copy(L.data(), G.data(), n, stream);
+      for (int rank = 1; rank <= n_rows; rank++) {
+        std::stringstream ss;
+        ss << "Rank " << rank
+           << ((uplo == CUBLAS_FILL_MODE_LOWER) ? ", lower" : ", upper");
+        SCOPED_TRACE(ss.str());
+
+        // Expected solution using Cholesky factorization from scratch
+        raft::copy(L_exp.data(), G.data(), n, stream);
+        CUSOLVER_CHECK(raft::linalg::cusolverDnpotrf(
+          solver_handle, uplo, rank, L_exp.data(), n_rows,
+          (math_t*)workspace.data(), Lwork, devInfo.data(), stream));
+
+        // Incremental Cholesky factorization using rank one updates.
+        raft::linalg::choleskyRank1Update(handle, L.data(), rank, n_rows,
+                                          workspace.data(), &Lwork, uplo,
+                                          stream);
+
+        ASSERT_TRUE(raft::devArrMatch(L_exp.data(), L.data(), n_rows * rank,
+                                      raft::CompareApprox<math_t>(3e-3)));
+      }
+    }
+  }
+
+  void testR1Error() {
+    raft::update_device(G.data(), G2_host, 4, stream);
+    std::vector<cublasFillMode_t> fillmode{CUBLAS_FILL_MODE_LOWER,
+                                           CUBLAS_FILL_MODE_UPPER};
+    for (auto uplo : fillmode) {
+      raft::copy(L.data(), G.data(), 4, stream);
+      ASSERT_NO_THROW(raft::linalg::choleskyRank1Update(
+        handle, L.data(), 1, 2, workspace.data(), &Lwork, uplo, stream));
+      ASSERT_THROW(
+        raft::linalg::choleskyRank1Update(
+          handle, L.data(), 2, 2, workspace.data(), &Lwork, uplo, stream),
+        raft::exception);
+    }
+  }
+
+  raft::handle_t handle;
+  std::shared_ptr<raft::mr::device::allocator> allocator;
+  cusolverDnHandle_t solver_handle;
+  cudaStream_t stream;
+
+  int n_rows = 4;
+  int Lwork;
+  math_t G_host[16] =  // clang-format off
+    {107.,  1393.,  1141.,  91.,
+     1393., 21132., 15689., 9539.,
+     1141., 15689., 13103., 2889.,
+     91.,   9539.,  2889.,  23649.};
+                       // clang-format on
+
+  math_t G2_host[4] = {3, 4, 2, 1};
+
+  raft::mr::device::buffer<int> devInfo;
+  raft::mr::device::buffer<math_t> G;
+  raft::mr::device::buffer<math_t> L_exp;
+  raft::mr::device::buffer<math_t> L;
+  raft::mr::device::buffer<char> workspace;
+};
+
+typedef ::testing::Types<float, double> FloatTypes;
+
+TYPED_TEST_CASE(CholeskyR1Test, FloatTypes);
+
+TYPED_TEST(CholeskyR1Test, update) { this->testR1Update(); }
+TYPED_TEST(CholeskyR1Test, throwError) { this->testR1Error(); }
+
+};  // namespace linalg
+};  // namespace raft


### PR DESCRIPTION
This PR implements rank one update for Cholesky decomposition. 

More info https://en.wikipedia.org/wiki/Cholesky_decomposition#Rank-one_update

This is a building block for LARS.

In addition to the new prim, cuBLAS wrappers for swap and copy are added.