### PR TITLE
[Review] Add idx_t template parameter to matrix helper routines

### DIFF
--- a/cpp/include/raft/matrix/matrix.cuh
+++ b/cpp/include/raft/matrix/matrix.cuh
@@ -47,21 +47,21 @@ using namespace std;
  * @param stream cuda stream
  * @param rowMajor whether the matrix has row major layout
  */
-template <typename m_t>
-void copyRows(const m_t *in, int n_rows, int n_cols, m_t *out,
-              const int *indices, int n_rows_indices, cudaStream_t stream,
-              bool rowMajor = false) {
+template <typename m_t, typename idx_array_t = int, typename idx_t = size_t>
+void copyRows(const m_t *in, idx_t n_rows, idx_t n_cols, m_t *out,
+              const idx_array_t *indices, idx_t n_rows_indices,
+              cudaStream_t stream, bool rowMajor = false) {
   if (rowMajor) {
     ASSERT(false, "matrix.h: row major is not supported yet!");
   }
 
-  auto size = n_rows_indices * n_cols;
-  auto counting = thrust::make_counting_iterator<int>(0);
+  idx_t size = n_rows_indices * n_cols;
+  auto counting = thrust::make_counting_iterator<idx_t>(0);
 
   thrust::for_each(thrust::cuda::par.on(stream), counting, counting + size,
-                   [=] __device__(int idx) {
-                     int row = idx % n_rows_indices;
-                     int col = idx / n_rows_indices;
+                   [=] __device__(idx_t idx) {
+                     idx_t row = idx % n_rows_indices;
+                     idx_t col = idx / n_rows_indices;
 
                      out[col * n_rows_indices + row] =
                        in[col * n_rows + indices[row]];
@@ -76,8 +76,8 @@ void copyRows(const m_t *in, int n_rows, int n_cols, m_t *out,
  * @param n_cols: number of columns of output matrix
  * @param stream: cuda stream
  */
-template <typename m_t>
-void copy(const m_t *in, m_t *out, int n_rows, int n_cols,
+template <typename m_t, typename idx_t = int>
+void copy(const m_t *in, m_t *out, idx_t n_rows, idx_t n_cols,
           cudaStream_t stream) {
   raft::copy_async(out, in, n_rows * n_cols, stream);
 }
@@ -92,20 +92,20 @@ void copy(const m_t *in, m_t *out, int n_rows, int n_cols,
  * @param out_n_cols: number of columns of output matrix
  * @param stream: cuda stream
  */
-template <typename m_t>
-void truncZeroOrigin(m_t *in, int in_n_rows, m_t *out, int out_n_rows,
-                     int out_n_cols, cudaStream_t stream) {
+template <typename m_t, typename idx_t = int>
+void truncZeroOrigin(m_t *in, idx_t in_n_rows, m_t *out, idx_t out_n_rows,
+                     idx_t out_n_cols, cudaStream_t stream) {
   auto m = out_n_rows;
   auto k = in_n_rows;
-  auto size = out_n_rows * out_n_cols;
+  idx_t size = out_n_rows * out_n_cols;
   auto d_q = in;
   auto d_q_trunc = out;
-  auto counting = thrust::make_counting_iterator<int>(0);
+  auto counting = thrust::make_counting_iterator<idx_t>(0);
 
   thrust::for_each(thrust::cuda::par.on(stream), counting, counting + size,
-                   [=] __device__(int idx) {
-                     int row = idx % m;
-                     int col = idx / m;
+                   [=] __device__(idx_t idx) {
+                     idx_t row = idx % m;
+                     idx_t col = idx / m;
                      d_q_trunc[col * m + row] = d_q[col * k + row];
                    });
 }
@@ -118,21 +118,21 @@ void truncZeroOrigin(m_t *in, int in_n_rows, m_t *out, int out_n_rows,
  * @param n_cols: number of columns of input matrix
  * @param stream: cuda stream
  */
-template <typename m_t>
-void colReverse(m_t *inout, int n_rows, int n_cols, cudaStream_t stream) {
+template <typename m_t, typename idx_t = int>
+void colReverse(m_t *inout, idx_t n_rows, idx_t n_cols, cudaStream_t stream) {
   auto n = n_cols;
   auto m = n_rows;
-  auto size = n_rows * n_cols;
+  idx_t size = n_rows * n_cols;
   auto d_q = inout;
   auto d_q_reversed = inout;
-  auto counting = thrust::make_counting_iterator<int>(0);
+  auto counting = thrust::make_counting_iterator<idx_t>(0);
 
   thrust::for_each(thrust::cuda::par.on(stream), counting,
-                   counting + (size / 2), [=] __device__(int idx) {
-                     int dest_row = idx % m;
-                     int dest_col = idx / m;
-                     int src_row = dest_row;
-                     int src_col = (n - dest_col) - 1;
+                   counting + (size / 2), [=] __device__(idx_t idx) {
+                     idx_t dest_row = idx % m;
+                     idx_t dest_col = idx / m;
+                     idx_t src_row = dest_row;
+                     idx_t src_col = (n - dest_col) - 1;
                      m_t temp = (m_t)d_q_reversed[idx];
                      d_q_reversed[idx] = d_q[src_col * m + src_row];
                      d_q[src_col * m + src_row] = temp;
@@ -147,21 +147,21 @@ void colReverse(m_t *inout, int n_rows, int n_cols, cudaStream_t stream) {
  * @param n_cols: number of columns of input matrix
  * @param stream: cuda stream
  */
-template <typename m_t>
-void rowReverse(m_t *inout, int n_rows, int n_cols, cudaStream_t stream) {
+template <typename m_t, typename idx_t = int>
+void rowReverse(m_t *inout, idx_t n_rows, idx_t n_cols, cudaStream_t stream) {
   auto m = n_rows;
-  auto size = n_rows * n_cols;
+  idx_t size = n_rows * n_cols;
   auto d_q = inout;
   auto d_q_reversed = inout;
-  auto counting = thrust::make_counting_iterator<int>(0);
+  auto counting = thrust::make_counting_iterator<idx_t>(0);
 
   thrust::for_each(thrust::cuda::par.on(stream), counting,
-                   counting + (size / 2), [=] __device__(int idx) {
-                     int dest_row = idx % m;
-                     int dest_col = idx / m;
-                     int src_row = (m - dest_row) - 1;
+                   counting + (size / 2), [=] __device__(idx_t idx) {
+                     idx_t dest_row = idx % m;
+                     idx_t dest_col = idx / m;
+                     idx_t src_row = (m - dest_row) - 1;
                      ;
-                     int src_col = dest_col;
+                     idx_t src_col = dest_col;
 
                      m_t temp = (m_t)d_q_reversed[idx];
                      d_q_reversed[idx] = d_q[src_col * m + src_row];
@@ -177,15 +177,15 @@ void rowReverse(m_t *inout, int n_rows, int n_cols, cudaStream_t stream) {
  * @param h_separator: horizontal separator character
  * @param v_separator: vertical separator character
  */
-template <typename m_t>
-void print(const m_t *in, int n_rows, int n_cols, char h_separator = ' ',
+template <typename m_t, typename idx_t = int>
+void print(const m_t *in, idx_t n_rows, idx_t n_cols, char h_separator = ' ',
            char v_separator = '\n') {
   std::vector<m_t> h_matrix = std::vector<m_t>(n_cols * n_rows);
   CUDA_CHECK(cudaMemcpy(h_matrix.data(), in, n_cols * n_rows * sizeof(m_t),
                         cudaMemcpyDeviceToHost));
 
-  for (auto i = 0; i < n_rows; i++) {
-    for (auto j = 0; j < n_cols; j++) {
+  for (idx_t i = 0; i < n_rows; i++) {
+    for (idx_t j = 0; j < n_cols; j++) {
       printf("%1.4f%c", h_matrix[j * n_rows + i],
              j < n_cols - 1 ? h_separator : v_separator);
     }
@@ -198,10 +198,10 @@ void print(const m_t *in, int n_rows, int n_cols, char h_separator = ' ',
  * @param n_rows: number of rows of input matrix
  * @param n_cols: number of columns of input matrix
  */
-template <typename m_t>
-void printHost(const m_t *in, int n_rows, int n_cols) {
-  for (auto i = 0; i < n_rows; i++) {
-    for (auto j = 0; j < n_cols; j++) {
+template <typename m_t, typename idx_t = int>
+void printHost(const m_t *in, idx_t n_rows, idx_t n_cols) {
+  for (idx_t i = 0; i < n_rows; i++) {
+    for (idx_t j = 0; j < n_cols; j++) {
       printf("%1.4f ", in[j * n_rows + i]);
     }
     printf("\n");
@@ -219,14 +219,14 @@ void printHost(const m_t *in, int n_rows, int n_cols) {
  * @param x2, y2: coordinate of the bottom-right point of the wanted area
  * (1-based)
  */
-template <typename m_t>
-__global__ void slice(m_t *src_d, int m, int n, m_t *dst_d, int x1, int y1,
-                      int x2, int y2) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
-  int dm = x2 - x1, dn = y2 - y1;
+template <typename m_t, typename idx_t = int>
+__global__ void slice(m_t *src_d, idx_t m, idx_t n, m_t *dst_d, idx_t x1,
+                      idx_t y1, idx_t x2, idx_t y2) {
+  idx_t idx = threadIdx.x + blockDim.x * blockIdx.x;
+  idx_t dm = x2 - x1, dn = y2 - y1;
   if (idx < dm * dn) {
-    int i = idx % dm, j = idx / dm;
-    int is = i + x1, js = j + y1;
+    idx_t i = idx % dm, j = idx / dm;
+    idx_t is = i + x1, js = j + y1;
     dst_d[idx] = src_d[is + js * m];
   }
 }
@@ -244,9 +244,9 @@ __global__ void slice(m_t *src_d, int m, int n, m_t *dst_d, int x1, int y1,
  * 3, 0, 1, 4, 3);
  * @param stream: cuda stream
  */
-template <typename m_t>
-void sliceMatrix(m_t *in, int n_rows, int n_cols, m_t *out, int x1, int y1,
-                 int x2, int y2, cudaStream_t stream) {
+template <typename m_t, typename idx_t = int>
+void sliceMatrix(m_t *in, idx_t n_rows, idx_t n_cols, m_t *out, idx_t x1,
+                 idx_t y1, idx_t x2, idx_t y2, cudaStream_t stream) {
   // Slicing
   dim3 block(64);
   dim3 grid(((x2 - x1) * (y2 - y1) + block.x - 1) / block.x);
@@ -261,13 +261,13 @@ void sliceMatrix(m_t *in, int n_rows, int n_cols, m_t *out, int x1, int y1,
  * @param n_cols: number of columns of input matrix
  * @param k: min(n_rows, n_cols)
  */
-template <typename m_t>
-__global__ void getUpperTriangular(m_t *src, m_t *dst, int n_rows, int n_cols,
-                                   int k) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
-  int m = n_rows, n = n_cols;
+template <typename m_t, typename idx_t = int>
+__global__ void getUpperTriangular(m_t *src, m_t *dst, idx_t n_rows,
+                                   idx_t n_cols, idx_t k) {
+  idx_t idx = threadIdx.x + blockDim.x * blockIdx.x;
+  idx_t m = n_rows, n = n_cols;
   if (idx < m * n) {
-    int i = idx % m, j = idx / m;
+    idx_t i = idx % m, j = idx / m;
     if (i < k && j < k && j >= i) {
       dst[i + j * k] = src[idx];
     }
@@ -282,11 +282,11 @@ __global__ void getUpperTriangular(m_t *src, m_t *dst, int n_rows, int n_cols,
  * @param n_cols: number of columns of input matrix
  * @param stream: cuda stream
  */
-template <typename m_t>
-void copyUpperTriangular(m_t *src, m_t *dst, int n_rows, int n_cols,
+template <typename m_t, typename idx_t = int>
+void copyUpperTriangular(m_t *src, m_t *dst, idx_t n_rows, idx_t n_cols,
                          cudaStream_t stream) {
-  int m = n_rows, n = n_cols;
-  int k = min(m, n);
+  idx_t m = n_rows, n = n_cols;
+  idx_t k = min(m, n);
   dim3 block(64);
   dim3 grid((m * n + block.x - 1) / block.x);
   getUpperTriangular<<<grid, block, 0, stream>>>(src, dst, m, n, k);
@@ -300,10 +300,10 @@ void copyUpperTriangular(m_t *src, m_t *dst, int n_rows, int n_cols,
  * @param n: number of columns of the matrix
  * @param k: dimensionality
  */
-template <typename m_t>
-__global__ void copyVectorToMatrixDiagonal(m_t *vec, m_t *matrix, int m, int n,
-                                           int k) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+template <typename m_t, typename idx_t = int>
+__global__ void copyVectorToMatrixDiagonal(m_t *vec, m_t *matrix, idx_t m,
+                                           idx_t n, idx_t k) {
+  idx_t idx = threadIdx.x + blockDim.x * blockIdx.x;
 
   if (idx < k) {
     matrix[idx + idx * m] = vec[idx];
@@ -318,10 +318,10 @@ __global__ void copyVectorToMatrixDiagonal(m_t *vec, m_t *matrix, int m, int n,
  * @param n_cols: number of columns of the matrix
  * @param stream: cuda stream
  */
-template <typename m_t>
-void initializeDiagonalMatrix(m_t *vec, m_t *matrix, int n_rows, int n_cols,
+template <typename m_t, typename idx_t = int>
+void initializeDiagonalMatrix(m_t *vec, m_t *matrix, idx_t n_rows, idx_t n_cols,
                               cudaStream_t stream) {
-  int k = min(n_rows, n_cols);
+  idx_t k = min(n_rows, n_cols);
   dim3 block(64);
   dim3 grid((k + block.x - 1) / block.x);
   copyVectorToMatrixDiagonal<<<grid, block, 0, stream>>>(vec, matrix, n_rows,
@@ -334,9 +334,9 @@ void initializeDiagonalMatrix(m_t *vec, m_t *matrix, int n_rows, int n_cols,
  * @param in: square input matrix with size len x len
  * @param len: size of one side of the matrix
  */
-template <typename m_t>
-__global__ void matrixDiagonalInverse(m_t *in, int len) {
-  int idx = threadIdx.x + blockDim.x * blockIdx.x;
+template <typename m_t, typename idx_t = int>
+__global__ void matrixDiagonalInverse(m_t *in, idx_t len) {
+  idx_t idx = threadIdx.x + blockDim.x * blockIdx.x;
   if (idx < len) {
     in[idx + idx * len] = 1.0 / in[idx + idx * len];
   }
@@ -348,8 +348,8 @@ __global__ void matrixDiagonalInverse(m_t *in, int len) {
  * @param len: size of one side of the matrix
  * @param stream: cuda stream
  */
-template <typename m_t>
-void getDiagonalInverseMatrix(m_t *in, int len, cudaStream_t stream) {
+template <typename m_t, typename idx_t = int>
+void getDiagonalInverseMatrix(m_t *in, idx_t len, cudaStream_t stream) {
   dim3 block(64);
   dim3 grid((len + block.x - 1) / block.x);
   matrixDiagonalInverse<m_t><<<grid, block, 0, stream>>>(in, len);
@@ -362,8 +362,8 @@ void getDiagonalInverseMatrix(m_t *in, int len, cudaStream_t stream) {
  * @param cublasH cublas handle
  * @param stream: cuda stream
  */
-template <typename m_t>
-m_t getL2Norm(const raft::handle_t &handle, m_t *in, int size,
+template <typename m_t, typename idx_t = int>
+m_t getL2Norm(const raft::handle_t &handle, m_t *in, idx_t size,
               cudaStream_t stream) {
   cublasHandle_t cublasH = handle.get_cublas_handle();
   m_t normval = 0;


### PR DESCRIPTION
This PR introduces a template type parameter for the matrix helper functions. The previous int type would overflow while accessing elements of a matrix that is larger than 2^31 elements. 

Related to https://github.com/rapidsai/cuml/issues/3233

A test is added for the copyRows function.
