### PR TITLE
[REVIEW] Make NCCL root initialization configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - PR #103: Epsilon parameter for Cholesky rank one update
 - PR #100: Add divyegala as codeowner
 - PR #111: Cleanup gpuCI scripts
+- PR #120: Update NCCL init process to support root node placement.
 
 ## Bug Fixes
 - PR #106: Specify dependency branches to avoid pip resolver failure

--- a/python/raft/dask/common/comms.py
+++ b/python/raft/dask/common/comms.py
@@ -377,7 +377,7 @@ def _func_set_scheduler_as_nccl_root(sessionId, verbose, dask_scheduler):
         session_state["nccl_uid"] = nccl.get_unique_id()
 
     if verbose:
-        logger.info(f"Done setting scheduler as NCCL root.")
+        logger.info("Done setting scheduler as NCCL root.")
 
     return session_state["nccl_uid"]
 
@@ -412,7 +412,7 @@ def _func_set_worker_as_nccl_root(sessionId, verbose):
 
     if verbose:
         get_worker().log_event(
-            topic="info", msg=f"Done setting scheduler as NCCL root."
+            topic="info", msg="Done setting scheduler as NCCL root."
         )
 
     return session_state["nccl_uid"]
@@ -492,7 +492,7 @@ def _func_init_nccl(sessionId, uniqueId):
         worker_state(sessionId)["nccl"] = n
     except Exception as e:
         get_worker().log_event(
-            topic="error", msg="An error occurred initializing NCCL!."
+            topic="error", msg=f"An error occurred initializing NCCL: {e}."
         )
         raise
 

--- a/python/raft/dask/common/comms.py
+++ b/python/raft/dask/common/comms.py
@@ -262,8 +262,7 @@ def local_handle(sessionId):
     state = get_raft_comm_state(sessionId, get_worker())
     return state["handle"] if "handle" in state else None
 
-
-def get_raft_comm_state(sessionId, state_object):
+def get_raft_comm_state(sessionId, state_object=None):
     """
     Retrieves cuML comms state on the scheduler node, for the given sessionId,
     creating a new session if it does not exist. If no session id is given,
@@ -281,6 +280,7 @@ def get_raft_comm_state(sessionId, state_object):
     session state : str
                     session state associated with sessionId
     """
+    state_object = state_object if state_object is not None else get_worker()
 
     if not hasattr(state_object, "_raft_comm_state"):
         state_object._raft_comm_state = {}

--- a/python/raft/dask/common/comms.py
+++ b/python/raft/dask/common/comms.py
@@ -549,7 +549,8 @@ async def _func_destroy_all(sessionId, comms_p2p, verbose=False):
             get_worker().log_event(topic="info", msg="NCCL session state destroyed.")
     else:
         if (verbose):
-            get_worker().log_event(topic="info", msg=f"{sessionId} does not contain")
+            get_worker().log_event(topic="warning",
+                                   msg=f"Session state for, '{sessionId}', does not contain expected 'nccl' element")
 
     if (verbose):
         get_worker().log_event(topic="info", msg=f"Destroy CUDA handle for sessionId, '{sessionId}.'")
@@ -557,8 +558,8 @@ async def _func_destroy_all(sessionId, comms_p2p, verbose=False):
         del session_state["handle"]
     else:
         if (verbose):
-            #TODO add logging for unexpected worker state
-            pass
+            get_worker().log_event(topic="warning",
+                                   msg=f"Session state for, '{sessionId}', does not contain expected 'handle' element")
 
 
 def _func_ucp_ports(client, workers):

--- a/python/raft/dask/common/comms.py
+++ b/python/raft/dask/common/comms.py
@@ -286,12 +286,12 @@ def get_raft_comm_state(sessionId, state_object):
         state_object._raft_comm_state = {}
 
     if (
-            sessionId is not None
-            and sessionId not in state_object._raft_comm_state
+        sessionId is not None
+        and sessionId not in state_object._raft_comm_state
     ):
         state_object._raft_comm_state[sessionId] = {"ts": time.time()}
 
-    if (sessionId is not None):
+    if sessionId is not None:
         return state_object._raft_comm_state[sessionId]
 
     return state_object._raft_comm_state
