### PR TITLE
[REVIEW] Add Divye as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,17 @@
 #cpp code owners
 cpp/               @rapidsai/cuml-cpp-codeowners
 cpp/               @rapidsai/cugraph-cpp-codeowners
+cpp/               @divyegala
 
 #python code owners
 python/            @rapidsai/cuml-python-codeowners
 python/            @rapidsai/cugraph-python-codeowners
+python/            @divyegala
 
 #cmake code owners
 **/CMakeLists.txt  @rapidsai/cuml-cmake-codeowners
 **/CMakeLists.txt  @rapidsai/cugraph-cmake-codeowners
+**/CMakeLists.txt  @divyegala
 **/cmake/          @rapidsai/cuml-cmake-codeowners
 **/cmake/          @rapidsai/cugraph-cmake-codeowners
 python/setup.py    @rapidsai/cuml-cmake-codeowners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Improvements
 - PR #73: Move DistanceType enum from cuML to RAFT
 - PR #98: Adding InnerProduct to DistanceType
+- PR #100: Add divyegala as codeowner
 
 ## Bug Fixes
 - PR #77: Fixing CUB include for CUDA < 11


### PR DESCRIPTION
This adds @divyegala directly as a codeowner. This should work, per github docs, but if ops would prefer we add this username to a group instead, please let me know.