### PR TITLE
`debug_utils.cuh` in RAFT

### DIFF
--- a/cpp/include/raft/debug_utils.cuh
+++ b/cpp/include/raft/debug_utils.cuh
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <rmm/exec_policy.hpp>
+
+struct isnan_functor {
+  template <typename value_t>
+  __host__ __device__ bool operator()(const value_t a) const {
+    return isnan(a);
+  }
+};
+
+/*
+ * Function to check if any nans exist in device vector
+ */
+template <typename value_t, typename value_idx>
+bool isnan_test(const value_t *buffer, const value_idx size,
+                cudaStream_t stream) {
+  auto policy = rmm::exec_policy(stream);
+
+  return thrust::transform_reduce(policy, buffer, buffer + size,
+                                  isnan_functor(), 0, thrust::plus<bool>());
+}


### PR DESCRIPTION
This PR introduces `debug_utils.cuh` in RAFT, which aims to provide primitives for standard testing/debugging. The first primitive to be provided by this PR is to check whether `nans` exist in a given device vector