### PR TITLE
[REVIEW] Fixing Incorrect Deallocation Size and Count Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PR #86: Missing headers for newly moved prims
 - PR #102: Check alignment before binaryOp dispatch
 - PR #104: Fix update-version.sh
+- PR #109: Fixing Incorrect Deallocation Size and Count Bugs
 
 # RAFT 0.16.0 (Date TBD)
 

--- a/cpp/include/raft/mr/buffer_base.hpp
+++ b/cpp/include/raft/mr/buffer_base.hpp
@@ -104,6 +104,9 @@ class buffer_base {
         allocator_->allocate(new_capacity * sizeof(value_type), stream_));
       if (size_ > 0) {
         raft::copy(new_data, data_, size_, stream_);
+      }
+      // Only deallocate if we have allocated a pointer
+      if (nullptr != data_) {
         allocator_->deallocate(data_, capacity_ * sizeof(value_type), stream_);
       }
       data_ = new_data;

--- a/cpp/include/raft/mr/host/allocator.hpp
+++ b/cpp/include/raft/mr/host/allocator.hpp
@@ -43,9 +43,9 @@ class default_allocator : public allocator {
   }
 
   void deallocate(void* p, std::size_t n, cudaStream_t stream) override {
-    ///@todo: enable this once logging is enabled in raft
-    //CUDA_CHECK_NO_THROW(cudaFreeHost(p));
-    CUDA_CHECK(cudaFreeHost(p));
+    //Must call _NO_THROW here is this is called frequently from object
+    //destructors which are "nothrow" by default
+    CUDA_CHECK_NO_THROW(cudaFreeHost(p));
   }
 };  // class default_allocator
 

--- a/cpp/include/raft/spectral/matrix_wrappers.hpp
+++ b/cpp/include/raft/spectral/matrix_wrappers.hpp
@@ -105,9 +105,8 @@ class vector_t {
       stream_(raft_handle.get_stream()) {}
 
   ~vector_t(void) {
-    handle_.get_device_allocator()->deallocate(buffer_,
-                                               size_ * sizeof(value_type),
-                                               stream_);
+    handle_.get_device_allocator()->deallocate(
+      buffer_, size_ * sizeof(value_type), stream_);
   }
 
   size_type size(void) const { return size_; }

--- a/cpp/include/raft/spectral/matrix_wrappers.hpp
+++ b/cpp/include/raft/spectral/matrix_wrappers.hpp
@@ -105,7 +105,9 @@ class vector_t {
       stream_(raft_handle.get_stream()) {}
 
   ~vector_t(void) {
-    handle_.get_device_allocator()->deallocate(buffer_, size_, stream_);
+    handle_.get_device_allocator()->deallocate(buffer_,
+                                               size_ * sizeof(value_type),
+                                               stream_);
   }
 
   size_type size(void) const { return size_; }


### PR DESCRIPTION
During the development of this PR: https://github.com/rapidsai/rmm/pull/626, I discovered a couple of issues that prevented the new `TrackingMemoryResource` from functioning properly. In some cases, `deallocate()` was being called with the wrong number of bytes or shouldn't have been called at all. This inhibits the `TrackingMemoryResource` from functioning correctly since the allocation bytes and deallocation bytes do not match.

This PR fixes these issues and adds a unit test to check for it moving forward.