@@ -316,8 +316,9 @@ def get_ucx():
     A simple convenience wrapper to make sure UCP listener and
     endpoints are only ever assigned once per worker.
     """
-    raft_comm_state = get_raft_comm_state(sessionId="ucp",
-                                          state_object=get_worker())
+    raft_comm_state = get_raft_comm_state(
+        sessionId="ucp", state_object=get_worker()
+    )
     if "ucx" not in raft_comm_state:
         raft_comm_state["ucx"] = UCX.get()
 
@@ -413,8 +414,9 @@ async def _func_init_all(
     sessionId, uniqueId, comms_p2p, worker_info, verbose, streams_per_handle
 ):
     worker = get_worker()
-    raft_comm_state = get_raft_comm_state(sessionId=sessionId,
-                                        state_object=worker)
+    raft_comm_state = get_raft_comm_state(
+        sessionId=sessionId, state_object=worker
+    )
     raft_comm_state["nccl_uid"] = uniqueId
     raft_comm_state["wid"] = worker_info[get_worker().address]["rank"]
     raft_comm_state["nworkers"] = len(worker_info)
@@ -433,9 +435,7 @@ async def _func_init_all(
 
     if comms_p2p:
         if verbose:
-            worker.log_event(
-                topic="info", msg="Initializing UCX Endpoints"
-            )
+            worker.log_event(topic="info", msg="Initializing UCX Endpoints")
 
         if verbose:
             start = time.time()
@@ -472,8 +472,9 @@ def _func_init_nccl(sessionId, uniqueId):
     """
 
     worker = get_worker()
-    raft_comm_state = get_raft_comm_state(sessionId=sessionId,
-                                          state_object=get_worker())
+    raft_comm_state = get_raft_comm_state(
+        sessionId=sessionId, state_object=get_worker()
+    )
     wid = raft_comm_state["wid"]
     nWorkers = raft_comm_state["nworkers"]
 
@@ -503,8 +504,9 @@ def _func_build_handle_p2p(sessionId, streams_per_handle, verbose):
         worker.log_event(topic="info", msg="Building p2p handle.")
 
     ucp_worker = get_ucx().get_worker()
-    raft_comm_state = get_raft_comm_state(sessionId=sessionId,
-                                        state_object=worker)
+    raft_comm_state = get_raft_comm_state(
+        sessionId=sessionId, state_object=worker
+    )
 
     handle = Handle(streams_per_handle)
     nccl_comm = raft_comm_state["nccl"]
@@ -545,8 +547,9 @@ def _func_build_handle(sessionId, streams_per_handle, verbose):
 
     handle = Handle(streams_per_handle)
 
-    raft_comm_state = get_raft_comm_state(sessionId=sessionId,
-                                          state_object=worker)
+    raft_comm_state = get_raft_comm_state(
+        sessionId=sessionId, state_object=worker
+    )
 
     workerId = raft_comm_state["wid"]
     nWorkers = raft_comm_state["nworkers"]
@@ -559,8 +562,9 @@ def _func_build_handle(sessionId, streams_per_handle, verbose):
 
 
 def _func_store_initial_state(nworkers, sessionId, uniqueId, wid):
-    raft_comm_state = get_raft_comm_state(sessionId=sessionId,
-                                          state_object=get_worker())
+    raft_comm_state = get_raft_comm_state(
+        sessionId=sessionId, state_object=get_worker()
+    )
     raft_comm_state["nccl_uid"] = uniqueId
     raft_comm_state["wid"] = wid
     raft_comm_state["nworkers"] = nworkers
@@ -588,27 +592,25 @@ async def _func_ucp_create_endpoints(sessionId, worker_info):
         eps[worker_info[k]["rank"]] = ep
         count += 1
 
-    raft_comm_state = get_raft_comm_state(sessionId=sessionId,
-                                          state_object=get_worker())
+    raft_comm_state = get_raft_comm_state(
+        sessionId=sessionId, state_object=get_worker()
+    )
     raft_comm_state["ucp_eps"] = eps
 
 
 async def _func_destroy_all(sessionId, comms_p2p, verbose=False):
     worker = get_worker()
     if verbose:
-        worker.log_event(
-            topic="info", msg="Destroying NCCL session state."
-        )
+        worker.log_event(topic="info", msg="Destroying NCCL session state.")
 
-    raft_comm_state = get_raft_comm_state(sessionId=sessionId,
-                                          state_object=worker)
+    raft_comm_state = get_raft_comm_state(
+        sessionId=sessionId, state_object=worker
+    )
     if "nccl" in raft_comm_state:
         raft_comm_state["nccl"].destroy()
         del raft_comm_state["nccl"]
         if verbose:
