### PR TITLE
Pass stream to device_scalar::value() calls.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 #cpp code owners
-cpp/               @divyegala @rapidsai/cuml-cpp-codeowners @rapidsai/cugraph-cpp-codeowners
+cpp/               @rapidsai/cuml-cpp-codeowners @rapidsai/cugraph-cpp-codeowners
 
 #python code owners
-python/            @divyegala @rapidsai/cuml-python-codeowners @rapidsai/cugraph-python-codeowners
+python/            @rapidsai/cuml-python-codeowners @rapidsai/cugraph-python-codeowners
 
 #cmake code owners
-**/CMakeLists.txt  @divyegala @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners
+**/CMakeLists.txt  @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners
 **/cmake/          @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners
 python/setup.py    @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners
 build.sh           @rapidsai/cuml-cmake-codeowners @rapidsai/cugraph-cmake-codeowners

--- a/cpp/cmake/thirdparty/get_rmm.cmake
+++ b/cpp/cmake/thirdparty/get_rmm.cmake
@@ -20,13 +20,19 @@ function(find_and_configure_rmm VERSION)
         return()
     endif()
 
+    if(${VERSION} MATCHES [=[([0-9]+)\.([0-9]+)\.([0-9]+)]=])
+        set(MAJOR_AND_MINOR "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
+    else()
+        set(MAJOR_AND_MINOR "${VERSION}")
+    endif()
+
     rapids_cpm_find(rmm ${VERSION}
         GLOBAL_TARGETS      rmm::rmm
         BUILD_EXPORT_SET    raft-exports
         INSTALL_EXPORT_SET  raft-exports
         CPM_ARGS
             GIT_REPOSITORY  https://github.com/rapidsai/rmm.git
-            GIT_TAG         branch-${VERSION}
+            GIT_TAG         branch-${MAJOR_AND_MINOR}
             GIT_SHALLOW     TRUE
             OPTIONS         "BUILD_TESTS OFF"
                             "BUILD_BENCHMARKS OFF"
@@ -36,6 +42,6 @@ function(find_and_configure_rmm VERSION)
 
 endfunction()
 
-set(RAFT_MIN_VERSION_rmm "${RAFT_VERSION_MAJOR}.${RAFT_VERSION_MINOR}")
+set(RAFT_MIN_VERSION_rmm "${RAFT_VERSION_MAJOR}.${RAFT_VERSION_MINOR}.00")
 
 find_and_configure_rmm(${RAFT_MIN_VERSION_rmm})

--- a/cpp/include/raft/comms/test.hpp
+++ b/cpp/include/raft/comms/test.hpp
@@ -378,7 +378,7 @@ bool test_pointToPoint_device_send_or_recv(const handle_t &h, int numTrials) {
 
     communicator.sync_stream(stream);
 
-    if (!sender && received_data.value() != rank - 1) {
+    if (!sender && received_data.value(stream) != rank - 1) {
       ret = false;
     }
 
@@ -424,8 +424,8 @@ bool test_pointToPoint_device_sendrecv(const handle_t &h, int numTrials) {
 
     communicator.sync_stream(stream);
 
-    if (((rank % 2 == 0) && (received_data.value() != rank + 1)) ||
-        ((rank % 2 == 1) && (received_data.value() != rank - 1))) {
+    if (((rank % 2 == 0) && (received_data.value(stream) != rank + 1)) ||
+        ((rank % 2 == 1) && (received_data.value(stream) != rank - 1))) {
       ret = false;
     }
 


### PR DESCRIPTION
In comms/test.hpp `device_scalar::value` was not being passed an explicit stream, which means that the default stream was being synced. rapidsai/rmm#789 will remove the default from this parameter, and would have therefore broken the RAFT build. So this PR fixes the oversynchronization and ensures RAFT will build after the RMM PR is merged.

Note this PR includes the cmake changes from #258 (just so I could build locally). Once #258 is merged this PR's changes will be simplified.