### PR TITLE
[REVIEW] Replace RAFT `device::buffer` adapter with RMM `device_uvector`

### DIFF
--- a/cpp/include/raft/common/cub_wrappers.cuh
+++ b/cpp/include/raft/common/cub_wrappers.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cub/cub.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 namespace raft {
 
@@ -34,7 +34,7 @@ namespace raft {
      * @param stream cuda stream
      */
 template <typename KeyT, typename ValueT>
-void sortPairs(raft::mr::device::buffer<char> &workspace, const KeyT *inKeys,
+void sortPairs(rmm::device_uvector<char> &workspace, const KeyT *inKeys,
                KeyT *outKeys, const ValueT *inVals, ValueT *outVals, int len,
                cudaStream_t stream) {
   size_t worksize;

--- a/cpp/include/raft/comms/test.hpp
+++ b/cpp/include/raft/comms/test.hpp
@@ -18,7 +18,6 @@
 
 #include <raft/comms/comms.hpp>
 #include <raft/handle.hpp>
-#include <raft/mr/device/buffer.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -44,8 +43,7 @@ bool test_collective_allreduce(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
+  rmm::device_uvector<int> temp_d(1, stream);
   CUDA_CHECK(
     cudaMemcpyAsync(temp_d.data(), &send, 1, cudaMemcpyHostToDevice, stream));
 
@@ -76,8 +74,7 @@ bool test_collective_broadcast(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
+  rmm::device_uvector<int> temp_d(1, stream);
 
   if (communicator.get_rank() == root)
     CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), &send, sizeof(int),
@@ -104,8 +101,7 @@ bool test_collective_reduce(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
+  rmm::device_uvector<int> temp_d(1, stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), &send, sizeof(int),
                              cudaMemcpyHostToDevice, stream));
@@ -134,11 +130,8 @@ bool test_collective_allgather(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
-
-  raft::mr::device::buffer<int> recv_d(handle.get_device_allocator(), stream,
-                                       communicator.get_size());
+  rmm::device_uvector<int> temp_d(1, stream);
+  rmm::device_uvector<int> recv_d(communicator.get_size(), stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), &send, sizeof(int),
                              cudaMemcpyHostToDevice, stream));
@@ -169,12 +162,9 @@ bool test_collective_gather(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
-
-  raft::mr::device::buffer<int> recv_d(
-    handle.get_device_allocator(), stream,
-    communicator.get_rank() == root ? communicator.get_size() : 0);
+  rmm::device_uvector<int> temp_d(1, stream);
+  rmm::device_uvector<int> recv_d(
+    communicator.get_rank() == root ? communicator.get_size() : 0, stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), &send, sizeof(int),
                              cudaMemcpyHostToDevice, stream));
@@ -211,12 +201,9 @@ bool test_collective_gatherv(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(sends.size(), stream);
-
-  raft::mr::device::buffer<int> recv_d(
-    handle.get_device_allocator(), stream,
-    communicator.get_rank() == root ? displacements.back() : 0);
+  rmm::device_uvector<int> temp_d(sends.size(), stream);
+  rmm::device_uvector<int> recv_d(
+    communicator.get_rank() == root ? displacements.back() : 0, stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), sends.data(),
                              sends.size() * sizeof(int), cudaMemcpyHostToDevice,
@@ -256,10 +243,8 @@ bool test_collective_reducescatter(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream,
-                                       sends.size());
-  raft::mr::device::buffer<int> recv_d(handle.get_device_allocator(), stream,
-                                       1);
+  rmm::device_uvector<int> temp_d(sends.size(), stream);
+  rmm::device_uvector<int> recv_d(1, stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), sends.data(),
                              sends.size() * sizeof(int), cudaMemcpyHostToDevice,

--- a/cpp/include/raft/distance/distance.cuh
+++ b/cpp/include/raft/distance/distance.cuh
@@ -22,7 +22,7 @@
 #include <raft/distance/cosine.cuh>
 #include <raft/distance/euclidean.cuh>
 #include <raft/distance/l1.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 namespace raft {
 namespace distance {
@@ -243,7 +243,7 @@ void distance(const InType *x, const InType *y, OutType *dist, Index_ m,
 template <typename Type, typename Index_, raft::distance::DistanceType DistType>
 void pairwise_distance_impl(const Type *x, const Type *y, Type *dist, Index_ m,
                             Index_ n, Index_ k,
-                            raft::mr::device::buffer<char> &workspace,
+                            rmm::device_uvector<char> &workspace,
                             cudaStream_t stream, bool isRowMajor) {
   auto worksize =
     getWorkspaceSize<DistType, Type, Type, Type, Index_>(x, y, m, n, k);
@@ -254,8 +254,7 @@ void pairwise_distance_impl(const Type *x, const Type *y, Type *dist, Index_ m,
 
 template <typename Type, typename Index_ = int>
 void pairwise_distance(const Type *x, const Type *y, Type *dist, Index_ m,
-                       Index_ n, Index_ k,
-                       raft::mr::device::buffer<char> &workspace,
+                       Index_ n, Index_ k, rmm::device_uvector<char> &workspace,
                        raft::distance::DistanceType metric, cudaStream_t stream,
                        bool isRowMajor = true) {
   switch (metric) {

--- a/cpp/include/raft/linalg/eig.cuh
+++ b/cpp/include/raft/linalg/eig.cuh
@@ -22,7 +22,7 @@
 #include <raft/cuda_utils.cuh>
 #include <raft/handle.hpp>
 #include <raft/matrix/matrix.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 namespace raft {
 namespace linalg {
@@ -52,8 +52,8 @@ void eigDC(const raft::handle_t &handle, const math_t *in, int n_rows,
                                             CUBLAS_FILL_MODE_UPPER, n_rows, in,
                                             n_cols, eig_vals, &lwork));
 
-  raft::mr::device::buffer<math_t> d_work(allocator, stream, lwork);
-  raft::mr::device::buffer<int> d_dev_info(allocator, stream, 1);
+  rmm::device_uvector<math_t> d_work(lwork, stream);
+  rmm::device_uvector<int> d_dev_info(1, stream);
 
   raft::matrix::copy(in, eig_vectors, n_rows, n_cols, stream);
 
@@ -104,9 +104,9 @@ void eigSelDC(const raft::handle_t &handle, math_t *in, int n_rows, int n_cols,
     CUBLAS_FILL_MODE_UPPER, n_rows, in, n_cols, math_t(0.0), math_t(0.0),
     n_cols - n_eig_vals + 1, n_cols, &h_meig, eig_vals, &lwork));
 
-  raft::mr::device::buffer<math_t> d_work(allocator, stream, lwork);
-  raft::mr::device::buffer<int> d_dev_info(allocator, stream, 1);
-  raft::mr::device::buffer<math_t> d_eig_vectors(allocator, stream, 0);
+  rmm::device_uvector<math_t> d_work(lwork, stream);
+  rmm::device_uvector<int> d_dev_info(1, stream);
+  rmm::device_uvector<math_t> d_eig_vectors(0, stream);
 
   if (memUsage == OVERWRITE_INPUT) {
     CUSOLVER_CHECK(cusolverDnsyevdx(
@@ -176,8 +176,8 @@ void eigJacobi(const raft::handle_t &handle, const math_t *in, int n_rows,
     cusolverH, CUSOLVER_EIG_MODE_VECTOR, CUBLAS_FILL_MODE_UPPER, n_rows,
     eig_vectors, n_cols, eig_vals, &lwork, syevj_params));
 
-  raft::mr::device::buffer<math_t> d_work(allocator, stream, lwork);
-  raft::mr::device::buffer<int> dev_info(allocator, stream, 1);
+  rmm::device_uvector<math_t> d_work(lwork, stream);
+  rmm::device_uvector<int> dev_info(1, stream);
 
   raft::matrix::copy(in, eig_vectors, n_rows, n_cols, stream);
 

--- a/cpp/include/raft/linalg/svd.cuh
+++ b/cpp/include/raft/linalg/svd.cuh
@@ -23,7 +23,7 @@
 #include <raft/handle.hpp>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 #include "eig.cuh"
 #include "gemm.cuh"
 #include "transpose.h"
@@ -54,8 +54,6 @@ void svdQR(const raft::handle_t &handle, T *in, int n_rows, int n_cols,
            T *sing_vals, T *left_sing_vecs, T *right_sing_vecs,
            bool trans_right, bool gen_left_vec, bool gen_right_vec,
            cudaStream_t stream) {
-  std::shared_ptr<raft::mr::device::allocator> allocator =
-    handle.get_device_allocator();
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
   cublasHandle_t cublasH = handle.get_cublas_handle();
 
@@ -71,13 +69,13 @@ void svdQR(const raft::handle_t &handle, T *in, int n_rows, int n_cols,
   const int m = n_rows;
   const int n = n_cols;
 
-  raft::mr::device::buffer<int> devInfo(allocator, stream, 1);
+  rmm::device_uvector<int> devInfo(1, stream);
   T *d_rwork = nullptr;
 
   int lwork = 0;
   CUSOLVER_CHECK(
     cusolverDngesvd_bufferSize<T>(cusolverH, n_rows, n_cols, &lwork));
-  raft::mr::device::buffer<T> d_work(allocator, stream, lwork);
+  rmm::device_uvector<T> d_work(lwork, stream);
 
   char jobu = 'S';
   char jobvt = 'A';
@@ -112,12 +110,11 @@ void svdQR(const raft::handle_t &handle, T *in, int n_rows, int n_cols,
 template <typename T>
 void svdEig(const raft::handle_t &handle, T *in, int n_rows, int n_cols, T *S,
             T *U, T *V, bool gen_left_vec, cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
   cublasHandle_t cublasH = handle.get_cublas_handle();
 
   int len = n_cols * n_cols;
-  raft::mr::device::buffer<T> in_cross_mult(allocator, stream, len);
+  rmm::device_uvector<T> in_cross_mult(len, stream);
 
   T alpha = T(1);
   T beta = T(0);
@@ -162,7 +159,6 @@ void svdJacobi(const raft::handle_t &handle, math_t *in, int n_rows, int n_cols,
                math_t *sing_vals, math_t *left_sing_vecs,
                math_t *right_sing_vecs, bool gen_left_vec, bool gen_right_vec,
                math_t tol, int max_sweeps, cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
 
   gesvdjInfo_t gesvdj_params = NULL;
@@ -174,7 +170,7 @@ void svdJacobi(const raft::handle_t &handle, math_t *in, int n_rows, int n_cols,
   int m = n_rows;
   int n = n_cols;
 
-  raft::mr::device::buffer<int> devInfo(allocator, stream, 1);
+  rmm::device_uvector<int> devInfo(1, stream);
 
   int lwork = 0;
   int econ = 1;
@@ -183,7 +179,7 @@ void svdJacobi(const raft::handle_t &handle, math_t *in, int n_rows, int n_cols,
     cusolverH, CUSOLVER_EIG_MODE_VECTOR, econ, m, n, in, m, sing_vals,
     left_sing_vecs, m, right_sing_vecs, n, &lwork, gesvdj_params));
 
-  raft::mr::device::buffer<math_t> d_work(allocator, stream, lwork);
+  rmm::device_uvector<math_t> d_work(lwork, stream);
 
   CUSOLVER_CHECK(raft::linalg::cusolverDngesvdj(
     cusolverH, CUSOLVER_EIG_MODE_VECTOR, econ, m, n, in, m, sing_vals,
@@ -210,10 +206,8 @@ template <typename math_t>
 void svdReconstruction(const raft::handle_t &handle, math_t *U, math_t *S,
                        math_t *V, math_t *out, int n_rows, int n_cols, int k,
                        cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
-
   const math_t alpha = 1.0, beta = 0.0;
-  raft::mr::device::buffer<math_t> SVT(allocator, stream, k * n_cols);
+  rmm::device_uvector<math_t> SVT(k * n_cols, stream);
 
   raft::linalg::gemm(handle, S, k, k, V, SVT.data(), k, n_cols, CUBLAS_OP_N,
                      CUBLAS_OP_T, alpha, beta, stream);
@@ -239,14 +233,13 @@ template <typename math_t>
 bool evaluateSVDByL2Norm(const raft::handle_t &handle, math_t *A_d, math_t *U,
                          math_t *S_vec, math_t *V, int n_rows, int n_cols,
                          int k, math_t tol, cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
   cublasHandle_t cublasH = handle.get_cublas_handle();
 
   int m = n_rows, n = n_cols;
 
   // form product matrix
-  raft::mr::device::buffer<math_t> P_d(allocator, stream, m * n);
-  raft::mr::device::buffer<math_t> S_mat(allocator, stream, k * k);
+  rmm::device_uvector<math_t> P_d(m * n, stream);
+  rmm::device_uvector<math_t> S_mat(k * k, stream);
   CUDA_CHECK(cudaMemsetAsync(P_d.data(), 0, sizeof(math_t) * m * n, stream));
   CUDA_CHECK(cudaMemsetAsync(S_mat.data(), 0, sizeof(math_t) * k * k, stream));
 
@@ -262,7 +255,7 @@ bool evaluateSVDByL2Norm(const raft::handle_t &handle, math_t *A_d, math_t *U,
 
   // calculate percent error
   const math_t alpha = 1.0, beta = -1.0;
-  raft::mr::device::buffer<math_t> A_minus_P(allocator, stream, m * n);
+  rmm::device_uvector<math_t> A_minus_P(m * n, stream);
   CUDA_CHECK(
     cudaMemsetAsync(A_minus_P.data(), 0, sizeof(math_t) * m * n, stream));
 

--- a/cpp/include/raft/matrix/math.cuh
+++ b/cpp/include/raft/matrix/math.cuh
@@ -22,7 +22,7 @@
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 namespace raft {
 namespace matrix {
@@ -294,10 +294,7 @@ void ratio(const raft::handle_t &handle, math_t *src, math_t *dest, IdxType len,
   auto d_src = src;
   auto d_dest = dest;
 
-  std::shared_ptr<raft::mr::device::allocator> allocator =
-    handle.get_device_allocator();
-
-  raft::mr::device::buffer<math_t> d_sum(allocator, stream, 1);
+  rmm::device_uvector<math_t> d_sum(1, stream);
   auto *d_sum_ptr = d_sum.data();
   auto no_op = [] __device__(math_t in) { return in; };
   raft::linalg::mapThenSumReduce(d_sum_ptr, len, no_op, stream, src);

--- a/cpp/include/raft/random/rng.cuh
+++ b/cpp/include/raft/random/rng.cuh
@@ -25,8 +25,8 @@
 #include <raft/cuda_utils.cuh>
 #include <raft/handle.hpp>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
 #include <random>
+#include <rmm/device_uvector.hpp>
 #include <type_traits>
 #include "rng_impl.cuh"
 
@@ -512,10 +512,10 @@ class Rng {
     std::shared_ptr<raft::mr::device::allocator> allocator =
       handle.get_device_allocator();
 
-    raft::mr::device::buffer<WeightsT> expWts(allocator, stream, len);
-    raft::mr::device::buffer<WeightsT> sortedWts(allocator, stream, len);
-    raft::mr::device::buffer<IdxT> inIdx(allocator, stream, len);
-    raft::mr::device::buffer<IdxT> outIdxBuff(allocator, stream, len);
+    rmm::device_uvector<WeightsT> expWts(len, stream);
+    rmm::device_uvector<WeightsT> sortedWts(len, stream);
+    rmm::device_uvector<IdxT> inIdx(len, stream);
+    rmm::device_uvector<IdxT> outIdxBuff(len, stream);
     auto *inIdxPtr = inIdx.data();
     // generate modified weights
     custom_distribution(
@@ -533,7 +533,7 @@ class Rng {
     ///@todo: use a more efficient partitioning scheme instead of full sort
     // sort the array and pick the top sampledLen items
     IdxT *outIdxPtr = outIdxBuff.data();
-    raft::mr::device::buffer<char> workspace(allocator, stream);
+    rmm::device_uvector<char> workspace(0, stream);
     sortPairs(workspace, expWts.data(), sortedWts.data(), inIdxPtr, outIdxPtr,
               (int)len, stream);
     if (outIdx != nullptr) {

--- a/cpp/include/raft/sparse/coo.cuh
+++ b/cpp/include/raft/sparse/coo.cuh
@@ -18,7 +18,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <cusparse_v2.h>
 
@@ -58,9 +58,9 @@ namespace sparse {
 template <typename T, typename Index_Type = int>
 class COO {
  protected:
-  raft::mr::device::buffer<Index_Type> rows_arr;
-  raft::mr::device::buffer<Index_Type> cols_arr;
-  raft::mr::device::buffer<T> vals_arr;
+  rmm::device_uvector<Index_Type> rows_arr;
+  rmm::device_uvector<Index_Type> cols_arr;
+  rmm::device_uvector<T> vals_arr;
 
  public:
   Index_Type nnz;
@@ -72,9 +72,9 @@ class COO {
     * @param stream: CUDA stream to use
     */
   COO(std::shared_ptr<raft::mr::device::allocator> d_alloc, cudaStream_t stream)
-    : rows_arr(d_alloc, stream, 0),
-      cols_arr(d_alloc, stream, 0),
-      vals_arr(d_alloc, stream, 0),
+    : rows_arr(0, stream),
+      cols_arr(0, stream),
+      vals_arr(0, stream),
       nnz(0),
       n_rows(0),
       n_cols(0) {}
@@ -87,10 +87,9 @@ class COO {
     * @param n_rows: number of rows in the dense matrix
     * @param n_cols: number of cols in the dense matrix
     */
-  COO(raft::mr::device::buffer<Index_Type> &rows,
-      raft::mr::device::buffer<Index_Type> &cols,
-      raft::mr::device::buffer<T> &vals, Index_Type nnz, Index_Type n_rows = 0,
-      Index_Type n_cols = 0)
+  COO(rmm::device_uvector<Index_Type> &rows,
+      rmm::device_uvector<Index_Type> &cols, rmm::device_uvector<T> &vals,
+      Index_Type nnz, Index_Type n_rows = 0, Index_Type n_cols = 0)
     : rows_arr(rows),
       cols_arr(cols),
       vals_arr(vals),
@@ -109,9 +108,9 @@ class COO {
   COO(std::shared_ptr<raft::mr::device::allocator> d_alloc, cudaStream_t stream,
       Index_Type nnz, Index_Type n_rows = 0, Index_Type n_cols = 0,
       bool init = true)
-    : rows_arr(d_alloc, stream, nnz),
-      cols_arr(d_alloc, stream, nnz),
-      vals_arr(d_alloc, stream, nnz),
+    : rows_arr(nnz, stream),
+      cols_arr(nnz, stream),
+      vals_arr(nnz, stream),
       nnz(nnz),
       n_rows(n_rows),
       n_cols(n_cols) {

--- a/cpp/include/raft/sparse/csr.cuh
+++ b/cpp/include/raft/sparse/csr.cuh
@@ -21,7 +21,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
@@ -219,7 +219,7 @@ void weak_cc(Index_ *labels, const Index_ *row_ind, const Index_ *row_ind_ptr,
              Index_ nnz, Index_ N,
              std::shared_ptr<raft::mr::device::allocator> d_alloc,
              cudaStream_t stream, Lambda filter_op) {
-  raft::mr::device::buffer<bool> m(d_alloc, stream, 1);
+  rmm::device_uvector<bool> m(1, stream);
 
   WeakCCState state(m.data());
   weak_cc_batched<Index_, TPB_X>(labels, row_ind, row_ind_ptr, nnz, N, 0, N,
@@ -253,7 +253,7 @@ void weak_cc(Index_ *labels, const Index_ *row_ind, const Index_ *row_ind_ptr,
              Index_ nnz, Index_ N,
              std::shared_ptr<raft::mr::device::allocator> d_alloc,
              cudaStream_t stream) {
-  raft::mr::device::buffer<bool> m(d_alloc, stream, 1);
+  rmm::device_uvector<bool> m(1, stream);
   WeakCCState state(m.data());
   weak_cc_batched<Index_, TPB_X>(labels, row_ind, row_ind_ptr, nnz, N, 0, N,
                                  stream, [](Index_) { return true; });

--- a/cpp/include/raft/sparse/distance/bin_distance.cuh
+++ b/cpp/include/raft/sparse/distance/bin_distance.cuh
@@ -24,7 +24,7 @@
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/distance/common.h>
 #include <raft/sparse/utils.h>
@@ -88,8 +88,8 @@ void compute_bin_distance(value_t *out, const value_idx *Q_coo_rows,
                           cusparseHandle_t handle,
                           std::shared_ptr<raft::mr::device::allocator> alloc,
                           cudaStream_t stream, expansion_f expansion_func) {
-  raft::mr::device::buffer<value_t> Q_norms(alloc, stream, m);
-  raft::mr::device::buffer<value_t> R_norms(alloc, stream, n);
+  rmm::device_uvector<value_t> Q_norms(m, stream);
+  rmm::device_uvector<value_t> R_norms(n, stream);
   CUDA_CHECK(
     cudaMemsetAsync(Q_norms.data(), 0, Q_norms.size() * sizeof(value_t)));
   CUDA_CHECK(
@@ -113,9 +113,7 @@ class jaccard_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit jaccard_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     ip_dists.compute(out_dists);
@@ -123,8 +121,8 @@ class jaccard_expanded_distances_t : public distances_t<value_t> {
     value_idx *b_indices = ip_dists.b_rows_coo();
     value_t *b_data = ip_dists.b_data_coo();
 
-    raft::mr::device::buffer<value_idx> search_coo_rows(
-      config_->allocator, config_->stream, config_->a_nnz);
+    rmm::device_uvector<value_idx> search_coo_rows(config_->a_nnz,
+                                                   config_->stream);
     raft::sparse::convert::csr_to_coo(config_->a_indptr, config_->a_nrows,
                                       search_coo_rows.data(), config_->a_nnz,
                                       config_->stream);
@@ -149,7 +147,7 @@ class jaccard_expanded_distances_t : public distances_t<value_t> {
 
  private:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 
@@ -162,9 +160,7 @@ class dice_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit dice_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     ip_dists.compute(out_dists);
@@ -172,8 +168,8 @@ class dice_expanded_distances_t : public distances_t<value_t> {
     value_idx *b_indices = ip_dists.b_rows_coo();
     value_t *b_data = ip_dists.b_data_coo();
 
-    raft::mr::device::buffer<value_idx> search_coo_rows(
-      config_->allocator, config_->stream, config_->a_nnz);
+    rmm::device_uvector<value_idx> search_coo_rows(config_->a_nnz,
+                                                   config_->stream);
     raft::sparse::convert::csr_to_coo(config_->a_indptr, config_->a_nrows,
                                       search_coo_rows.data(), config_->a_nnz,
                                       config_->stream);
@@ -194,7 +190,7 @@ class dice_expanded_distances_t : public distances_t<value_t> {
 
  private:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 

--- a/cpp/include/raft/sparse/distance/csr_spmv.cuh
+++ b/cpp/include/raft/sparse/distance/csr_spmv.cuh
@@ -20,7 +20,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/distance/common.h>
 #include <raft/sparse/utils.h>
@@ -346,7 +346,7 @@ template <typename value_idx>
 inline value_idx max_degree(
   value_idx *indptr, value_idx n_rows,
   std::shared_ptr<raft::mr::device::allocator> allocator, cudaStream_t stream) {
-  raft::mr::device::buffer<value_idx> max_d(allocator, stream, 1);
+  rmm::device_uvector<value_idx> max_d(1, stream);
   CUDA_CHECK(cudaMemsetAsync(max_d.data(), 0, sizeof(value_idx), stream));
 
   /**

--- a/cpp/include/raft/sparse/distance/l2_distance.cuh
+++ b/cpp/include/raft/sparse/distance/l2_distance.cuh
@@ -24,7 +24,7 @@
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/utils.h>
 #include <raft/sparse/csr.cuh>
@@ -92,8 +92,8 @@ void compute_l2(value_t *out, const value_idx *Q_coo_rows,
                 cusparseHandle_t handle,
                 std::shared_ptr<raft::mr::device::allocator> alloc,
                 cudaStream_t stream, expansion_f expansion_func) {
-  raft::mr::device::buffer<value_t> Q_sq_norms(alloc, stream, m);
-  raft::mr::device::buffer<value_t> R_sq_norms(alloc, stream, n);
+  rmm::device_uvector<value_t> Q_sq_norms(m, stream);
+  rmm::device_uvector<value_t> R_sq_norms(n, stream);
   CUDA_CHECK(
     cudaMemsetAsync(Q_sq_norms.data(), 0, Q_sq_norms.size() * sizeof(value_t)));
   CUDA_CHECK(
@@ -117,9 +117,7 @@ class l2_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit l2_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     ip_dists.compute(out_dists);
@@ -127,8 +125,8 @@ class l2_expanded_distances_t : public distances_t<value_t> {
     value_idx *b_indices = ip_dists.b_rows_coo();
     value_t *b_data = ip_dists.b_data_coo();
 
-    raft::mr::device::buffer<value_idx> search_coo_rows(
-      config_->allocator, config_->stream, config_->a_nnz);
+    rmm::device_uvector<value_idx> search_coo_rows(config_->a_nnz,
+                                                   config_->stream);
     raft::sparse::convert::csr_to_coo(config_->a_indptr, config_->a_nrows,
                                       search_coo_rows.data(), config_->a_nnz,
                                       config_->stream);
@@ -146,7 +144,7 @@ class l2_expanded_distances_t : public distances_t<value_t> {
 
  protected:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 
@@ -186,9 +184,7 @@ class cosine_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit cosine_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     ip_dists.compute(out_dists);
@@ -196,8 +192,8 @@ class cosine_expanded_distances_t : public distances_t<value_t> {
     value_idx *b_indices = ip_dists.b_rows_coo();
     value_t *b_data = ip_dists.b_data_coo();
 
-    raft::mr::device::buffer<value_idx> search_coo_rows(
-      config_->allocator, config_->stream, config_->a_nnz);
+    rmm::device_uvector<value_idx> search_coo_rows(config_->a_nnz,
+                                                   config_->stream);
     raft::sparse::convert::csr_to_coo(config_->a_indptr, config_->a_nrows,
                                       search_coo_rows.data(), config_->a_nnz,
                                       config_->stream);
@@ -221,7 +217,7 @@ class cosine_expanded_distances_t : public distances_t<value_t> {
 
  private:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 
@@ -239,9 +235,7 @@ class hellinger_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit hellinger_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     // First sqrt A and B
@@ -282,7 +276,7 @@ class hellinger_expanded_distances_t : public distances_t<value_t> {
 
  private:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 

--- a/cpp/include/raft/sparse/distance/lp_distance.cuh
+++ b/cpp/include/raft/sparse/distance/lp_distance.cuh
@@ -24,7 +24,7 @@
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/utils.h>
 #include <raft/sparse/csr.cuh>
@@ -62,8 +62,8 @@ void unexpanded_lp_distances(
     // for max occupancy.
     // Ref: https://github.com/rapidsai/cuml/issues/3371
 
-    raft::mr::device::buffer<value_idx> coo_rows(
-      config_->allocator, config_->stream, max(config_->b_nnz, config_->a_nnz));
+    rmm::device_uvector<value_idx> coo_rows(max(config_->b_nnz, config_->a_nnz),
+                                            config_->stream);
 
     raft::sparse::convert::csr_to_coo(config_->b_indptr, config_->b_nrows,
                                       coo_rows.data(), config_->b_nnz,

--- a/cpp/include/raft/sparse/linalg/add.cuh
+++ b/cpp/include/raft/sparse/linalg/add.cuh
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
@@ -168,7 +168,7 @@ size_t csr_add_calc_inds(const int *a_ind, const int *a_indptr, const T *a_val,
   dim3 grid(raft::ceildiv(m, TPB_X), 1, 1);
   dim3 blk(TPB_X, 1, 1);
 
-  raft::mr::device::buffer<int> row_counts(d_alloc, stream, m + 1);
+  rmm::device_uvector<int> row_counts(m + 1, stream);
   CUDA_CHECK(
     cudaMemsetAsync(row_counts.data(), 0, (m + 1) * sizeof(int), stream));
 

--- a/cpp/include/raft/sparse/linalg/transpose.h
+++ b/cpp/include/raft/sparse/linalg/transpose.h
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
@@ -72,8 +72,8 @@ void csr_transpose(cusparseHandle_t handle, const value_idx *csr_indptr,
     CUSPARSE_INDEX_BASE_ZERO, CUSPARSE_CSR2CSC_ALG1,
     &convert_csc_workspace_size, stream));
 
-  raft::mr::device::buffer<char> convert_csc_workspace(
-    allocator, stream, convert_csc_workspace_size);
+  rmm::device_uvector<char> convert_csc_workspace(convert_csc_workspace_size,
+                                                  stream);
 
   CUSPARSE_CHECK(raft::sparse::cusparsecsr2csc(
     handle, csr_nrows, csr_ncols, nnz, csr_data, csr_indptr, csr_indices,

--- a/cpp/include/raft/sparse/op/filter.cuh
+++ b/cpp/include/raft/sparse/op/filter.cuh
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
@@ -87,8 +87,8 @@ void coo_remove_scalar(const int *rows, const int *cols, const T *vals, int nnz,
                        int *cur_cnnz, T scalar, int n,
                        std::shared_ptr<raft::mr::device::allocator> d_alloc,
                        cudaStream_t stream) {
-  raft::mr::device::buffer<int> ex_scan(d_alloc, stream, n);
-  raft::mr::device::buffer<int> cur_ex_scan(d_alloc, stream, n);
+  rmm::device_uvector<int> ex_scan(n, stream);
+  rmm::device_uvector<int> cur_ex_scan(n, stream);
 
   CUDA_CHECK(cudaMemsetAsync(ex_scan.data(), 0, n * sizeof(int), stream));
   CUDA_CHECK(cudaMemsetAsync(cur_ex_scan.data(), 0, n * sizeof(int), stream));
@@ -129,8 +129,8 @@ template <int TPB_X, typename T>
 void coo_remove_scalar(COO<T> *in, COO<T> *out, T scalar,
                        std::shared_ptr<raft::mr::device::allocator> d_alloc,
                        cudaStream_t stream) {
-  raft::mr::device::buffer<int> row_count_nz(d_alloc, stream, in->n_rows);
-  raft::mr::device::buffer<int> row_count(d_alloc, stream, in->n_rows);
+  rmm::device_uvector<int> row_count_nz(in->n_rows, stream);
+  rmm::device_uvector<int> row_count(in->n_rows, stream);
 
   CUDA_CHECK(
     cudaMemsetAsync(row_count_nz.data(), 0, in->n_rows * sizeof(int), stream));

--- a/cpp/include/raft/spatial/knn/detail/knn_brute_force_faiss.cuh
+++ b/cpp/include/raft/spatial/knn/detail/knn_brute_force_faiss.cuh
@@ -19,6 +19,8 @@
 #include <raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
+#include <rmm/device_uvector.hpp>
+
 #include <faiss/gpu/GpuDistance.h>
 #include <faiss/gpu/GpuResources.h>
 #include <faiss/gpu/StandardGpuResources.h>
@@ -243,13 +245,12 @@ void brute_force_knn_impl(std::vector<float *> &input, std::vector<int> &sizes,
   int device;
   CUDA_CHECK(cudaGetDevice(&device));
 
-  raft::mr::device::buffer<int64_t> trans(allocator, userStream,
-                                          id_ranges->size());
+  rmm::device_uvector<int64_t> trans(id_ranges->size(), userStream);
   raft::update_device(trans.data(), id_ranges->data(), id_ranges->size(),
                       userStream);
 
-  raft::mr::device::buffer<float> all_D(allocator, userStream, 0);
-  raft::mr::device::buffer<int64_t> all_I(allocator, userStream, 0);
+  rmm::device_uvector<float> all_D(0, userStream);
+  rmm::device_uvector<int64_t> all_I(0, userStream);
 
   float *out_D = res_D;
   int64_t *out_I = res_I;

--- a/cpp/test/lap/lap.cu
+++ b/cpp/test/lap/lap.cu
@@ -24,6 +24,8 @@
  */
 #include <gtest/gtest.h>
 
+#include <rmm/device_uvector.hpp>
+
 #include <omp.h>
 #include <iostream>
 #include <raft/lap/lap.cuh>
@@ -65,15 +67,12 @@ void hungarian_test(int problemsize, int costrange, int problemcount,
   for (int j = 0; j < problemcount; j++) {
     generateProblem(h_cost, batchsize, problemsize, costrange);
 
-    raft::mr::device::buffer<weight_t> elements_v(
-      handle.get_device_allocator(), handle.get_stream(),
-      batchsize * problemsize * problemsize);
-    raft::mr::device::buffer<vertex_t> row_assignment_v(
-      handle.get_device_allocator(), handle.get_stream(),
-      batchsize * problemsize);
-    raft::mr::device::buffer<vertex_t> col_assignment_v(
-      handle.get_device_allocator(), handle.get_stream(),
-      batchsize * problemsize);
+    rmm::device_uvector<weight_t> elements_v(
+      batchsize * problemsize * problemsize, handle.get_stream());
+    rmm::device_uvector<vertex_t> row_assignment_v(batchsize * problemsize,
+                                                   handle.get_stream());
+    rmm::device_uvector<vertex_t> col_assignment_v(batchsize * problemsize,
+                                                   handle.get_stream());
 
     raft::update_device(elements_v.data(), h_cost,
                         batchsize * problemsize * problemsize,

--- a/cpp/test/linalg/cholesky_r1.cu
+++ b/cpp/test/linalg/cholesky_r1.cu
@@ -20,7 +20,8 @@
 #include <raft/handle.hpp>
 #include <raft/linalg/cholesky_r1_update.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
+
 #include <sstream>
 #include <vector>
 #include "../test_utils.h"
@@ -31,12 +32,11 @@ template <typename math_t>
 class CholeskyR1Test : public ::testing::Test {
  protected:
   CholeskyR1Test()
-    : allocator(handle.get_device_allocator()),
-      G(allocator, handle.get_stream(), n_rows * n_rows),
-      L(allocator, handle.get_stream(), n_rows * n_rows),
-      L_exp(allocator, handle.get_stream(), n_rows * n_rows),
-      devInfo(allocator, handle.get_stream(), 1),
-      workspace(allocator, handle.get_stream()) {
+    : G(n_rows * n_rows, handle.get_stream()),
+      L(n_rows * n_rows, handle.get_stream()),
+      L_exp(n_rows * n_rows, handle.get_stream()),
+      devInfo(1, handle.get_stream()),
+      workspace(0, handle.get_stream()) {
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.set_stream(stream);
     raft::update_device(G.data(), G_host, n_rows * n_rows, stream);
@@ -105,7 +105,6 @@ class CholeskyR1Test : public ::testing::Test {
   }
 
   raft::handle_t handle;
-  std::shared_ptr<raft::mr::device::allocator> allocator;
   cusolverDnHandle_t solver_handle;
   cudaStream_t stream;
 
@@ -120,11 +119,11 @@ class CholeskyR1Test : public ::testing::Test {
 
   math_t G2_host[4] = {3, 4, 2, 1};
 
-  raft::mr::device::buffer<int> devInfo;
-  raft::mr::device::buffer<math_t> G;
-  raft::mr::device::buffer<math_t> L_exp;
-  raft::mr::device::buffer<math_t> L;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<int> devInfo;
+  rmm::device_uvector<math_t> G;
+  rmm::device_uvector<math_t> L_exp;
+  rmm::device_uvector<math_t> L;
+  rmm::device_uvector<char> workspace;
 };
 
 typedef ::testing::Types<float, double> FloatTypes;

--- a/cpp/test/linalg/map_then_reduce.cu
+++ b/cpp/test/linalg/map_then_reduce.cu
@@ -19,6 +19,7 @@
 #include <limits>
 #include <raft/linalg/map_then_reduce.cuh>
 #include <raft/random/rng.cuh>
+#include <rmm/device_uvector.hpp>
 #include "../test_utils.h"
 
 namespace raft {
@@ -131,9 +132,7 @@ class MapGenericReduceTest : public ::testing::Test {
 
  protected:
   MapGenericReduceTest()
-    : allocator(handle.get_device_allocator()),
-      input(allocator, handle.get_stream(), n),
-      output(allocator, handle.get_stream(), 1) {
+    : input(n, handle.get_stream()), output(1, handle.get_stream()) {
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.set_stream(stream);
     initInput(input.data(), input.size(), stream);
@@ -172,9 +171,8 @@ class MapGenericReduceTest : public ::testing::Test {
   int n = 1237;
   raft::handle_t handle;
   cudaStream_t stream;
-  std::shared_ptr<raft::mr::device::allocator> allocator;
-  raft::mr::device::buffer<InType> input;
-  raft::mr::device::buffer<OutType> output;
+  rmm::device_uvector<InType> input;
+  rmm::device_uvector<OutType> output;
 };
 
 using IoTypePair =

--- a/cpp/test/matrix/matrix.cu
+++ b/cpp/test/matrix/matrix.cu
@@ -18,6 +18,7 @@
 #include <raft/cudart_utils.h>
 #include <raft/matrix/matrix.cuh>
 #include <raft/random/rng.cuh>
+#include <rmm/device_uvector.hpp>
 #include "../test_utils.h"
 
 namespace raft {
@@ -102,10 +103,9 @@ class MatrixCopyRowsTest : public ::testing::Test {
 
  protected:
   MatrixCopyRowsTest()
-    : allocator(handle.get_device_allocator()),
-      input(allocator, handle.get_stream(), n_cols * n_rows),
-      indices(allocator, handle.get_stream(), n_selected),
-      output(allocator, handle.get_stream(), n_cols * n_selected) {
+    : input(n_cols * n_rows, handle.get_stream()),
+      indices(n_selected, handle.get_stream()),
+      output(n_cols * n_selected, handle.get_stream()) {
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.set_stream(stream);
     raft::update_device(indices.data(), indices_host, n_selected, stream);
@@ -143,10 +143,9 @@ class MatrixCopyRowsTest : public ::testing::Test {
                                     14, 21, 22, 23, 27, 28, 29};
   raft::handle_t handle;
   cudaStream_t stream;
-  std::shared_ptr<raft::mr::device::allocator> allocator;
-  raft::mr::device::buffer<math_t> input;
-  raft::mr::device::buffer<math_t> output;
-  raft::mr::device::buffer<idx_array_t> indices;
+  rmm::device_uvector<math_t> input;
+  rmm::device_uvector<math_t> output;
+  rmm::device_uvector<idx_array_t> indices;
 };
 
 using TypeTuple =

--- a/cpp/test/sparse/dist_coo_spmv.cu
+++ b/cpp/test/sparse/dist_coo_spmv.cu
@@ -23,6 +23,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/convert/coo.cuh>
 #include <raft/sparse/distance/coo_spmv.cuh>
@@ -67,9 +68,8 @@ class SparseDistanceCOOSPMVTest
   template <typename reduce_f, typename accum_f, typename write_f>
   void compute_dist(reduce_f reduce_func, accum_f accum_func,
                     write_f write_func, bool rev = true) {
-    raft::mr::device::buffer<value_idx> coo_rows(
-      dist_config.allocator, dist_config.stream,
-      max(dist_config.b_nnz, dist_config.a_nnz));
+    rmm::device_uvector<value_idx> coo_rows(
+      max(dist_config.b_nnz, dist_config.a_nnz), dist_config.stream);
 
     raft::sparse::convert::csr_to_coo(dist_config.b_indptr, dist_config.b_nrows,
                                       coo_rows.data(), dist_config.b_nnz,

--- a/cpp/test/sparse/linkage.cu
+++ b/cpp/test/sparse/linkage.cu
@@ -117,7 +117,7 @@ double compute_rand_index(
   ASSERT(size >= 2, "Rand Index for size less than 2 not defined!");
 
   //allocating and initializing memory for a and b in the GPU
-  raft::mr::device::buffer<uint64_t> arr_buf(allocator, stream, 2);
+  rmm::device_uvector<uint64_t> arr_buf(2, stream);
   CUDA_CHECK(cudaMemsetAsync(arr_buf.data(), 0, 2 * sizeof(uint64_t), stream));
 
   //kernel configuration


### PR DESCRIPTION
This PR contributes to planned changes described in #97.
It replaces references to RAFT's `raft::mr::device::buffer` into its RMM equivalent : `rmm::device_uvector` in the RAFT codebase. Removing the `raft::mr` namespace would only be possible once all references to it are removed from RAFT and other libraries using it.
