### PR TITLE
Add `cuco::cuco` to list of linked libraries

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -131,6 +131,7 @@ INTERFACE
   CUDA::cudart
   CUDA::cusparse
   rmm::rmm
+  cuco::cuco
   )
 
 target_compile_features(raft INTERFACE cxx_std_17 $<BUILD_INTERFACE:cuda_std_17>)

--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -16,6 +16,10 @@
 
 function(find_and_configure_cuco VERSION)
 
+    if(TARGET cuco::cuco)
+      return()
+    endif()
+
     rapids_cpm_find(cuco ${VERSION}
       GLOBAL_TARGETS cuco cuco::cuco
       BUILD_EXPORT_SET    raft-exports

--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -18,6 +18,8 @@ function(find_and_configure_cuco VERSION)
 
     rapids_cpm_find(cuco ${VERSION}
       GLOBAL_TARGETS cuco cuco::cuco
+      BUILD_EXPORT_SET    raft-exports
+      INSTALL_EXPORT_SET  raft-exports
       CPM_ARGS
         GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
         GIT_TAG        e5e2abe55152608ef449ecf162a1ef52ded19801

--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -25,8 +25,8 @@ function(find_and_configure_cuco VERSION)
       BUILD_EXPORT_SET    raft-exports
       INSTALL_EXPORT_SET  raft-exports
       CPM_ARGS
-        GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
-        GIT_TAG        e5e2abe55152608ef449ecf162a1ef52ded19801
+        GIT_REPOSITORY https://github.com/trxcllnt/cuCollections.git
+        GIT_TAG        dev
         OPTIONS        "BUILD_TESTS OFF"
                        "BUILD_BENCHMARKS OFF"
                        "BUILD_EXAMPLES OFF"


### PR DESCRIPTION
Adds `cuco::cuco` to `target_link_libraries` because it's used by https://github.com/rapidsai/raft/blob/branch-21.08/cpp/include/raft/sparse/distance/coo_spmv_strategies/hash_strategy.cuh#L21