### PR TITLE
Only add cuco::cuco alias to `global_targets`

### DIFF
--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -21,7 +21,7 @@ function(find_and_configure_cuco VERSION)
     endif()
 
     rapids_cpm_find(cuco ${VERSION}
-      GLOBAL_TARGETS cuco cuco::cuco
+      GLOBAL_TARGETS      cuco::cuco
       BUILD_EXPORT_SET    raft-exports
       INSTALL_EXPORT_SET  raft-exports
       CPM_ARGS


### PR DESCRIPTION
Trying to fix this error in https://github.com/rapidsai/cuml/pull/4012:

```
CMake Warning (dev) at /opt/conda/envs/rapids/lib64/cmake/raft/raft-dependencies.cmake:23:
  Syntax Warning in cmake code at column 46

  Argument not separated from preceding token by whitespace.
Call Stack (most recent call first):
  /opt/conda/envs/rapids/lib64/cmake/raft/raft-config.cmake:72 (include)
  build/cmake/CPM_7644c3a40fc7889f8dee53ce21e85dc390b883dc.cmake:204 (find_package)
  build/cmake/CPM_7644c3a40fc7889f8dee53ce21e85dc390b883dc.cmake:255 (cpm_find_package)
  build/_deps/rapids-cmake-src/rapids-cmake/cpm/find.cmake:92 (CPMFindPackage)
  cmake/thirdparty/get_raft.cmake:23 (rapids_cpm_find)
  cmake/thirdparty/get_raft.cmake:45 (find_and_configure_raft)
  CMakeLists.txt:187 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /opt/conda/envs/rapids/lib64/cmake/raft/raft-dependencies.cmake:27 (if):
  if given arguments:

    "TARGET" "("

  mismatched parenthesis in condition
Call Stack (most recent call first):
  /opt/conda/envs/rapids/lib64/cmake/raft/raft-config.cmake:72 (include)
  build/cmake/CPM_7644c3a40fc7889f8dee53ce21e85dc390b883dc.cmake:204 (find_package)
  build/cmake/CPM_7644c3a40fc7889f8dee53ce21e85dc390b883dc.cmake:255 (cpm_find_package)
  build/_deps/rapids-cmake-src/rapids-cmake/cpm/find.cmake:92 (CPMFindPackage)
  cmake/thirdparty/get_raft.cmake:23 (rapids_cpm_find)
  cmake/thirdparty/get_raft.cmake:45 (find_and_configure_raft)
  CMakeLists.txt:187 (include)


-- Configuring incomplete, errors occurred!
See also "/workspace/cpp/build/CMakeFiles/CMakeOutput.log".
See also "/workspace/cpp/build/CMakeFiles/CMakeError.log".
```