### PR TITLE
Adjust Hellinger pairwise distance to vaoid NaNs

### DIFF
--- a/cpp/include/raft/sparse/distance/l2_distance.cuh
+++ b/cpp/include/raft/sparse/distance/l2_distance.cuh
@@ -270,7 +270,11 @@ class hellinger_expanded_distances_t : public distances_t<value_t> {
 
     raft::linalg::unaryOp<value_t>(
       out_dists, out_dists, config_->a_nrows * config_->b_nrows,
-      [=] __device__(value_t input) { return sqrt(1 - input); },
+      [=] __device__(value_t input) {
+        // Adjust to replace NaN in sqrt with 0 if input to sqrt is negative
+        value_t rectifier = (1 - input) > 0;
+        return rectifier * sqrt(1 - input);
+      },
       config_->stream);
   }
 

--- a/cpp/include/raft/sparse/distance/l2_distance.cuh
+++ b/cpp/include/raft/sparse/distance/l2_distance.cuh
@@ -272,7 +272,7 @@ class hellinger_expanded_distances_t : public distances_t<value_t> {
       out_dists, out_dists, config_->a_nrows * config_->b_nrows,
       [=] __device__(value_t input) {
         // Adjust to replace NaN in sqrt with 0 if input to sqrt is negative
-        value_t rectifier = (1 - input) > 0;
+        bool rectifier = abs(1 - input) > 1e-8;
         return rectifier * sqrt(1 - input);
       },
       config_->stream);


### PR DESCRIPTION
This change will fix NaNs that arise in Hellinger pairwise distance when the input to sqrt is negative.
These kind of inputs can happen even when the inputs are normalized row-wise to 1 due to accumulation of rounding approximation.