### PR TITLE
Pin `dask` versions in CI

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,8 +59,8 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
 # Install the master version of dask, distributed, and dask-ml
 gpuci_logger "Install the master version of dask and distributed"
 set -x
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+pip install "git+https://github.com/dask/distributed.git@2021.05.1" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git@2021.05.1" --upgrade --no-deps
 set +x
 
 

--- a/ci/local/old-gpubuild.sh
+++ b/ci/local/old-gpubuild.sh
@@ -80,10 +80,10 @@ if [ "$RUN_CUGRAPH_LIBCUGRAPH_TESTS" = "ON" ] || [ "$RUN_CUGRAPH_PYTHON_TESTS" =
 fi
 
 # Install the master version of dask, distributed, and dask-ml
-gpuci_logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-gpuci_logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+set -x
+pip install "git+https://github.com/dask/distributed.git@2021.05.1" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git@2021.05.1" --upgrade --no-deps
+set +x
 
 
 gpuci_logger "Check versions"


### PR DESCRIPTION
Similarly to https://github.com/rapidsai/cuml/pull/3937/files, this PR pins the version of `dask` and `distributed` that's used in CI.