### PR TITLE
[gpuCI] Forward-merge branch-0.19 to branch-0.20 [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,15 @@
 #cpp code owners
-cpp/               @rapidsai/cuml-cpp-codeowners
-cpp/               @rapidsai/cugraph-cpp-codeowners
-cpp/               @divyegala
+cpp/               @divyegala @rapidsai/cuml-cpp-codeowners @rapidsai/cugraph-cpp-codeowners
 
 #python code owners
-python/            @rapidsai/cuml-python-codeowners
-python/            @rapidsai/cugraph-python-codeowners
-python/            @divyegala
+python/            @divyegala @rapidsai/cuml-python-codeowners @rapidsai/cugraph-python-codeowners
 
 #cmake code owners
-**/CMakeLists.txt  @rapidsai/cuml-cmake-codeowners
-**/CMakeLists.txt  @rapidsai/cugraph-cmake-codeowners
-**/CMakeLists.txt  @divyegala
-**/cmake/          @rapidsai/cuml-cmake-codeowners
-**/cmake/          @rapidsai/cugraph-cmake-codeowners
-python/setup.py    @rapidsai/cuml-cmake-codeowners
-python/setup.py    @rapidsai/cugraph-cmake-codeowners
-build.sh           @rapidsai/cuml-cmake-codeowners
-build.sh           @rapidsai/cugraph-cmake-codeowners
-**/build.sh        @rapidsai/cuml-cmake-codeowners
-**/build.sh        @rapidsai/cugraph-cmake-codeowners
+**/CMakeLists.txt  @divyegala @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners
+**/cmake/          @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners
+python/setup.py    @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners
+build.sh           @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners
+**/build.sh        @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners
 
 #build/ops code owners
 .github/           @rapidsai/ops-codeowners


### PR DESCRIPTION
Forward-merge triggered by push to `branch-0.19` that creates a PR to keep `branch-0.20` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.