### PR TITLE
[REVIEW] Eliminate CUDA 10.2 as valid for large svd solving

### DIFF
--- a/cpp/include/raft/linalg/svd.cuh
+++ b/cpp/include/raft/linalg/svd.cuh
@@ -64,7 +64,7 @@ void svdQR(const raft::handle_t &handle, T *in, int n_rows, int n_cols,
   ASSERT(n_rows <= 46340,
          "svd solver is not supported for the data that has more than 46340 "
          "samples (rows) "
-         "if you are using CUDA version 10.1. Please use other solvers such as "
+         "if you are using CUDA version <11. Please use other solvers such as "
          "eig if it is available.");
 #endif
 

--- a/cpp/include/raft/linalg/svd.cuh
+++ b/cpp/include/raft/linalg/svd.cuh
@@ -59,7 +59,7 @@ void svdQR(const raft::handle_t &handle, T *in, int n_rows, int n_cols,
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
   cublasHandle_t cublasH = handle.get_cublas_handle();
 
-#if CUDART_VERSION >= 10010 && CUDART_VERSION < 10020
+#if CUDART_VERSION >= 10010 && CUDART_VERSION < 11000
   // 46340: sqrt of max int value
   ASSERT(n_rows <= 46340,
          "svd solver is not supported for the data that has more than 46340 "


### PR DESCRIPTION
Do not allow use of svd solver for input with more than 46430 rows until CUDA 11