-            worker.log_event(
-                topic="info", msg="NCCL session state destroyed."
-            )
+            worker.log_event(topic="info", msg="NCCL session state destroyed.")
     else:
         if verbose:
             worker.log_event(

--- a/python/raft/dask/common/comms.py
+++ b/python/raft/dask/common/comms.py
@@ -262,6 +262,7 @@ def local_handle(sessionId):
     state = get_raft_comm_state(sessionId, get_worker())
     return state["handle"] if "handle" in state else None
 
+
 def get_raft_comm_state(sessionId, state_object=None):
     """
     Retrieves cuML comms state on the scheduler node, for the given sessionId,

--- a/python/raft/test/test_comms.py
+++ b/python/raft/test/test_comms.py
@@ -88,17 +88,17 @@ def func_check_uid(sessionId, uniqueId, state_object):
 
 
 def func_check_uid_on_scheduler(sessionId, uniqueId, dask_scheduler):
-    return func_check_uid(sessionId=sessionId,
-                          uniqueId=uniqueId,
-                          state_object=dask_scheduler)
+    return func_check_uid(
+        sessionId=sessionId, uniqueId=uniqueId, state_object=dask_scheduler
+    )
 
 
 def func_check_uid_on_worker(sessionId, uniqueId):
     from dask.distributed import get_worker
 
-    return func_check_uid(sessionId=sessionId,
-                          uniqueId=uniqueId,
-                          state_object=get_worker())
+    return func_check_uid(
+        sessionId=sessionId, uniqueId=uniqueId, state_object=get_worker()
+    )
 
 
 def test_handles(cluster):

--- a/python/raft/test/test_comms.py
+++ b/python/raft/test/test_comms.py
@@ -67,7 +67,7 @@ def func_test_comm_split(sessionId, n_trials):
     handle = local_handle(sessionId)
     return perform_test_comm_split(handle, n_trials)
 
-def func_chk_uid_on_scheduler(sessionId, uniqueId, dask_scheduler):
+def func_check_uid_on_scheduler(sessionId, uniqueId, dask_scheduler):
     if (not hasattr(dask_scheduler, '_raft_comm_state')):
         return 1
 
@@ -85,7 +85,7 @@ def func_chk_uid_on_scheduler(sessionId, uniqueId, dask_scheduler):
 
     return 0
 
-def func_chk_uid_on_worker(sessionId, uniqueId):
+def func_check_uid_on_worker(sessionId, uniqueId):
     from dask.distributed import get_worker
 
     worker_state = get_worker()
@@ -154,12 +154,12 @@ def test_nccl_root_placement(client, root_location):
             client.scheduler_info()["workers"].keys()))
 
         if (root_location in ('worker',)):
-            result = client.run(func_chk_uid_on_worker,
+            result = client.run(func_check_uid_on_worker,
                                 cb.sessionId,
                                 cb.uniqueId,
                                 workers=[worker_addresses[0]])[worker_addresses[0]]
         elif (root_location in ('scheduler',)):
-            result = client.run_on_scheduler(func_chk_uid_on_scheduler, cb.sessionId, cb.uniqueId)
+            result = client.run_on_scheduler(func_check_uid_on_scheduler, cb.sessionId, cb.uniqueId)
         else:
             result = int(cb.uniqueId == None)
 
@@ -168,6 +168,8 @@ def test_nccl_root_placement(client, root_location):
     finally:
         if (cb):
             cb.destroy()
+
+# TODO: Add negative case test for bad location type, and Comm init failure so we check cleanup routines.
 
 @pytest.mark.parametrize("func", functions)
 @pytest.mark.parametrize("root_location", ['client', 'worker', 'scheduler'])

--- a/python/raft/test/test_comms.py
+++ b/python/raft/test/test_comms.py
@@ -180,7 +180,6 @@ def test_nccl_root_placement(client, root_location):
             cb.destroy()
 
 
-
 @pytest.mark.parametrize("func", functions)
 @pytest.mark.parametrize("root_location", ["client", "worker", "scheduler"])
 @pytest.mark.nccl

--- a/python/raft/test/test_comms.py
+++ b/python/raft/test/test_comms.py
@@ -22,7 +22,6 @@ from dask.distributed import wait
 
 try:
     from raft.dask import Comms
-    from raft.dask.common import nccl
     from raft.dask.common import local_handle
     from raft.dask.common import perform_test_comms_send_recv
     from raft.dask.common import perform_test_comms_allreduce
@@ -31,6 +30,7 @@ try:
     from raft.dask.common import perform_test_comms_allgather
     from raft.dask.common import perform_test_comms_reducescatter
     from raft.dask.common import perform_test_comm_split
+
     pytestmark = pytest.mark.mg
 except ImportError:
     pytestmark = pytest.mark.skip
@@ -67,41 +67,43 @@ def func_test_comm_split(sessionId, n_trials):
     handle = local_handle(sessionId)
     return perform_test_comm_split(handle, n_trials)
 
+
 def func_check_uid_on_scheduler(sessionId, uniqueId, dask_scheduler):
-    if (not hasattr(dask_scheduler, '_raft_comm_state')):
+    if not hasattr(dask_scheduler, "_raft_comm_state"):
         return 1
 
     state_object = dask_scheduler._raft_comm_state
-    if (sessionId not in state_object):
+    if sessionId not in state_object:
         return 2
 
     session_state = state_object[sessionId]
-    if ('nccl_uid' not in dask_scheduler._raft_comm_state[sessionId]):
+    if "nccl_uid" not in dask_scheduler._raft_comm_state[sessionId]:
         return 3
 
-    nccl_uid = session_state['nccl_uid']
-    if (nccl_uid != uniqueId):
+    nccl_uid = session_state["nccl_uid"]
+    if nccl_uid != uniqueId:
         return 4
 
     return 0
+
 
 def func_check_uid_on_worker(sessionId, uniqueId):
     from dask.distributed import get_worker
 
     worker_state = get_worker()
-    if (not hasattr(worker_state, '_raft_comm_state')):
+    if not hasattr(worker_state, "_raft_comm_state"):
         return 1
 
     state_object = worker_state._raft_comm_state
-    if (sessionId not in state_object):
+    if sessionId not in state_object:
         return 2
 
     session_state = state_object[sessionId]
-    if ('nccl_uid' not in session_state):
+    if "nccl_uid" not in session_state:
         return 3
 
-    nccl_uid = session_state['nccl_uid']
-    if (nccl_uid != uniqueId):
+    nccl_uid = session_state["nccl_uid"]
+    if nccl_uid != uniqueId:
         return 4
 
     return 0
@@ -118,11 +120,10 @@ def test_handles(cluster):
         cb = Comms(verbose=True)
         cb.init()
 
-        dfs = [client.submit(_has_handle,
-                             cb.sessionId,
-                             pure=False,
-                             workers=[w])
-               for w in cb.worker_addresses]
+        dfs = [
+            client.submit(_has_handle, cb.sessionId, pure=False, workers=[w])
+            for w in cb.worker_addresses
+        ]
         wait(dfs, timeout=5)
 
         assert all(client.compute(dfs, sync=True))
@@ -132,69 +133,87 @@ def test_handles(cluster):
         client.close()
 
 
-if pytestmark.markname != 'skip':
-    functions = [perform_test_comms_allgather,
-                 perform_test_comms_allreduce,
-                 perform_test_comms_bcast,
-                 perform_test_comms_reduce,
-                 perform_test_comms_reducescatter]
+if pytestmark.markname != "skip":
+    functions = [
+        perform_test_comms_allgather,
+        perform_test_comms_allreduce,
+        perform_test_comms_bcast,
+        perform_test_comms_reduce,
+        perform_test_comms_reducescatter,
+    ]
 else:
     functions = [None]
 
 
-@pytest.mark.parametrize("root_location", ['client', 'worker', 'scheduler'])
+@pytest.mark.parametrize("root_location", ["client", "worker", "scheduler"])
 def test_nccl_root_placement(client, root_location):
 
     cb = None
     try:
-        cb = Comms(verbose=True, client=client, nccl_root_location=root_location)
+        cb = Comms(
+            verbose=True, client=client, nccl_root_location=root_location
+        )
         cb.init()
 
-        worker_addresses = list(OrderedDict.fromkeys(
-            client.scheduler_info()["workers"].keys()))
+        worker_addresses = list(
+            OrderedDict.fromkeys(client.scheduler_info()["workers"].keys())
+        )
 
-        if (root_location in ('worker',)):
-            result = client.run(func_check_uid_on_worker,
-                                cb.sessionId,
-                                cb.uniqueId,
-                                workers=[worker_addresses[0]])[worker_addresses[0]]
-        elif (root_location in ('scheduler',)):
-            result = client.run_on_scheduler(func_check_uid_on_scheduler, cb.sessionId, cb.uniqueId)
+        if root_location in ("worker",):
+            result = client.run(
+                func_check_uid_on_worker,
+                cb.sessionId,
+                cb.uniqueId,
+                workers=[worker_addresses[0]],
+            )[worker_addresses[0]]
+        elif root_location in ("scheduler",):
+            result = client.run_on_scheduler(
+                func_check_uid_on_scheduler, cb.sessionId, cb.uniqueId
+            )
         else:
             result = int(cb.uniqueId == None)
 
-        assert (result == 0)
+        assert result == 0
 
     finally:
-        if (cb):
+        if cb:
             cb.destroy()
+
 
 # TODO: Add negative case test for bad location type, and Comm init failure so we check cleanup routines.
 
+
 @pytest.mark.parametrize("func", functions)
-@pytest.mark.parametrize("root_location", ['client', 'worker', 'scheduler'])
+@pytest.mark.parametrize("root_location", ["client", "worker", "scheduler"])
 @pytest.mark.nccl
 def test_collectives(client, func, root_location):
 
     try:
-        cb = Comms(verbose=True, client=client, nccl_root_location=root_location)
+        cb = Comms(
+            verbose=True, client=client, nccl_root_location=root_location
+        )
         cb.init()
 
         for k, v in cb.worker_info(cb.worker_addresses).items():
 
-            dfs = [client.submit(func_test_collective,
-                                 func,
-                                 cb.sessionId,
-                                 v["rank"],
-                                 pure=False,
-                                 workers=[w])
-                   for w in cb.worker_addresses]
+            dfs = [
+                client.submit(
+                    func_test_collective,
+                    func,
+                    cb.sessionId,
+                    v["rank"],
+                    pure=False,
+                    workers=[w],
+                )
+                for w in cb.worker_addresses
+            ]
             wait(dfs, timeout=5)
 
             assert all([x.result() for x in dfs])
     finally:
-        if (cb):
+        if cb:
             cb.destroy()
+
 
 @pytest.mark.nccl
 def test_comm_split(client):
@@ -202,12 +221,12 @@ def test_comm_split(client):
     cb = Comms(comms_p2p=True, verbose=True)
     cb.init()
 
-    dfs = [client.submit(func_test_comm_split,
-                         cb.sessionId,
-                         3,
-                         pure=False,
-                         workers=[w])
-           for w in cb.worker_addresses]
+    dfs = [
+        client.submit(
+            func_test_comm_split, cb.sessionId, 3, pure=False, workers=[w]
+        )
+        for w in cb.worker_addresses
+    ]
 
     wait(dfs, timeout=5)
 
@@ -221,13 +240,17 @@ def test_send_recv(n_trials, client):
     cb = Comms(comms_p2p=True, verbose=True)
     cb.init()
 
-    dfs = [client.submit(func_test_send_recv,
-                         cb.sessionId,
-                         n_trials,
-                         pure=False,
-                         workers=[w])
-           for w in cb.worker_addresses]
+    dfs = [
+        client.submit(
+            func_test_send_recv,
+            cb.sessionId,
+            n_trials,
+            pure=False,
+            workers=[w],
+        )
+        for w in cb.worker_addresses
+    ]
 
     wait(dfs, timeout=5)
 
-    assert(list(map(lambda x: x.result(), dfs)))
+    assert list(map(lambda x: x.result(), dfs))

--- a/python/raft/test/test_comms.py
+++ b/python/raft/test/test_comms.py
@@ -171,7 +171,7 @@ def test_nccl_root_placement(client, root_location):
                 func_check_uid_on_scheduler, cb.sessionId, cb.uniqueId
             )
         else:
-            result = int(cb.uniqueId == None)
+            result = int(cb.uniqueId is None)
 
         assert result == 0
 
@@ -179,8 +179,6 @@ def test_nccl_root_placement(client, root_location):
         if cb:
             cb.destroy()
 
-
-# TODO: Add negative case test for bad location type, and Comm init failure so we check cleanup routines.
 
 
 @pytest.mark.parametrize("func", functions)


### PR DESCRIPTION
This updates the raft comms implementation to support configurable NCCL root placement, updates scheduler and worker routine logging so that it is visible and usable in a multi-node deployment, and adds additional error handling to the NCCL initialization process to fail early if errors are encountered.

Updates resolve MNMG failures in out of band cuML algorithms where the DASK client does not have the ability to directly communicate with workers.

Unit tests are implemented and passing.

Closes https://github.com/rapidsai/cuml/issues/3261