### PR TITLE
[REVIEW] Update check to allow svd solver on CUDA>=10.2

### DIFF
--- a/cpp/include/raft/linalg/svd.cuh
+++ b/cpp/include/raft/linalg/svd.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ void svdQR(const raft::handle_t &handle, T *in, int n_rows, int n_cols,
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
   cublasHandle_t cublasH = handle.get_cublas_handle();
 
-#if CUDART_VERSION >= 10010
+#if CUDART_VERSION >= 10010 && CUDART_VERSION < 10020
   // 46340: sqrt of max int value
   ASSERT(n_rows <= 46340,
          "svd solver is not supported for the data that has more than 46340 "


### PR DESCRIPTION
Allow CUDA 10.2 or greater to use svd solver with greater than 46340 rows/columns; eliminate restriction relevant to CUDA 10.1 only