### PR TITLE
[REVIEW] Adding assert for MST edge count in SLHC

### DIFF
--- a/cpp/include/raft/sparse/hierarchy/detail/mst.cuh
+++ b/cpp/include/raft/sparse/hierarchy/detail/mst.cuh
@@ -201,6 +201,12 @@ void build_sorted_mst(const raft::handle_t &handle, const value_t *X,
                " or increase 'max_iter'",
                max_iter);
 
+  RAFT_EXPECTS(mst_coo.n_edges == m - 1,
+               "n_edges should be %d but was %d. This"
+               "could be an indication of duplicate edges returned from the"
+               "MST or symmetrization stage.",
+               m - 1, mst_coo.n_edges);
+
   sort_coo_by_data(mst_coo.src.data(), mst_coo.dst.data(),
                    mst_coo.weights.data(), mst_coo.n_edges, stream);
 


### PR DESCRIPTION
We've seen a few failure in cuML's SLHC pytests where the dendrogram didn't have the correct number of nodes even though the edges are connected. This is an indication that either there might not be the correct number of edges in the MST or there might be duplicate edges. Unfortunately, I've been unable to reproduce the pytest failure locally so I've added an assertion to verify the number of expected edges in the MST to, hopefully, give us an indicator of what's going wrong. 