### PR TITLE
Fix mst knn test build failure due to RMM device_buffer change

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -51,7 +51,7 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
       "rmm=${MINOR_VERSION}" \
       "dask-cudf=${MINOR_VERSION}" \
       "dask-cuda=${MINOR_VERSION}" \
-      "ucx-py=${MINOR_VERSION}" \
+      "ucx-py=0.21" \
       "rapids-build-env=${MINOR_VERSION}.*" \
       "rapids-notebook-env=${MINOR_VERSION}.*" \
       "rapids-doc-env=${MINOR_VERSION}.*"

--- a/cpp/test/mst.cu
+++ b/cpp/test/mst.cu
@@ -58,7 +58,7 @@ weight_t prims(CSRHost<vertex_t, edge_t, weight_t> &csr_h) {
   auto n_vertices = csr_h.offsets.size() - 1;
 
   bool active_vertex[n_vertices];
-  // bool mst_set[csr_h.n_edges];
+  //  bool mst_set[csr_h.n_edges];
   weight_t curr_edge[n_vertices];
 
   for (auto i = 0; i < n_vertices; i++) {

--- a/cpp/test/mst.cu
+++ b/cpp/test/mst.cu
@@ -198,15 +198,15 @@ class MSTTest
       MSTTestInput<vertex_t, edge_t, weight_t>>::GetParam();
     iterations = mst_input.iterations;
 
-    csr_d.offsets =
-      rmm::device_buffer(mst_input.csr_h.offsets.data(),
-                         mst_input.csr_h.offsets.size() * sizeof(edge_t));
-    csr_d.indices =
-      rmm::device_buffer(mst_input.csr_h.indices.data(),
-                         mst_input.csr_h.indices.size() * sizeof(vertex_t));
-    csr_d.weights =
-      rmm::device_buffer(mst_input.csr_h.weights.data(),
-                         mst_input.csr_h.weights.size() * sizeof(weight_t));
+    csr_d.offsets = rmm::device_buffer(
+      mst_input.csr_h.offsets.data(),
+      mst_input.csr_h.offsets.size() * sizeof(edge_t), handle.get_stream());
+    csr_d.indices = rmm::device_buffer(
+      mst_input.csr_h.indices.data(),
+      mst_input.csr_h.indices.size() * sizeof(vertex_t), handle.get_stream());
+    csr_d.weights = rmm::device_buffer(
+      mst_input.csr_h.weights.data(),
+      mst_input.csr_h.weights.size() * sizeof(weight_t), handle.get_stream());
   }
 
   void TearDown() override {}

--- a/cpp/test/spatial/knn.cu
+++ b/cpp/test/spatial/knn.cu
@@ -107,11 +107,13 @@ class KNNTest : public ::testing::TestWithParam<KNNInputs> {
       }
     }
     rmm::device_buffer input_d = rmm::device_buffer(
-      row_major_input.data(), row_major_input.size() * sizeof(float));
+      row_major_input.data(), row_major_input.size() * sizeof(float),
+      handle_.get_stream());
     float *input_ptr = static_cast<float *>(input_d.data());
 
     rmm::device_buffer labels_d = rmm::device_buffer(
-      params_.labels.data(), params_.labels.size() * sizeof(int));
+      params_.labels.data(), params_.labels.size() * sizeof(int),
+      handle_.get_stream());
     int *labels_ptr = static_cast<int *>(labels_d.data());
 
     raft::allocate(input_, rows_ * cols_, true);


### PR DESCRIPTION
This RMM change has caused below build failure - https://github.com/rapidsai/rmm/commit/7cbcd97586bcc48a39787de0c80e5e8e7e175c46 

[ 22%] Building CUDA object CMakeFiles/test_raft.dir/test/sparse/symmetrize.cu.o
/data/raft/cpp/test/mst.cu(202): error: no instance of constructor "rmm::device_buffer::device_buffer" matches the argument list
            argument types are: (int *, unsigned long)
          detected during instantiation of "void raft::mst::MSTTest<vertex_t, edge_t, weight_t>::SetUp() [with vertex_t=int, edge_t=int, weight_t=float]"
/data/raft/cpp/test/mst.cu(205): error: no instance of constructor "rmm::device_buffer::device_buffer" matches the argument list
            argument types are: (int *, unsigned long)
          detected during instantiation of "void raft::mst::MSTTest<vertex_t, edge_t, weight_t>::SetUp() [with vertex_t=int, edge_t=int, weight_t=float]"
/data/raft/cpp/test/mst.cu(208): error: no instance of constructor "rmm::device_buffer::device_buffer" matches the argument list
            argument types are: (float *, unsigned long)
          detected during instantiation of "void raft::mst::MSTTest<vertex_t, edge_t, weight_t>::SetUp() [with vertex_t=int, edge_t=int, weight_t=float]"
3 errors detected in the compilation of "/data/raft/cpp/test/mst.cu".
make[2]: *** [CMakeFiles/test_raft.dir/build.make:594: CMakeFiles/test_raft.dir/test/mst.cu.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/test_raft.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
