### PR TITLE
[REVIEW] Check alignment before binaryOp dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Bug Fixes
 - PR #77: Fixing CUB include for CUDA < 11
 - PR #86: Missing headers for newly moved prims
+- PR #102: Check alignment before binaryOp dispatch
 
 # RAFT 0.16.0 (Date TBD)
 


### PR DESCRIPTION
This PR adds pointer alignment check for the binaryOp. Without this, the added unit test would trigger `cudaErrorMisalignedAddress`.

The alignment check is done the same way as for the unaryOp: 
https://github.com/rapidsai/raft/blob/ca7465ed41d1129e446309e4a32649eb2d35e2e3/cpp/include/raft/linalg/unary_op.cuh#L79-L94