### PR TITLE
Add a default for epsilon in LAP constructor

### DIFF
--- a/cpp/include/raft/lap/lap.cuh
+++ b/cpp/include/raft/lap/lap.cuh
@@ -60,7 +60,7 @@ class LinearAssignmentProblem {
 
  public:
   LinearAssignmentProblem(raft::handle_t const &handle, vertex_t size,
-                          vertex_t batchsize, weight_t epsilon)
+                          vertex_t batchsize, weight_t epsilon=1e-6)
     : handle_(handle),
       size_(size),
       batchsize_(batchsize),


### PR DESCRIPTION
I encountered a fail when building cugraph against this latest version of raft. This change adds a default for the new epsilon parameter.
