### PR TITLE
Streams upgrade in RAFT handle (RMM backend + create handle from parent's pool)

### DIFF
--- a/cpp/include/raft/handle.hpp
+++ b/cpp/include/raft/handle.hpp
@@ -86,6 +86,9 @@ class handle_t {
 
   void set_stream(cudaStream_t stream) { user_stream_ = stream; }
   cudaStream_t get_stream() const { return user_stream_; }
+  rmm::cuda_stream_view get_stream_view() const {
+    return rmm::cuda_stream_view(user_stream_);
+  }
 
   void set_device_allocator(std::shared_ptr<mr::device::allocator> allocator) {
     device_allocator_ = allocator;
@@ -137,9 +140,15 @@ class handle_t {
     return cusparse_handle_;
   }
 
+  // legacy compatibility for cuML
   cudaStream_t get_internal_stream(int sid) const {
     return streams_.get_stream(sid).value();
   }
+  // new accessor return rmm::cuda_stream_view
+  rmm::cuda_stream_view get_internal_stream_view(int sid) const {
+    return streams_.get_stream(sid);
+  }
+
   int get_num_internal_streams() const { return streams_.get_pool_size(); }
   std::vector<cudaStream_t> get_internal_streams() const {
     std::vector<cudaStream_t> int_streams_vec;

--- a/cpp/include/raft/handle.hpp
+++ b/cpp/include/raft/handle.hpp
@@ -71,6 +71,8 @@ class handle_t {
   handle_t(const handle_t& h) : dev_id_(h.get_device()) {}
   handle_t(const handle_t&& h) : dev_id_(h.get_device()) {}
 
+  // light copy operator
+  // skip streams, comms, and libs handles
   handle_t& operator=(const handle_t& h) {
     prop_ = h.get_device_properties();
     device_prop_initialized_ = true;

--- a/cpp/include/raft/handle.hpp
+++ b/cpp/include/raft/handle.hpp
@@ -81,6 +81,9 @@ class handle_t {
   handle_t(const handle_t& other, int stream_id,
            int n_streams = kNumDefaultWorkerStreams)
     : dev_id_(other.get_device()), streams_(n_streams) {
+    RAFT_EXPECTS(
+      other.get_num_internal_streams() > 0,
+      "ERROR: the main handle must have at least one worker stream\n");
     prop_ = other.get_device_properties();
     device_prop_initialized_ = true;
     device_allocator_ = other.get_device_allocator();

--- a/cpp/test/handle.cpp
+++ b/cpp/test/handle.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <cstddef>
 #include <iostream>
 #include <memory>
 #include <raft/handle.hpp>
@@ -49,4 +50,14 @@ TEST(Raft, GetInternalStreams) {
   ASSERT_EQ(4U, streams.size());
 }
 
+TEST(Raft, GetHandleFromPool) {
+  handle_t parent(4);
+  int sid = 2;
+  auto child = parent.get_handle_from_internal_pool(sid);
+  std::cout << "done" << std::endl;
+
+  ASSERT_EQ(parent.get_internal_stream(sid), child.get_stream());
+  ASSERT_EQ(0, child.get_num_internal_streams());
+  ASSERT_EQ(parent.get_device(), child.get_device());
+}
 }  // namespace raft

--- a/cpp/test/handle.cpp
+++ b/cpp/test/handle.cpp
@@ -54,8 +54,6 @@ TEST(Raft, GetHandleFromPool) {
   handle_t parent(4);
   int sid = 2;
   auto child = parent.get_handle_from_internal_pool(sid);
-  std::cout << "done" << std::endl;
-
   ASSERT_EQ(parent.get_internal_stream(sid), child.get_stream());
   ASSERT_EQ(0, child.get_num_internal_streams());
   ASSERT_EQ(parent.get_device(), child.get_device());

--- a/cpp/test/handle.cpp
+++ b/cpp/test/handle.cpp
@@ -64,6 +64,18 @@ TEST(Raft, GetHandleFromPool) {
   ASSERT_EQ(parent.get_device(), child.get_device());
 }
 
+TEST(Raft, GetHandleFromPoolPerf) {
+  handle_t parent(100);
+  auto start = curTimeMillis();
+  for (int i = 0; i < parent.get_num_internal_streams(); i++) {
+    auto child = parent.get_handle_from_internal_pool(i);
+    ASSERT_EQ(parent.get_internal_stream(i), child.get_stream());
+    child.wait_on_user_stream();
+  }
+  // upperbound on 0.1ms per child handle
+  ASSERT_LE(curTimeMillis() - start, 10);
+}
+
 TEST(Raft, GetHandleStreamViews) {
   handle_t parent(4);
 

--- a/cpp/test/handle.cpp
+++ b/cpp/test/handle.cpp
@@ -52,10 +52,25 @@ TEST(Raft, GetInternalStreams) {
 
 TEST(Raft, GetHandleFromPool) {
   handle_t parent(4);
-  int sid = 2;
-  auto child = parent.get_handle_from_internal_pool(sid);
-  ASSERT_EQ(parent.get_internal_stream(sid), child.get_stream());
+
+  auto child = parent.get_handle_from_internal_pool(2);
+  ASSERT_EQ(parent.get_internal_stream(2), child.get_stream());
   ASSERT_EQ(0, child.get_num_internal_streams());
+
+  child.set_stream(parent.get_internal_stream(3));
+  ASSERT_EQ(parent.get_internal_stream(3), child.get_stream());
+  ASSERT_NE(parent.get_internal_stream(2), child.get_stream());
+
   ASSERT_EQ(parent.get_device(), child.get_device());
+}
+
+TEST(Raft, GetHandleStreamViews) {
+  handle_t parent(4);
+
+  auto child = parent.get_handle_from_internal_pool(2);
+  ASSERT_EQ(parent.get_internal_stream_view(2), child.get_stream_view());
+  ASSERT_EQ(parent.get_internal_stream_view(2).value(),
+            child.get_stream_view().value());
+  EXPECT_FALSE(child.get_stream_view().is_default());
 }
 }  // namespace raft

--- a/cpp/test/handle.cpp
+++ b/cpp/test/handle.cpp
@@ -53,7 +53,7 @@ TEST(Raft, GetInternalStreams) {
 TEST(Raft, GetHandleFromPool) {
   handle_t parent(4);
 
-  auto child = parent.get_handle_from_internal_pool(2);
+  handle_t child(parent, 2);
   ASSERT_EQ(parent.get_internal_stream(2), child.get_stream());
   ASSERT_EQ(0, child.get_num_internal_streams());
 
@@ -68,7 +68,7 @@ TEST(Raft, GetHandleFromPoolPerf) {
   handle_t parent(100);
   auto start = curTimeMillis();
   for (int i = 0; i < parent.get_num_internal_streams(); i++) {
-    auto child = parent.get_handle_from_internal_pool(i);
+    handle_t child(parent, i);
     ASSERT_EQ(parent.get_internal_stream(i), child.get_stream());
     child.wait_on_user_stream();
   }
@@ -79,7 +79,7 @@ TEST(Raft, GetHandleFromPoolPerf) {
 TEST(Raft, GetHandleStreamViews) {
   handle_t parent(4);
 
-  auto child = parent.get_handle_from_internal_pool(2);
+  handle_t child(parent, 2);
   ASSERT_EQ(parent.get_internal_stream_view(2), child.get_stream_view());
   ASSERT_EQ(parent.get_internal_stream_view(2).value(),
             child.get_stream_view().value());


### PR DESCRIPTION
Close #141 
Close #142

Add:
- RMM pool backends for handle's internal streams
- Feature to get a new handle from an existing handle by specifying a stream in the parent's pool 
- Keep previous accessors so that no change is needed in existing codes
- Additional accessors exposing `rmm::cuda_stream_view` for convenience (comes with `is_default()` and `synchronize()` features from rmm)

Verified that creating a light handle from a parent handle is very inexpensive (microseconds).

Needed for https://github.com/rapidsai/cugraph/issues/957