### PR TITLE
[REVIEW] Epsilon parameter for Cholesky rank one update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Improvements
 - PR #73: Move DistanceType enum from cuML to RAFT
 - PR #98: Adding InnerProduct to DistanceType
+- PR #103: Epsilon parameter for Cholesky rank one update
 
 ## Bug Fixes
 - PR #77: Fixing CUB include for CUDA < 11

--- a/cpp/test/linalg/cholesky_r1.cu
+++ b/cpp/test/linalg/cholesky_r1.cu
@@ -97,6 +97,10 @@ class CholeskyR1Test : public ::testing::Test {
         raft::linalg::choleskyRank1Update(
           handle, L.data(), 2, 2, workspace.data(), &Lwork, uplo, stream),
         raft::exception);
+
+      math_t eps = std::numeric_limits<math_t>::epsilon();
+      ASSERT_NO_THROW(raft::linalg::choleskyRank1Update(
+        handle, L.data(), 2, 2, workspace.data(), &Lwork, uplo, stream, eps));
     }
   }
 


### PR DESCRIPTION
[Scikit learn's LARS](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.Lars.html) provides eps parameter to act as a "regularization in the computation of the Cholesky diagonal factors".

In practice eps  [replaces](https://github.com/scikit-learn/scikit-learn/blob/d640b7fc61ce716af9d113a7c92c953c1ec3e36f/sklearn/linear_model/_least_angle.py#L602) the small or invalid diagonal value. 

This PR adds the correspond parameter to the Cholesky rank one update prim. This way cuML's LARS solver (https://github.com/rapidsai/cuml/pull/3160) has the same control knobs as scikit-learn.