### PR TITLE
[REVIEW] Specify branches to avoid pip resolver issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #100: Add divyegala as codeowner
 
 ## Bug Fixes
+- PR #106: Specify dependency branches to avoid pip resolver failure
 - PR #77: Fixing CUB include for CUDA < 11
 - PR #86: Missing headers for newly moved prims
 - PR #102: Check alignment before binaryOp dispatch

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -63,10 +63,10 @@ conda install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       "ucx-py=${MINOR_VERSION}"
 
 # Install the master version of dask, distributed, and dask-ml
-logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/distributed.git@master --upgrade --no-deps"
+pip install "git+https://github.com/dask/distributed.git@master" --upgrade --no-deps
+logger "pip install git+https://github.com/dask/dask.git@master --upgrade --no-deps"
+pip install "git+https://github.com/dask/dask.git@master" --upgrade --no-deps
 
 
 logger "Check versions..."


### PR DESCRIPTION
Avoid dependency resolution failure in latest version of pip by explicitly specifying versions for dask and distributed