### PR TITLE
Remove setCudaMallocWarning() call for libfaiss@v1.7.0

### DIFF
--- a/cpp/include/raft/spatial/knn/detail/brute_force_knn.hpp
+++ b/cpp/include/raft/spatial/knn/detail/brute_force_knn.hpp
@@ -290,7 +290,6 @@ void brute_force_knn_impl(
       raft::select_stream(userStream, internalStreams, n_int_streams, i);
 
     gpu_res.noTempMemory();
-    gpu_res.setCudaMallocWarning(false);
     gpu_res.setDefaultStream(device, stream);
 
     faiss::gpu::GpuDistanceParams args;


### PR DESCRIPTION
Remove call to method removed in `libfaiss@v1.7.0`.
