### PR TITLE
Revert "pin dask versions in CI (#260)"

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,8 +59,8 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
 # Install the master version of dask, distributed, and dask-ml
 gpuci_logger "Install the master version of dask and distributed"
 set -x
-pip install "git+https://github.com/dask/distributed.git@2021.05.1" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git@2021.05.1" --upgrade --no-deps
+pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
 set +x
 
 

--- a/ci/local/old-gpubuild.sh
+++ b/ci/local/old-gpubuild.sh
@@ -81,8 +81,8 @@ fi
 
 # Install the master version of dask, distributed, and dask-ml
 set -x
-pip install "git+https://github.com/dask/distributed.git@2021.05.1" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git@2021.05.1" --upgrade --no-deps
+pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
 set +x
 
 


### PR DESCRIPTION
This PR reverts the pins that were made in #260. Those changes were only needed for the `21.06` branch.