### PR TITLE
Add `warpId` and masked `warpReduce`.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -249,6 +249,7 @@ if(BUILD_RAFT_TESTS)
   # keep the files in alphabetical order!
   add_executable(test_raft
     test/cudart_utils.cpp
+    test/cuda_utils.cu
     test/distance/dist_adj.cu
     test/distance/dist_cos.cu
     test/distance/dist_euc_exp.cu

--- a/cpp/include/raft/cuda_utils.cuh
+++ b/cpp/include/raft/cuda_utils.cuh
@@ -618,7 +618,8 @@ DI T warpReduce(T val, uint32_t mask = warp_full_mask()) {
  */
 DI int32_t warpId() {
   int32_t n_warps_per_block = blockDim.x / raft::warp_size();
-  assert(blockDim.x % raft::warp_size() == 0 && "block size must be multiple of warp size");
+  assert(blockDim.x % raft::warp_size() == 0 &&
+         "block size must be multiple of warp size");
   int32_t n_warps = n_warps_per_block * blockIdx.x;
   int32_t warp_id = n_warps + threadIdx.x / raft::warp_size();
   return warp_id;

--- a/cpp/include/raft/sparse/hierarchy/detail/mst.cuh
+++ b/cpp/include/raft/sparse/hierarchy/detail/mst.cuh
@@ -202,7 +202,7 @@ void build_sorted_mst(const raft::handle_t &handle, const value_t *X,
                max_iter);
 
   RAFT_EXPECTS(mst_coo.n_edges == m - 1,
-               "n_edges should be %d but was %lu. This"
+               "n_edges should be %d but was %d. This"
                "could be an indication of duplicate edges returned from the"
                "MST or symmetrization stage.",
                m - 1, mst_coo.n_edges);

--- a/cpp/include/raft/sparse/hierarchy/detail/mst.cuh
+++ b/cpp/include/raft/sparse/hierarchy/detail/mst.cuh
@@ -202,7 +202,7 @@ void build_sorted_mst(const raft::handle_t &handle, const value_t *X,
                max_iter);
 
   RAFT_EXPECTS(mst_coo.n_edges == m - 1,
-               "n_edges should be %d but was %d. This"
+               "n_edges should be %d but was %lu. This"
                "could be an indication of duplicate edges returned from the"
                "MST or symmetrization stage.",
                m - 1, mst_coo.n_edges);

--- a/cpp/test/cuda_utils.cu
+++ b/cpp/test/cuda_utils.cu
@@ -3,24 +3,27 @@
 #include <raft/cuda_utils.cuh>
 
 void __global__ testWarpReduce(float* data, float* out) {
-  uint32_t mask = __ballot_sync(raft::warp_full_mask(), raft::laneId() < 16);
+  size_t half_warp = raft::warp_size() / 2;
+  uint32_t mask = __ballot_sync(raft::warp_full_mask(), raft::laneId() < half_warp);
   float val = 0.0f;
-  if (raft::laneId() < 16) {
+  if (raft::laneId() < half_warp) {
     val = raft::warpReduce(data[threadIdx.x], mask);
   }
 
-  data[raft::warpId()] = val;
+  if (raft::laneId() == 0) {
+    out[raft::warpId()] = val;
+  }
 }
 
-
 TEST(Raft, WarpReduce) {
-  size_t constexpr kBlock = 256;
-  thrust::device_vector<float> buffer(kBlock);
-  thrust::fill(buffer.begin(), buffer.end(), 1.0f);
+  size_t constexpr kBlock = 256, kGrid = 2;
+  thrust::device_vector<float> input(kBlock * kGrid);
+  thrust::fill(input.begin(), input.end(), 1.0f);
 
-  thrust::device_vector<float> out(buffer.size() / raft::warp_size());
+  // allocate buffer with size equal to number of warps
+  thrust::device_vector<float> out(input.size() / raft::warp_size());
 
-  testWarpReduce<<<1, kBlock>>>(buffer.data().get(), out.data().get());
+  testWarpReduce<<<kGrid, kBlock>>>(input.data().get(), out.data().get());
   cudaDeviceSynchronize();
 
   for (size_t i = 0; i < out.size(); ++i) {

--- a/cpp/test/cuda_utils.cu
+++ b/cpp/test/cuda_utils.cu
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#include <thrust/device_vector.h>
+#include <raft/cuda_utils.cuh>
+
+void __global__ testWarpReduce(float* data, float* out) {
+  uint32_t mask = __ballot_sync(raft::warp_full_mask(), raft::laneId() < 16);
+  float val = 0.0f;
+  if (raft::laneId() < 16) {
+    val = raft::warpReduce(data[threadIdx.x], mask);
+  }
+
+  data[raft::warpId()] = val;
+}
+
+
+TEST(Raft, WarpReduce) {
+  size_t constexpr kBlock = 256;
+  thrust::device_vector<float> buffer(kBlock);
+  thrust::fill(buffer.begin(), buffer.end(), 1.0f);
+
+  thrust::device_vector<float> out(buffer.size() / raft::warp_size());
+
+  testWarpReduce<<<1, kBlock>>>(buffer.data().get(), out.data().get());
+  cudaDeviceSynchronize();
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    ASSERT_EQ(out[i], float(raft::warp_size() / 2));
+  }
+}

--- a/cpp/test/cuda_utils.cu
+++ b/cpp/test/cuda_utils.cu
@@ -4,7 +4,8 @@
 
 void __global__ testWarpReduce(float* data, float* out) {
   size_t half_warp = raft::warp_size() / 2;
-  uint32_t mask = __ballot_sync(raft::warp_full_mask(), raft::laneId() < half_warp);
+  uint32_t mask =
+    __ballot_sync(raft::warp_full_mask(), raft::laneId() < half_warp);
   float val = 0.0f;
   if (raft::laneId() < half_warp) {
     val = raft::warpReduce(data[threadIdx.x], mask);


### PR DESCRIPTION
Please do NOT merge it for now.  This is a part of the effort for implementing deterministic UMAP optimization.