### PR TITLE
[REVIEW] Adding inner product to DistanceType for max inner product searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Improvements
 - PR #73: Move DistanceType enum from cuML to RAFT
+- PR #98: Adding InnerProduct to DistanceType
 
 ## Bug Fixes
 - PR #77: Fixing CUB include for CUDA < 11

--- a/cpp/include/raft/linalg/distance_type.h
+++ b/cpp/include/raft/linalg/distance_type.h
@@ -33,6 +33,8 @@ enum DistanceType : unsigned short {
   EucUnexpandedL2 = 4,
   /** same as above, but inside the epilogue, perform square root operation */
   EucUnexpandedL2Sqrt = 5,
+  /** basic inner product **/
+  InnerProduct = 6
 };
 
 };  // namespace distance


### PR DESCRIPTION
Now that the `DistanceType` enum has moved to RAFT, some changes made in the [sparse knn](https://github.com/rapidsai/cuml/pull/2836) need to reconciled here. 