### PR TITLE
[REVIEW] error.hpp contains unnecessary extra headers

### DIFF
--- a/cpp/include/raft/error.hpp
+++ b/cpp/include/raft/error.hpp
@@ -16,11 +16,6 @@
 
 #pragma once
 
-#include <cuda.h>
-#include <cuda_runtime_api.h>
-#include <curand.h>
-#include <cusparse_v2.h>
-
 #include <execinfo.h>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Got a bunch of warnings compiling cugraph.  This lead to the observation that error.hpp contains 4 headers that don't appear to be necessary.

This PR removes those extraneous includes.