### PR TITLE
[REVIEW] Remove RAFT `device::allocator` adapter

### DIFF
--- a/cpp/include/raft/common/cub_wrappers.cuh
+++ b/cpp/include/raft/common/cub_wrappers.cuh
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <cub/cub.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 namespace raft {
 
@@ -34,7 +34,7 @@ namespace raft {
      * @param stream cuda stream
      */
 template <typename KeyT, typename ValueT>
-void sortPairs(raft::mr::device::buffer<char> &workspace, const KeyT *inKeys,
+void sortPairs(rmm::device_uvector<char> &workspace, const KeyT *inKeys,
                KeyT *outKeys, const ValueT *inVals, ValueT *outVals, int len,
                cudaStream_t stream) {
   size_t worksize;

--- a/cpp/include/raft/comms/helper.hpp
+++ b/cpp/include/raft/comms/helper.hpp
@@ -38,11 +38,10 @@ namespace comms {
  */
 void build_comms_nccl_only(handle_t *handle, ncclComm_t nccl_comm,
                            int num_ranks, int rank) {
-  auto d_alloc = handle->get_device_allocator();
   cudaStream_t stream = handle->get_stream();
 
   auto communicator = std::make_shared<comms_t>(std::unique_ptr<comms_iface>(
-    new raft::comms::std_comms(nccl_comm, num_ranks, rank, d_alloc, stream)));
+    new raft::comms::std_comms(nccl_comm, num_ranks, rank, stream)));
   handle->set_comms(communicator);
 }
 
@@ -80,12 +79,11 @@ void build_comms_nccl_ucx(handle_t *handle, ncclComm_t nccl_comm,
     }
   }
 
-  auto d_alloc = handle->get_device_allocator();
   cudaStream_t stream = handle->get_stream();
 
-  auto communicator = std::make_shared<comms_t>(std::unique_ptr<comms_iface>(
-    new raft::comms::std_comms(nccl_comm, (ucp_worker_h)ucp_worker, eps_sp,
-                               num_ranks, rank, d_alloc, stream)));
+  auto communicator = std::make_shared<comms_t>(
+    std::unique_ptr<comms_iface>(new raft::comms::std_comms(
+      nccl_comm, (ucp_worker_h)ucp_worker, eps_sp, num_ranks, rank, stream)));
   handle->set_comms(communicator);
 }
 

--- a/cpp/include/raft/comms/test.hpp
+++ b/cpp/include/raft/comms/test.hpp
@@ -18,7 +18,6 @@
 
 #include <raft/comms/comms.hpp>
 #include <raft/handle.hpp>
-#include <raft/mr/device/buffer.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -44,8 +43,7 @@ bool test_collective_allreduce(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
+  rmm::device_uvector<int> temp_d(1, stream);
   CUDA_CHECK(
     cudaMemcpyAsync(temp_d.data(), &send, 1, cudaMemcpyHostToDevice, stream));
 
@@ -76,8 +74,7 @@ bool test_collective_broadcast(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
+  rmm::device_uvector<int> temp_d(1, stream);
 
   if (communicator.get_rank() == root)
     CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), &send, sizeof(int),
@@ -104,8 +101,7 @@ bool test_collective_reduce(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
+  rmm::device_uvector<int> temp_d(1, stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), &send, sizeof(int),
                              cudaMemcpyHostToDevice, stream));
@@ -134,11 +130,8 @@ bool test_collective_allgather(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
-
-  raft::mr::device::buffer<int> recv_d(handle.get_device_allocator(), stream,
-                                       communicator.get_size());
+  rmm::device_uvector<int> temp_d(1, stream);
+  rmm::device_uvector<int> recv_d(communicator.get_size(), stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), &send, sizeof(int),
                              cudaMemcpyHostToDevice, stream));
@@ -169,12 +162,9 @@ bool test_collective_gather(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(1, stream);
-
-  raft::mr::device::buffer<int> recv_d(
-    handle.get_device_allocator(), stream,
-    communicator.get_rank() == root ? communicator.get_size() : 0);
+  rmm::device_uvector<int> temp_d(1, stream);
+  rmm::device_uvector<int> recv_d(
+    communicator.get_rank() == root ? communicator.get_size() : 0, stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), &send, sizeof(int),
                              cudaMemcpyHostToDevice, stream));
@@ -211,12 +201,9 @@ bool test_collective_gatherv(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream);
-  temp_d.resize(sends.size(), stream);
-
-  raft::mr::device::buffer<int> recv_d(
-    handle.get_device_allocator(), stream,
-    communicator.get_rank() == root ? displacements.back() : 0);
+  rmm::device_uvector<int> temp_d(sends.size(), stream);
+  rmm::device_uvector<int> recv_d(
+    communicator.get_rank() == root ? displacements.back() : 0, stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), sends.data(),
                              sends.size() * sizeof(int), cudaMemcpyHostToDevice,
@@ -256,10 +243,8 @@ bool test_collective_reducescatter(const handle_t &handle, int root) {
 
   cudaStream_t stream = handle.get_stream();
 
-  raft::mr::device::buffer<int> temp_d(handle.get_device_allocator(), stream,
-                                       sends.size());
-  raft::mr::device::buffer<int> recv_d(handle.get_device_allocator(), stream,
-                                       1);
+  rmm::device_uvector<int> temp_d(sends.size(), stream);
+  rmm::device_uvector<int> recv_d(1, stream);
 
   CUDA_CHECK(cudaMemcpyAsync(temp_d.data(), sends.data(),
                              sends.size() * sizeof(int), cudaMemcpyHostToDevice,

--- a/cpp/include/raft/distance/distance.cuh
+++ b/cpp/include/raft/distance/distance.cuh
@@ -22,7 +22,7 @@
 #include <raft/distance/cosine.cuh>
 #include <raft/distance/euclidean.cuh>
 #include <raft/distance/l1.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 namespace raft {
 namespace distance {
@@ -243,7 +243,7 @@ void distance(const InType *x, const InType *y, OutType *dist, Index_ m,
 template <typename Type, typename Index_, raft::distance::DistanceType DistType>
 void pairwise_distance_impl(const Type *x, const Type *y, Type *dist, Index_ m,
                             Index_ n, Index_ k,
-                            raft::mr::device::buffer<char> &workspace,
+                            rmm::device_uvector<char> &workspace,
                             cudaStream_t stream, bool isRowMajor) {
   auto worksize =
     getWorkspaceSize<DistType, Type, Type, Type, Index_>(x, y, m, n, k);
@@ -254,8 +254,7 @@ void pairwise_distance_impl(const Type *x, const Type *y, Type *dist, Index_ m,
 
 template <typename Type, typename Index_ = int>
 void pairwise_distance(const Type *x, const Type *y, Type *dist, Index_ m,
-                       Index_ n, Index_ k,
-                       raft::mr::device::buffer<char> &workspace,
+                       Index_ n, Index_ k, rmm::device_uvector<char> &workspace,
                        raft::distance::DistanceType metric, cudaStream_t stream,
                        bool isRowMajor = true) {
   switch (metric) {

--- a/cpp/include/raft/label/classlabels.cuh
+++ b/cpp/include/raft/label/classlabels.cuh
@@ -21,7 +21,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/unary_op.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 namespace raft {
@@ -40,12 +39,11 @@ namespace label {
  *   on exit it has size [n_unique]
  * \param [out] n_unique number of unique labels
  * \param [in] stream cuda stream
- * \param [in] allocator device allocator
  */
 template <typename value_t>
-void getUniquelabels(value_t *y, size_t n, value_t **y_unique, int *n_unique,
-                     cudaStream_t stream,
-                     std::shared_ptr<raft::mr::device::allocator> allocator) {
+int getUniquelabels(rmm::device_uvector<value_t> &y_unique, value_t *y,
+                    size_t n, cudaStream_t stream) {
+  int n_unique;
   rmm::device_uvector<value_t> y2(n, stream);
   rmm::device_uvector<value_t> y3(n, stream);
   rmm::device_uvector<int> d_num_selected(1, stream);
@@ -64,13 +62,13 @@ void getUniquelabels(value_t *y, size_t n, value_t **y_unique, int *n_unique,
   cub::DeviceRadixSort::SortKeys(cub_storage.data(), bytes, y, y2.data(), n);
   cub::DeviceSelect::Unique(cub_storage.data(), bytes, y2.data(), y3.data(),
                             d_num_selected.data(), n);
-  raft::update_host(n_unique, d_num_selected.data(), 1, stream);
+  raft::update_host(&n_unique, d_num_selected.data(), 1, stream);
   CUDA_CHECK(cudaStreamSynchronize(stream));
 
   // Copy unique classes to output
-  *y_unique =
-    (value_t *)allocator->allocate(*n_unique * sizeof(value_t), stream);
-  raft::copy(*y_unique, y3.data(), *n_unique, stream);
+  y_unique.resize(n_unique, stream);
+  raft::copy(y_unique.data(), y3.data(), n_unique, stream);
+  return n_unique;
 }
 
 /**
@@ -147,22 +145,17 @@ __global__ void map_label_kernel(Type *map_ids, size_t N_labels, Type *in,
    */
 template <typename Type, typename Lambda>
 void make_monotonic(Type *out, Type *in, size_t N, cudaStream_t stream,
-                    Lambda filter_op,
-                    std::shared_ptr<raft::mr::device::allocator> allocator,
-                    bool zero_based = false) {
+                    Lambda filter_op, bool zero_based = false) {
   static const size_t TPB_X = 256;
 
   dim3 blocks(raft::ceildiv(N, TPB_X));
   dim3 threads(TPB_X);
 
-  Type *map_ids;
-  int num_clusters;
-  getUniquelabels(in, N, &map_ids, &num_clusters, stream, allocator);
+  rmm::device_uvector<Type> map_ids(0, stream);
+  int num_clusters = getUniquelabels(map_ids, in, N, stream);
 
   map_label_kernel<Type, TPB_X><<<blocks, threads, 0, stream>>>(
-    map_ids, num_clusters, in, out, N, filter_op, zero_based);
-
-  allocator->deallocate(map_ids, num_clusters * sizeof(Type), stream);
+    map_ids.data(), num_clusters, in, out, N, filter_op, zero_based);
 }
 
 /**
@@ -184,11 +177,9 @@ void make_monotonic(Type *out, Type *in, size_t N, cudaStream_t stream,
    */
 template <typename Type>
 void make_monotonic(Type *out, Type *in, size_t N, cudaStream_t stream,
-                    std::shared_ptr<raft::mr::device::allocator> allocator,
                     bool zero_based = false) {
   make_monotonic<Type>(
-    out, in, N, stream, [] __device__(Type val) { return false; }, allocator,
-    zero_based);
+    out, in, N, stream, [] __device__(Type val) { return false; }, zero_based);
 }
 };  // namespace label
 };  // end namespace raft

--- a/cpp/include/raft/linalg/cholesky_r1_update.cuh
+++ b/cpp/include/raft/linalg/cholesky_r1_update.cuh
@@ -63,11 +63,11 @@ namespace linalg {
  * @code{.cpp}
  * // Initialize arrays
  * int ld_L = n_rows;
- * device_buffer<math_t> L(allocator, stream, ld_L * n_rows);
+ * rmm::device_uvector<math_t> L(ld_L * n_rows, stream);
  * MLCommon::LinAlg::choleskyRank1Update(handle, L, n_rows, ld_L, nullptr,
  *                                       &n_bytes, CUBLAS_FILL_MODE_LOWER,
  *                                       stream);
- * device_buffer<char> workspace(allocator, stream, n_bytes);
+ * rmm::device_uvector<char> workspace(n_bytes, stream);
  *
  * for (n=1; n<=n_rows; rank++) {
  *   // Calculate a new row/column of matrix A into A_new
@@ -87,11 +87,11 @@ namespace linalg {
  * @code{.cpp}
  * // Initialize arrays
  * int ld_U = n_rows;
- * device_buffer<math_t> U(allocator, stream, ld_U * n_rows);
+ * rmm::device_uvector<math_t> U(ld_U * n_rows, stream);
  * MLCommon::LinAlg::choleskyRank1Update(handle, L, n_rows, ld_U, nullptr,
  *                                       &n_bytes, CUBLAS_FILL_MODE_UPPER,
  *                                       stream);
- * device_buffer<char> workspace(allocator, stream, n_bytes);
+ * rmm::device_uvector<char> workspace(stream, n_bytes, stream);
  *
  * for (n=1; n<=n_rows; n++) {
  *   // Calculate a new row/column of matrix A into array A_new

--- a/cpp/include/raft/linalg/eig.cuh
+++ b/cpp/include/raft/linalg/eig.cuh
@@ -44,7 +44,6 @@ template <typename math_t>
 void eigDC(const raft::handle_t &handle, const math_t *in, int n_rows,
            int n_cols, math_t *eig_vectors, math_t *eig_vals,
            cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
 
   int lwork;
@@ -93,7 +92,6 @@ template <typename math_t>
 void eigSelDC(const raft::handle_t &handle, math_t *in, int n_rows, int n_cols,
               int n_eig_vals, math_t *eig_vectors, math_t *eig_vals,
               EigVecMemUsage memUsage, cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
 
   int lwork;
@@ -163,7 +161,6 @@ template <typename math_t>
 void eigJacobi(const raft::handle_t &handle, const math_t *in, int n_rows,
                int n_cols, math_t *eig_vectors, math_t *eig_vals,
                cudaStream_t stream, math_t tol = 1.e-7, int sweeps = 15) {
-  auto allocator = handle.get_device_allocator();
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
 
   syevjInfo_t syevj_params = nullptr;

--- a/cpp/include/raft/linalg/eig.cuh
+++ b/cpp/include/raft/linalg/eig.cuh
@@ -22,7 +22,7 @@
 #include <raft/cuda_utils.cuh>
 #include <raft/handle.hpp>
 #include <raft/matrix/matrix.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 namespace raft {
 namespace linalg {
@@ -52,8 +52,8 @@ void eigDC(const raft::handle_t &handle, const math_t *in, int n_rows,
                                             CUBLAS_FILL_MODE_UPPER, n_rows, in,
                                             n_cols, eig_vals, &lwork));
 
-  raft::mr::device::buffer<math_t> d_work(allocator, stream, lwork);
-  raft::mr::device::buffer<int> d_dev_info(allocator, stream, 1);
+  rmm::device_uvector<math_t> d_work(lwork, stream);
+  rmm::device_uvector<int> d_dev_info(1, stream);
 
   raft::matrix::copy(in, eig_vectors, n_rows, n_cols, stream);
 
@@ -104,9 +104,9 @@ void eigSelDC(const raft::handle_t &handle, math_t *in, int n_rows, int n_cols,
     CUBLAS_FILL_MODE_UPPER, n_rows, in, n_cols, math_t(0.0), math_t(0.0),
     n_cols - n_eig_vals + 1, n_cols, &h_meig, eig_vals, &lwork));
 
-  raft::mr::device::buffer<math_t> d_work(allocator, stream, lwork);
-  raft::mr::device::buffer<int> d_dev_info(allocator, stream, 1);
-  raft::mr::device::buffer<math_t> d_eig_vectors(allocator, stream, 0);
+  rmm::device_uvector<math_t> d_work(lwork, stream);
+  rmm::device_uvector<int> d_dev_info(1, stream);
+  rmm::device_uvector<math_t> d_eig_vectors(0, stream);
 
   if (memUsage == OVERWRITE_INPUT) {
     CUSOLVER_CHECK(cusolverDnsyevdx(
@@ -176,8 +176,8 @@ void eigJacobi(const raft::handle_t &handle, const math_t *in, int n_rows,
     cusolverH, CUSOLVER_EIG_MODE_VECTOR, CUBLAS_FILL_MODE_UPPER, n_rows,
     eig_vectors, n_cols, eig_vals, &lwork, syevj_params));
 
-  raft::mr::device::buffer<math_t> d_work(allocator, stream, lwork);
-  raft::mr::device::buffer<int> dev_info(allocator, stream, 1);
+  rmm::device_uvector<math_t> d_work(lwork, stream);
+  rmm::device_uvector<int> dev_info(1, stream);
 
   raft::matrix::copy(in, eig_vectors, n_rows, n_cols, stream);
 

--- a/cpp/include/raft/linalg/svd.cuh
+++ b/cpp/include/raft/linalg/svd.cuh
@@ -23,7 +23,7 @@
 #include <raft/handle.hpp>
 #include <raft/matrix/math.cuh>
 #include <raft/matrix/matrix.cuh>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 #include "eig.cuh"
 #include "gemm.cuh"
 #include "transpose.h"
@@ -54,8 +54,6 @@ void svdQR(const raft::handle_t &handle, T *in, int n_rows, int n_cols,
            T *sing_vals, T *left_sing_vecs, T *right_sing_vecs,
            bool trans_right, bool gen_left_vec, bool gen_right_vec,
            cudaStream_t stream) {
-  std::shared_ptr<raft::mr::device::allocator> allocator =
-    handle.get_device_allocator();
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
   cublasHandle_t cublasH = handle.get_cublas_handle();
 
@@ -71,13 +69,13 @@ void svdQR(const raft::handle_t &handle, T *in, int n_rows, int n_cols,
   const int m = n_rows;
   const int n = n_cols;
 
-  raft::mr::device::buffer<int> devInfo(allocator, stream, 1);
+  rmm::device_uvector<int> devInfo(1, stream);
   T *d_rwork = nullptr;
 
   int lwork = 0;
   CUSOLVER_CHECK(
     cusolverDngesvd_bufferSize<T>(cusolverH, n_rows, n_cols, &lwork));
-  raft::mr::device::buffer<T> d_work(allocator, stream, lwork);
+  rmm::device_uvector<T> d_work(lwork, stream);
 
   char jobu = 'S';
   char jobvt = 'A';
@@ -112,12 +110,11 @@ void svdQR(const raft::handle_t &handle, T *in, int n_rows, int n_cols,
 template <typename T>
 void svdEig(const raft::handle_t &handle, T *in, int n_rows, int n_cols, T *S,
             T *U, T *V, bool gen_left_vec, cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
   cublasHandle_t cublasH = handle.get_cublas_handle();
 
   int len = n_cols * n_cols;
-  raft::mr::device::buffer<T> in_cross_mult(allocator, stream, len);
+  rmm::device_uvector<T> in_cross_mult(len, stream);
 
   T alpha = T(1);
   T beta = T(0);
@@ -162,7 +159,6 @@ void svdJacobi(const raft::handle_t &handle, math_t *in, int n_rows, int n_cols,
                math_t *sing_vals, math_t *left_sing_vecs,
                math_t *right_sing_vecs, bool gen_left_vec, bool gen_right_vec,
                math_t tol, int max_sweeps, cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
   cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
 
   gesvdjInfo_t gesvdj_params = NULL;
@@ -174,7 +170,7 @@ void svdJacobi(const raft::handle_t &handle, math_t *in, int n_rows, int n_cols,
   int m = n_rows;
   int n = n_cols;
 
-  raft::mr::device::buffer<int> devInfo(allocator, stream, 1);
+  rmm::device_uvector<int> devInfo(1, stream);
 
   int lwork = 0;
   int econ = 1;
@@ -183,7 +179,7 @@ void svdJacobi(const raft::handle_t &handle, math_t *in, int n_rows, int n_cols,
     cusolverH, CUSOLVER_EIG_MODE_VECTOR, econ, m, n, in, m, sing_vals,
     left_sing_vecs, m, right_sing_vecs, n, &lwork, gesvdj_params));
 
-  raft::mr::device::buffer<math_t> d_work(allocator, stream, lwork);
+  rmm::device_uvector<math_t> d_work(lwork, stream);
 
   CUSOLVER_CHECK(raft::linalg::cusolverDngesvdj(
     cusolverH, CUSOLVER_EIG_MODE_VECTOR, econ, m, n, in, m, sing_vals,
@@ -210,10 +206,8 @@ template <typename math_t>
 void svdReconstruction(const raft::handle_t &handle, math_t *U, math_t *S,
                        math_t *V, math_t *out, int n_rows, int n_cols, int k,
                        cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
-
   const math_t alpha = 1.0, beta = 0.0;
-  raft::mr::device::buffer<math_t> SVT(allocator, stream, k * n_cols);
+  rmm::device_uvector<math_t> SVT(k * n_cols, stream);
 
   raft::linalg::gemm(handle, S, k, k, V, SVT.data(), k, n_cols, CUBLAS_OP_N,
                      CUBLAS_OP_T, alpha, beta, stream);
@@ -239,14 +233,13 @@ template <typename math_t>
 bool evaluateSVDByL2Norm(const raft::handle_t &handle, math_t *A_d, math_t *U,
                          math_t *S_vec, math_t *V, int n_rows, int n_cols,
                          int k, math_t tol, cudaStream_t stream) {
-  auto allocator = handle.get_device_allocator();
   cublasHandle_t cublasH = handle.get_cublas_handle();
 
   int m = n_rows, n = n_cols;
 
   // form product matrix
-  raft::mr::device::buffer<math_t> P_d(allocator, stream, m * n);
-  raft::mr::device::buffer<math_t> S_mat(allocator, stream, k * k);
+  rmm::device_uvector<math_t> P_d(m * n, stream);
+  rmm::device_uvector<math_t> S_mat(k * k, stream);
   CUDA_CHECK(cudaMemsetAsync(P_d.data(), 0, sizeof(math_t) * m * n, stream));
   CUDA_CHECK(cudaMemsetAsync(S_mat.data(), 0, sizeof(math_t) * k * k, stream));
 
@@ -262,7 +255,7 @@ bool evaluateSVDByL2Norm(const raft::handle_t &handle, math_t *A_d, math_t *U,
 
   // calculate percent error
   const math_t alpha = 1.0, beta = -1.0;
-  raft::mr::device::buffer<math_t> A_minus_P(allocator, stream, m * n);
+  rmm::device_uvector<math_t> A_minus_P(m * n, stream);
   CUDA_CHECK(
     cudaMemsetAsync(A_minus_P.data(), 0, sizeof(math_t) * m * n, stream));
 

--- a/cpp/include/raft/matrix/math.cuh
+++ b/cpp/include/raft/matrix/math.cuh
@@ -22,7 +22,7 @@
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 namespace raft {
 namespace matrix {
@@ -294,10 +294,7 @@ void ratio(const raft::handle_t &handle, math_t *src, math_t *dest, IdxType len,
   auto d_src = src;
   auto d_dest = dest;
 
-  std::shared_ptr<raft::mr::device::allocator> allocator =
-    handle.get_device_allocator();
-
-  raft::mr::device::buffer<math_t> d_sum(allocator, stream, 1);
+  rmm::device_uvector<math_t> d_sum(1, stream);
   auto *d_sum_ptr = d_sum.data();
   auto no_op = [] __device__(math_t in) { return in; };
   raft::linalg::mapThenSumReduce(d_sum_ptr, len, no_op, stream, src);

--- a/cpp/include/raft/matrix/math.cuh
+++ b/cpp/include/raft/matrix/math.cuh
@@ -21,7 +21,6 @@
 #include <raft/linalg/map_then_reduce.cuh>
 #include <raft/linalg/matrix_vector_op.cuh>
 #include <raft/linalg/unary_op.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 namespace raft {
@@ -285,7 +284,6 @@ void setValue(math_t *out, const math_t *in, math_t scalar, int len,
  * @param src: input matrix
  * @param dest: output matrix. The result is stored in the dest matrix
  * @param len: number elements of input matrix
- * @param allocator device allocator
  * @param stream cuda stream
  */
 template <typename math_t, typename IdxType = int>

--- a/cpp/include/raft/random/rng.cuh
+++ b/cpp/include/raft/random/rng.cuh
@@ -24,7 +24,6 @@
 #include <raft/common/scatter.cuh>
 #include <raft/cuda_utils.cuh>
 #include <raft/handle.hpp>
-#include <raft/mr/device/allocator.hpp>
 #include <random>
 #include <rmm/device_uvector.hpp>
 #include <type_traits>
@@ -498,7 +497,6 @@ class Rng {
    * sampling is desired
    * @param sampledLen output sampled array length
    * @param len input array length
-   * @param allocator device allocator for allocating any workspace required
    * @param stream cuda stream
    */
   template <typename DataT, typename WeightsT, typename IdxT = int>
@@ -508,9 +506,6 @@ class Rng {
                                 cudaStream_t stream) {
     ASSERT(sampledLen <= len,
            "sampleWithoutReplacement: 'sampledLen' cant be more than 'len'.");
-
-    std::shared_ptr<raft::mr::device::allocator> allocator =
-      handle.get_device_allocator();
 
     rmm::device_uvector<WeightsT> expWts(len, stream);
     rmm::device_uvector<WeightsT> sortedWts(len, stream);

--- a/cpp/include/raft/random/rng.cuh
+++ b/cpp/include/raft/random/rng.cuh
@@ -25,8 +25,8 @@
 #include <raft/cuda_utils.cuh>
 #include <raft/handle.hpp>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
 #include <random>
+#include <rmm/device_uvector.hpp>
 #include <type_traits>
 #include "rng_impl.cuh"
 
@@ -512,10 +512,10 @@ class Rng {
     std::shared_ptr<raft::mr::device::allocator> allocator =
       handle.get_device_allocator();
 
-    raft::mr::device::buffer<WeightsT> expWts(allocator, stream, len);
-    raft::mr::device::buffer<WeightsT> sortedWts(allocator, stream, len);
-    raft::mr::device::buffer<IdxT> inIdx(allocator, stream, len);
-    raft::mr::device::buffer<IdxT> outIdxBuff(allocator, stream, len);
+    rmm::device_uvector<WeightsT> expWts(len, stream);
+    rmm::device_uvector<WeightsT> sortedWts(len, stream);
+    rmm::device_uvector<IdxT> inIdx(len, stream);
+    rmm::device_uvector<IdxT> outIdxBuff(len, stream);
     auto *inIdxPtr = inIdx.data();
     // generate modified weights
     custom_distribution(
@@ -533,7 +533,7 @@ class Rng {
     ///@todo: use a more efficient partitioning scheme instead of full sort
     // sort the array and pick the top sampledLen items
     IdxT *outIdxPtr = outIdxBuff.data();
-    raft::mr::device::buffer<char> workspace(allocator, stream);
+    rmm::device_uvector<char> workspace(0, stream);
     sortPairs(workspace, expWts.data(), sortedWts.data(), inIdxPtr, outIdxPtr,
               (int)len, stream);
     if (outIdx != nullptr) {

--- a/cpp/include/raft/sparse/coo.cuh
+++ b/cpp/include/raft/sparse/coo.cuh
@@ -17,7 +17,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cusparse_v2.h>
@@ -68,10 +67,9 @@ class COO {
   Index_Type n_cols;
 
   /**
-    * @param d_alloc: the device allocator to use for the underlying buffers
     * @param stream: CUDA stream to use
     */
-  COO(std::shared_ptr<raft::mr::device::allocator> d_alloc, cudaStream_t stream)
+  COO(cudaStream_t stream)
     : rows_arr(0, stream),
       cols_arr(0, stream),
       vals_arr(0, stream),
@@ -98,16 +96,14 @@ class COO {
       n_cols(n_cols) {}
 
   /**
-    * @param d_alloc: the device allocator use
     * @param stream: CUDA stream to use
     * @param nnz: size of the rows/cols/vals arrays
     * @param n_rows: number of rows in the dense matrix
     * @param n_cols: number of cols in the dense matrix
     * @param init: initialize arrays with zeros
     */
-  COO(std::shared_ptr<raft::mr::device::allocator> d_alloc, cudaStream_t stream,
-      Index_Type nnz, Index_Type n_rows = 0, Index_Type n_cols = 0,
-      bool init = true)
+  COO(cudaStream_t stream, Index_Type nnz, Index_Type n_rows = 0,
+      Index_Type n_cols = 0, bool init = true)
     : rows_arr(nnz, stream),
       cols_arr(nnz, stream),
       vals_arr(nnz, stream),

--- a/cpp/include/raft/sparse/coo.cuh
+++ b/cpp/include/raft/sparse/coo.cuh
@@ -18,7 +18,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <cusparse_v2.h>
 
@@ -58,9 +58,9 @@ namespace sparse {
 template <typename T, typename Index_Type = int>
 class COO {
  protected:
-  raft::mr::device::buffer<Index_Type> rows_arr;
-  raft::mr::device::buffer<Index_Type> cols_arr;
-  raft::mr::device::buffer<T> vals_arr;
+  rmm::device_uvector<Index_Type> rows_arr;
+  rmm::device_uvector<Index_Type> cols_arr;
+  rmm::device_uvector<T> vals_arr;
 
  public:
   Index_Type nnz;
@@ -72,9 +72,9 @@ class COO {
     * @param stream: CUDA stream to use
     */
   COO(std::shared_ptr<raft::mr::device::allocator> d_alloc, cudaStream_t stream)
-    : rows_arr(d_alloc, stream, 0),
-      cols_arr(d_alloc, stream, 0),
-      vals_arr(d_alloc, stream, 0),
+    : rows_arr(0, stream),
+      cols_arr(0, stream),
+      vals_arr(0, stream),
       nnz(0),
       n_rows(0),
       n_cols(0) {}
@@ -87,10 +87,9 @@ class COO {
     * @param n_rows: number of rows in the dense matrix
     * @param n_cols: number of cols in the dense matrix
     */
-  COO(raft::mr::device::buffer<Index_Type> &rows,
-      raft::mr::device::buffer<Index_Type> &cols,
-      raft::mr::device::buffer<T> &vals, Index_Type nnz, Index_Type n_rows = 0,
-      Index_Type n_cols = 0)
+  COO(rmm::device_uvector<Index_Type> &rows,
+      rmm::device_uvector<Index_Type> &cols, rmm::device_uvector<T> &vals,
+      Index_Type nnz, Index_Type n_rows = 0, Index_Type n_cols = 0)
     : rows_arr(rows),
       cols_arr(cols),
       vals_arr(vals),
@@ -109,9 +108,9 @@ class COO {
   COO(std::shared_ptr<raft::mr::device::allocator> d_alloc, cudaStream_t stream,
       Index_Type nnz, Index_Type n_rows = 0, Index_Type n_cols = 0,
       bool init = true)
-    : rows_arr(d_alloc, stream, nnz),
-      cols_arr(d_alloc, stream, nnz),
-      vals_arr(d_alloc, stream, nnz),
+    : rows_arr(nnz, stream),
+      cols_arr(nnz, stream),
+      vals_arr(nnz, stream),
       nnz(nnz),
       n_rows(n_rows),
       n_cols(n_cols) {

--- a/cpp/include/raft/sparse/csr.cuh
+++ b/cpp/include/raft/sparse/csr.cuh
@@ -21,7 +21,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
@@ -219,7 +219,7 @@ void weak_cc(Index_ *labels, const Index_ *row_ind, const Index_ *row_ind_ptr,
              Index_ nnz, Index_ N,
              std::shared_ptr<raft::mr::device::allocator> d_alloc,
              cudaStream_t stream, Lambda filter_op) {
-  raft::mr::device::buffer<bool> m(d_alloc, stream, 1);
+  rmm::device_uvector<bool> m(1, stream);
 
   WeakCCState state(m.data());
   weak_cc_batched<Index_, TPB_X>(labels, row_ind, row_ind_ptr, nnz, N, 0, N,
@@ -253,7 +253,7 @@ void weak_cc(Index_ *labels, const Index_ *row_ind, const Index_ *row_ind_ptr,
              Index_ nnz, Index_ N,
              std::shared_ptr<raft::mr::device::allocator> d_alloc,
              cudaStream_t stream) {
-  raft::mr::device::buffer<bool> m(d_alloc, stream, 1);
+  rmm::device_uvector<bool> m(1, stream);
   WeakCCState state(m.data());
   weak_cc_batched<Index_, TPB_X>(labels, row_ind, row_ind_ptr, nnz, N, 0, N,
                                  stream, [](Index_) { return true; });

--- a/cpp/include/raft/sparse/distance/bin_distance.cuh
+++ b/cpp/include/raft/sparse/distance/bin_distance.cuh
@@ -24,7 +24,7 @@
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/distance/common.h>
 #include <raft/sparse/utils.h>
@@ -88,8 +88,8 @@ void compute_bin_distance(value_t *out, const value_idx *Q_coo_rows,
                           cusparseHandle_t handle,
                           std::shared_ptr<raft::mr::device::allocator> alloc,
                           cudaStream_t stream, expansion_f expansion_func) {
-  raft::mr::device::buffer<value_t> Q_norms(alloc, stream, m);
-  raft::mr::device::buffer<value_t> R_norms(alloc, stream, n);
+  rmm::device_uvector<value_t> Q_norms(m, stream);
+  rmm::device_uvector<value_t> R_norms(n, stream);
   CUDA_CHECK(
     cudaMemsetAsync(Q_norms.data(), 0, Q_norms.size() * sizeof(value_t)));
   CUDA_CHECK(
@@ -113,9 +113,7 @@ class jaccard_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit jaccard_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     ip_dists.compute(out_dists);
@@ -123,8 +121,8 @@ class jaccard_expanded_distances_t : public distances_t<value_t> {
     value_idx *b_indices = ip_dists.b_rows_coo();
     value_t *b_data = ip_dists.b_data_coo();
 
-    raft::mr::device::buffer<value_idx> search_coo_rows(
-      config_->allocator, config_->stream, config_->a_nnz);
+    rmm::device_uvector<value_idx> search_coo_rows(config_->a_nnz,
+                                                   config_->stream);
     raft::sparse::convert::csr_to_coo(config_->a_indptr, config_->a_nrows,
                                       search_coo_rows.data(), config_->a_nnz,
                                       config_->stream);
@@ -149,7 +147,7 @@ class jaccard_expanded_distances_t : public distances_t<value_t> {
 
  private:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 
@@ -162,9 +160,7 @@ class dice_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit dice_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     ip_dists.compute(out_dists);
@@ -172,8 +168,8 @@ class dice_expanded_distances_t : public distances_t<value_t> {
     value_idx *b_indices = ip_dists.b_rows_coo();
     value_t *b_data = ip_dists.b_data_coo();
 
-    raft::mr::device::buffer<value_idx> search_coo_rows(
-      config_->allocator, config_->stream, config_->a_nnz);
+    rmm::device_uvector<value_idx> search_coo_rows(config_->a_nnz,
+                                                   config_->stream);
     raft::sparse::convert::csr_to_coo(config_->a_indptr, config_->a_nrows,
                                       search_coo_rows.data(), config_->a_nnz,
                                       config_->stream);
@@ -194,7 +190,7 @@ class dice_expanded_distances_t : public distances_t<value_t> {
 
  private:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 

--- a/cpp/include/raft/sparse/distance/bin_distance.cuh
+++ b/cpp/include/raft/sparse/distance/bin_distance.cuh
@@ -23,7 +23,6 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/distance/common.h>
@@ -85,9 +84,8 @@ void compute_bin_distance(value_t *out, const value_idx *Q_coo_rows,
                           const value_t *Q_data, value_idx Q_nnz,
                           const value_idx *R_coo_rows, const value_t *R_data,
                           value_idx R_nnz, value_idx m, value_idx n,
-                          cusparseHandle_t handle,
-                          std::shared_ptr<raft::mr::device::allocator> alloc,
-                          cudaStream_t stream, expansion_f expansion_func) {
+                          cusparseHandle_t handle, cudaStream_t stream,
+                          expansion_f expansion_func) {
   rmm::device_uvector<value_t> Q_norms(m, stream);
   rmm::device_uvector<value_t> R_norms(n, stream);
   CUDA_CHECK(
@@ -130,7 +128,7 @@ class jaccard_expanded_distances_t : public distances_t<value_t> {
     compute_bin_distance(
       out_dists, search_coo_rows.data(), config_->a_data, config_->a_nnz,
       b_indices, b_data, config_->b_nnz, config_->a_nrows, config_->b_nrows,
-      config_->handle, config_->allocator, config_->stream,
+      config_->handle, config_->stream,
       [] __device__ __host__(value_t dot, value_t q_norm, value_t r_norm) {
         value_t q_r_union = q_norm + r_norm;
         value_t denom = q_r_union - dot;
@@ -177,7 +175,7 @@ class dice_expanded_distances_t : public distances_t<value_t> {
     compute_bin_distance(
       out_dists, search_coo_rows.data(), config_->a_data, config_->a_nnz,
       b_indices, b_data, config_->b_nnz, config_->a_nrows, config_->b_nrows,
-      config_->handle, config_->allocator, config_->stream,
+      config_->handle, config_->stream,
       [] __device__ __host__(value_t dot, value_t q_norm, value_t r_norm) {
         value_t q_r_union = q_norm + r_norm;
         value_t dice = (2 * dot) / q_r_union;

--- a/cpp/include/raft/sparse/distance/common.h
+++ b/cpp/include/raft/sparse/distance/common.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cusparse_v2.h>
-#include <raft/mr/device/allocator.hpp>
 
 namespace raft {
 namespace sparse {
@@ -42,8 +41,6 @@ struct distances_config_t {
   value_t *b_data;
 
   cusparseHandle_t handle;
-
-  std::shared_ptr<raft::mr::device::allocator> allocator;
   cudaStream_t stream;
 };
 

--- a/cpp/include/raft/sparse/distance/coo_spmv.cuh
+++ b/cpp/include/raft/sparse/distance/coo_spmv.cuh
@@ -19,7 +19,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <raft/mr/device/buffer.hpp>
 
 #include <raft/sparse/distance/common.h>

--- a/cpp/include/raft/sparse/distance/csr_spmv.cuh
+++ b/cpp/include/raft/sparse/distance/csr_spmv.cuh
@@ -20,7 +20,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/distance/common.h>
 #include <raft/sparse/utils.h>
@@ -346,7 +346,7 @@ template <typename value_idx>
 inline value_idx max_degree(
   value_idx *indptr, value_idx n_rows,
   std::shared_ptr<raft::mr::device::allocator> allocator, cudaStream_t stream) {
-  raft::mr::device::buffer<value_idx> max_d(allocator, stream, 1);
+  rmm::device_uvector<value_idx> max_d(1, stream);
   CUDA_CHECK(cudaMemsetAsync(max_d.data(), 0, sizeof(value_idx), stream));
 
   /**

--- a/cpp/include/raft/sparse/distance/distance.cuh
+++ b/cpp/include/raft/sparse/distance/distance.cuh
@@ -22,7 +22,6 @@
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <raft/mr/device/buffer.hpp>
 
 #include <raft/sparse/linalg/transpose.h>

--- a/cpp/include/raft/sparse/distance/ip_distance.cuh
+++ b/cpp/include/raft/sparse/distance/ip_distance.cuh
@@ -22,7 +22,6 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/distance/common.h>
@@ -207,7 +206,7 @@ class ip_distances_gemm_t : public ip_trans_getters_t<value_idx, value_t> {
     raft::sparse::linalg::csr_transpose(
       config_->handle, config_->b_indptr, config_->b_indices, config_->b_data,
       csc_indptr.data(), csc_indices.data(), csc_data.data(), config_->b_nrows,
-      config_->b_ncols, config_->b_nnz, config_->allocator, config_->stream);
+      config_->b_ncols, config_->b_nnz, config_->stream);
   }
 
   value_t alpha;

--- a/cpp/include/raft/sparse/distance/l2_distance.cuh
+++ b/cpp/include/raft/sparse/distance/l2_distance.cuh
@@ -24,7 +24,7 @@
 #include <raft/cuda_utils.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/utils.h>
 #include <raft/sparse/csr.cuh>
@@ -92,8 +92,8 @@ void compute_l2(value_t *out, const value_idx *Q_coo_rows,
                 cusparseHandle_t handle,
                 std::shared_ptr<raft::mr::device::allocator> alloc,
                 cudaStream_t stream, expansion_f expansion_func) {
-  raft::mr::device::buffer<value_t> Q_sq_norms(alloc, stream, m);
-  raft::mr::device::buffer<value_t> R_sq_norms(alloc, stream, n);
+  rmm::device_uvector<value_t> Q_sq_norms(m, stream);
+  rmm::device_uvector<value_t> R_sq_norms(n, stream);
   CUDA_CHECK(
     cudaMemsetAsync(Q_sq_norms.data(), 0, Q_sq_norms.size() * sizeof(value_t)));
   CUDA_CHECK(
@@ -117,9 +117,7 @@ class l2_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit l2_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     ip_dists.compute(out_dists);
@@ -127,8 +125,8 @@ class l2_expanded_distances_t : public distances_t<value_t> {
     value_idx *b_indices = ip_dists.b_rows_coo();
     value_t *b_data = ip_dists.b_data_coo();
 
-    raft::mr::device::buffer<value_idx> search_coo_rows(
-      config_->allocator, config_->stream, config_->a_nnz);
+    rmm::device_uvector<value_idx> search_coo_rows(config_->a_nnz,
+                                                   config_->stream);
     raft::sparse::convert::csr_to_coo(config_->a_indptr, config_->a_nrows,
                                       search_coo_rows.data(), config_->a_nnz,
                                       config_->stream);
@@ -146,7 +144,7 @@ class l2_expanded_distances_t : public distances_t<value_t> {
 
  protected:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 
@@ -186,9 +184,7 @@ class cosine_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit cosine_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     ip_dists.compute(out_dists);
@@ -196,8 +192,8 @@ class cosine_expanded_distances_t : public distances_t<value_t> {
     value_idx *b_indices = ip_dists.b_rows_coo();
     value_t *b_data = ip_dists.b_data_coo();
 
-    raft::mr::device::buffer<value_idx> search_coo_rows(
-      config_->allocator, config_->stream, config_->a_nnz);
+    rmm::device_uvector<value_idx> search_coo_rows(config_->a_nnz,
+                                                   config_->stream);
     raft::sparse::convert::csr_to_coo(config_->a_indptr, config_->a_nrows,
                                       search_coo_rows.data(), config_->a_nnz,
                                       config_->stream);
@@ -221,7 +217,7 @@ class cosine_expanded_distances_t : public distances_t<value_t> {
 
  private:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 
@@ -239,9 +235,7 @@ class hellinger_expanded_distances_t : public distances_t<value_t> {
  public:
   explicit hellinger_expanded_distances_t(
     const distances_config_t<value_idx, value_t> &config)
-    : config_(&config),
-      workspace(config.allocator, config.stream, 0),
-      ip_dists(config) {}
+    : config_(&config), workspace(0, config.stream), ip_dists(config) {}
 
   void compute(value_t *out_dists) {
     // First sqrt A and B
@@ -282,7 +276,7 @@ class hellinger_expanded_distances_t : public distances_t<value_t> {
 
  private:
   const distances_config_t<value_idx, value_t> *config_;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<char> workspace;
   ip_distances_t<value_idx, value_t> ip_dists;
 };
 

--- a/cpp/include/raft/sparse/distance/lp_distance.cuh
+++ b/cpp/include/raft/sparse/distance/lp_distance.cuh
@@ -24,7 +24,7 @@
 #include <raft/cuda_utils.cuh>
 
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/utils.h>
 #include <raft/sparse/csr.cuh>
@@ -62,8 +62,8 @@ void unexpanded_lp_distances(
     // for max occupancy.
     // Ref: https://github.com/rapidsai/cuml/issues/3371
 
-    raft::mr::device::buffer<value_idx> coo_rows(
-      config_->allocator, config_->stream, max(config_->b_nnz, config_->a_nnz));
+    rmm::device_uvector<value_idx> coo_rows(max(config_->b_nnz, config_->a_nnz),
+                                            config_->stream);
 
     raft::sparse::convert::csr_to_coo(config_->b_indptr, config_->b_nrows,
                                       coo_rows.data(), config_->b_nnz,

--- a/cpp/include/raft/sparse/distance/lp_distance.cuh
+++ b/cpp/include/raft/sparse/distance/lp_distance.cuh
@@ -23,7 +23,6 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/utils.h>

--- a/cpp/include/raft/sparse/hierarchy/detail/agglomerative.cuh
+++ b/cpp/include/raft/sparse/hierarchy/detail/agglomerative.cuh
@@ -99,7 +99,6 @@ void build_dendrogram_host(const handle_t &handle, const value_idx *rows,
                            const value_idx *cols, const value_t *data,
                            size_t nnz, value_idx *children, value_t *out_delta,
                            value_idx *out_size) {
-  auto d_alloc = handle.get_device_allocator();
   auto stream = handle.get_stream();
 
   value_idx n_edges = nnz;
@@ -224,7 +223,6 @@ template <typename value_idx, int tpb = 256>
 void extract_flattened_clusters(const raft::handle_t &handle, value_idx *labels,
                                 const value_idx *children, size_t n_clusters,
                                 size_t n_leaves) {
-  auto d_alloc = handle.get_device_allocator();
   auto stream = handle.get_stream();
   auto thrust_policy = rmm::exec_policy(rmm::cuda_stream_view{stream});
 

--- a/cpp/include/raft/sparse/hierarchy/detail/mst.cuh
+++ b/cpp/include/raft/sparse/hierarchy/detail/mst.cuh
@@ -80,18 +80,16 @@ void connect_knn_graph(const raft::handle_t &handle, const value_t *X,
                        red_op reduction_op,
                        raft::distance::DistanceType metric =
                          raft::distance::DistanceType::L2SqrtExpanded) {
-  auto d_alloc = handle.get_device_allocator();
   auto stream = handle.get_stream();
 
-  raft::sparse::COO<value_t, value_idx> connected_edges(d_alloc, stream);
+  raft::sparse::COO<value_t, value_idx> connected_edges(stream);
 
   raft::linkage::connect_components<value_idx, value_t>(
     handle, connected_edges, X, color, m, n, reduction_op);
 
   rmm::device_uvector<value_idx> indptr2(m + 1, stream);
-  raft::sparse::convert::sorted_coo_to_csr(connected_edges.rows(),
-                                           connected_edges.nnz, indptr2.data(),
-                                           m + 1, d_alloc, stream);
+  raft::sparse::convert::sorted_coo_to_csr(
+    connected_edges.rows(), connected_edges.nnz, indptr2.data(), m + 1, stream);
 
   // On the second call, we hand the MST the original colors
   // and the new set of edges and let it restart the optimization process
@@ -136,7 +134,6 @@ void build_sorted_mst(const raft::handle_t &handle, const value_t *X,
                       raft::distance::DistanceType metric =
                         raft::distance::DistanceType::L2SqrtExpanded,
                       int max_iter = 10) {
-  auto d_alloc = handle.get_device_allocator();
   auto stream = handle.get_stream();
 
   // We want to have MST initialize colors on first call.
@@ -145,7 +142,7 @@ void build_sorted_mst(const raft::handle_t &handle, const value_t *X,
     true);
 
   int iters = 1;
-  int n_components = linkage::get_n_components(color, m, d_alloc, stream);
+  int n_components = linkage::get_n_components(color, m, stream);
 
   while (n_components > 1 && iters < max_iter) {
     connect_knn_graph<value_idx, value_t>(handle, X, mst_coo, m, n, color,
@@ -153,7 +150,7 @@ void build_sorted_mst(const raft::handle_t &handle, const value_t *X,
 
     iters++;
 
-    n_components = linkage::get_n_components(color, m, d_alloc, stream);
+    n_components = linkage::get_n_components(color, m, stream);
   }
 
   /**

--- a/cpp/include/raft/sparse/hierarchy/single_linkage.hpp
+++ b/cpp/include/raft/sparse/hierarchy/single_linkage.hpp
@@ -58,7 +58,6 @@ void single_linkage(const raft::handle_t &handle, const value_t *X, size_t m,
          "n_clusters must be less than or equal to the number of data points");
 
   auto stream = handle.get_stream();
-  auto d_alloc = handle.get_device_allocator();
 
   rmm::device_uvector<value_idx> indptr(EMPTY, stream);
   rmm::device_uvector<value_idx> indices(EMPTY, stream);

--- a/cpp/include/raft/sparse/linalg/add.cuh
+++ b/cpp/include/raft/sparse/linalg/add.cuh
@@ -21,7 +21,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
@@ -156,14 +155,12 @@ __global__ void csr_add_kernel(const int *a_ind, const int *a_indptr,
  * @param nnz2: size of right hand index_ptr and val arrays
  * @param m: size of output array (number of rows in final matrix)
  * @param out_ind: output row_ind array
- * @param d_alloc: device allocator to use for temp memory
  * @param stream: cuda stream to use
  */
 template <typename T, int TPB_X = 128>
 size_t csr_add_calc_inds(const int *a_ind, const int *a_indptr, const T *a_val,
                          int nnz1, const int *b_ind, const int *b_indptr,
                          const T *b_val, int nnz2, int m, int *out_ind,
-                         std::shared_ptr<raft::mr::device::allocator> d_alloc,
                          cudaStream_t stream) {
   dim3 grid(raft::ceildiv(m, TPB_X), 1, 1);
   dim3 blk(TPB_X, 1, 1);

--- a/cpp/include/raft/sparse/linalg/add.cuh
+++ b/cpp/include/raft/sparse/linalg/add.cuh
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
@@ -168,7 +168,7 @@ size_t csr_add_calc_inds(const int *a_ind, const int *a_indptr, const T *a_val,
   dim3 grid(raft::ceildiv(m, TPB_X), 1, 1);
   dim3 blk(TPB_X, 1, 1);
 
-  raft::mr::device::buffer<int> row_counts(d_alloc, stream, m + 1);
+  rmm::device_uvector<int> row_counts(m + 1, stream);
   CUDA_CHECK(
     cudaMemsetAsync(row_counts.data(), 0, (m + 1) * sizeof(int), stream));
 

--- a/cpp/include/raft/sparse/linalg/spectral.cuh
+++ b/cpp/include/raft/sparse/linalg/spectral.cuh
@@ -18,7 +18,6 @@
 
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <raft/spectral/partition.hpp>
 #include <rmm/device_uvector.hpp>
 
@@ -35,7 +34,6 @@ void fit_embedding(const raft::handle_t &handle, int *rows, int *cols, T *vals,
                    int nnz, int n, int n_components, T *out,
                    unsigned long long seed = 1234567) {
   auto stream = handle.get_stream();
-  auto d_alloc = handle.get_device_allocator();
   rmm::device_uvector<int> src_offsets(n + 1, stream);
   rmm::device_uvector<int> dst_cols(nnz, stream);
   rmm::device_uvector<T> dst_vals(nnz, stream);

--- a/cpp/include/raft/sparse/linalg/symmetrize.cuh
+++ b/cpp/include/raft/sparse/linalg/symmetrize.cuh
@@ -21,7 +21,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/op/sort.h>
@@ -121,13 +120,11 @@ __global__ void coo_symmetrize_kernel(int *row_ind, int *rows, int *cols,
  * @param in: Input COO matrix
  * @param out: Output symmetrized COO matrix
  * @param reduction_op: a custom reduction function
- * @param d_alloc device allocator for temporary buffers
  * @param stream: cuda stream to use
  */
 template <int TPB_X = 128, typename T, typename Lambda>
 void coo_symmetrize(COO<T> *in, COO<T> *out,
                     Lambda reduction_op,  // two-argument reducer
-                    std::shared_ptr<raft::mr::device::allocator> d_alloc,
                     cudaStream_t stream) {
   dim3 grid(raft::ceildiv(in->n_rows, TPB_X), 1, 1);
   dim3 blk(TPB_X, 1, 1);
@@ -136,7 +133,7 @@ void coo_symmetrize(COO<T> *in, COO<T> *out,
 
   rmm::device_uvector<int> in_row_ind(in->n_rows, stream);
 
-  convert::sorted_coo_to_csr(in, in_row_ind.data(), d_alloc, stream);
+  convert::sorted_coo_to_csr(in, in_row_ind.data(), stream);
 
   out->allocate(in->nnz * 2, in->n_rows, in->n_cols, true, stream);
 
@@ -249,14 +246,14 @@ __global__ static void symmetric_sum(value_idx *restrict edges,
  * @param k: Number of n_neighbors
  * @param out: Output COO Matrix class
  * @param stream: Input cuda stream
- * @param d_alloc device allocator for temporary buffers
  */
 template <typename value_idx = int64_t, typename value_t = float,
           int TPB_X = 32, int TPB_Y = 32>
-void from_knn_symmetrize_matrix(
-  const value_idx *restrict knn_indices, const value_t *restrict knn_dists,
-  const value_idx n, const int k, COO<value_t, value_idx> *out,
-  cudaStream_t stream, std::shared_ptr<raft::mr::device::allocator> d_alloc) {
+void from_knn_symmetrize_matrix(const value_idx *restrict knn_indices,
+                                const value_t *restrict knn_dists,
+                                const value_idx n, const int k,
+                                COO<value_t, value_idx> *out,
+                                cudaStream_t stream) {
   // (1) Find how much space needed in each row
   // We look through all datapoints and increment the count for each row.
   const dim3 threadsPerBlock(TPB_X, TPB_Y);
@@ -313,7 +310,6 @@ template <typename value_idx, typename value_t>
 void symmetrize(const raft::handle_t &handle, const value_idx *rows,
                 const value_idx *cols, const value_t *vals, size_t m, size_t n,
                 size_t nnz, raft::sparse::COO<value_t, value_idx> &out) {
-  auto d_alloc = handle.get_device_allocator();
   auto stream = handle.get_stream();
 
   // copy rows to cols and cols to rows
@@ -332,7 +328,7 @@ void symmetrize(const raft::handle_t &handle, const value_idx *rows,
   // sort COO
   raft::sparse::op::coo_sort((value_idx)m, (value_idx)n, (value_idx)nnz * 2,
                              symm_rows.data(), symm_cols.data(),
-                             symm_vals.data(), d_alloc, stream);
+                             symm_vals.data(), stream);
 
   raft::sparse::op::max_duplicates(handle, out, symm_rows.data(),
                                    symm_cols.data(), symm_vals.data(), nnz * 2,

--- a/cpp/include/raft/sparse/linalg/transpose.h
+++ b/cpp/include/raft/sparse/linalg/transpose.h
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
@@ -72,8 +72,8 @@ void csr_transpose(cusparseHandle_t handle, const value_idx *csr_indptr,
     CUSPARSE_INDEX_BASE_ZERO, CUSPARSE_CSR2CSC_ALG1,
     &convert_csc_workspace_size, stream));
 
-  raft::mr::device::buffer<char> convert_csc_workspace(
-    allocator, stream, convert_csc_workspace_size);
+  rmm::device_uvector<char> convert_csc_workspace(convert_csc_workspace_size,
+                                                  stream);
 
   CUSPARSE_CHECK(raft::sparse::cusparsecsr2csc(
     handle, csr_nrows, csr_ncols, nnz, csr_data, csr_indptr, csr_indices,

--- a/cpp/include/raft/sparse/linalg/transpose.h
+++ b/cpp/include/raft/sparse/linalg/transpose.h
@@ -21,7 +21,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
@@ -53,7 +52,6 @@ namespace linalg {
  * @param[in] csr_nrows : Number of rows in CSR
  * @param[in] csr_ncols : Number of columns in CSR
  * @param[in] nnz : Number of nonzeros of CSR
- * @param[in] allocator : Allocator for intermediate memory
  * @param[in] stream : Cuda stream for ordering events
  */
 template <typename value_idx, typename value_t>
@@ -61,9 +59,7 @@ void csr_transpose(cusparseHandle_t handle, const value_idx *csr_indptr,
                    const value_idx *csr_indices, const value_t *csr_data,
                    value_idx *csc_indptr, value_idx *csc_indices,
                    value_t *csc_data, value_idx csr_nrows, value_idx csr_ncols,
-                   value_idx nnz,
-                   std::shared_ptr<raft::mr::device::allocator> allocator,
-                   cudaStream_t stream) {
+                   value_idx nnz, cudaStream_t stream) {
   size_t convert_csc_workspace_size = 0;
 
   CUSPARSE_CHECK(raft::sparse::cusparsecsr2csc_bufferSize(

--- a/cpp/include/raft/sparse/op/filter.cuh
+++ b/cpp/include/raft/sparse/op/filter.cuh
@@ -22,7 +22,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
@@ -87,8 +87,8 @@ void coo_remove_scalar(const int *rows, const int *cols, const T *vals, int nnz,
                        int *cur_cnnz, T scalar, int n,
                        std::shared_ptr<raft::mr::device::allocator> d_alloc,
                        cudaStream_t stream) {
-  raft::mr::device::buffer<int> ex_scan(d_alloc, stream, n);
-  raft::mr::device::buffer<int> cur_ex_scan(d_alloc, stream, n);
+  rmm::device_uvector<int> ex_scan(n, stream);
+  rmm::device_uvector<int> cur_ex_scan(n, stream);
 
   CUDA_CHECK(cudaMemsetAsync(ex_scan.data(), 0, n * sizeof(int), stream));
   CUDA_CHECK(cudaMemsetAsync(cur_ex_scan.data(), 0, n * sizeof(int), stream));
@@ -129,8 +129,8 @@ template <int TPB_X, typename T>
 void coo_remove_scalar(COO<T> *in, COO<T> *out, T scalar,
                        std::shared_ptr<raft::mr::device::allocator> d_alloc,
                        cudaStream_t stream) {
-  raft::mr::device::buffer<int> row_count_nz(d_alloc, stream, in->n_rows);
-  raft::mr::device::buffer<int> row_count(d_alloc, stream, in->n_rows);
+  rmm::device_uvector<int> row_count_nz(in->n_rows, stream);
+  rmm::device_uvector<int> row_count(in->n_rows, stream);
 
   CUDA_CHECK(
     cudaMemsetAsync(row_count_nz.data(), 0, in->n_rows * sizeof(int), stream));

--- a/cpp/include/raft/sparse/op/reduce.cuh
+++ b/cpp/include/raft/sparse/op/reduce.cuh
@@ -21,7 +21,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <raft/mr/device/buffer.hpp>
 
 #include <raft/sparse/op/sort.h>
@@ -126,7 +125,6 @@ void max_duplicates(const raft::handle_t &handle,
                     raft::sparse::COO<value_t, value_idx> &out,
                     const value_idx *rows, const value_idx *cols,
                     const value_t *vals, size_t nnz, size_t m, size_t n) {
-  auto d_alloc = handle.get_device_allocator();
   auto stream = handle.get_stream();
 
   auto exec_policy = rmm::exec_policy(rmm::cuda_stream_view{stream});

--- a/cpp/include/raft/sparse/op/sort.h
+++ b/cpp/include/raft/sparse/op/sort.h
@@ -21,7 +21,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/cuda_utils.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <raft/mr/device/buffer.hpp>
 
 #include <thrust/device_ptr.h>
@@ -62,13 +61,10 @@ struct TupleComp {
  * @param rows rows array from coo matrix
  * @param cols cols array from coo matrix
  * @param vals vals array from coo matrix
- * @param d_alloc device allocator for temporary buffers
  * @param stream: cuda stream to use
  */
 template <typename T>
 void coo_sort(int m, int n, int nnz, int *rows, int *cols, T *vals,
-              // TODO: Remove this
-              std::shared_ptr<raft::mr::device::allocator> d_alloc,
               cudaStream_t stream) {
   auto coo_indices = thrust::make_zip_iterator(thrust::make_tuple(rows, cols));
 
@@ -81,16 +77,12 @@ void coo_sort(int m, int n, int nnz, int *rows, int *cols, T *vals,
  * @brief Sort the underlying COO arrays by row
  * @tparam T: the type name of the underlying value array
  * @param in: COO to sort by row
- * @param d_alloc device allocator for temporary buffers
  * @param stream: the cuda stream to use
  */
 template <typename T>
-void coo_sort(COO<T> *const in,
-              // TODO: Remove this
-              std::shared_ptr<raft::mr::device::allocator> d_alloc,
-              cudaStream_t stream) {
+void coo_sort(COO<T> *const in, cudaStream_t stream) {
   coo_sort<T>(in->n_rows, in->n_cols, in->nnz, in->rows(), in->cols(),
-              in->vals(), d_alloc, stream);
+              in->vals(), stream);
 }
 
 /**

--- a/cpp/include/raft/sparse/selection/connect_components.cuh
+++ b/cpp/include/raft/sparse/selection/connect_components.cuh
@@ -159,14 +159,10 @@ struct CubKVPMinReduce {
  */
 template <typename value_idx>
 value_idx get_n_components(value_idx *colors, size_t n_rows,
-                           std::shared_ptr<raft::mr::device::allocator> d_alloc,
                            cudaStream_t stream) {
-  value_idx *map_ids;
-  int num_clusters;
-  raft::label::getUniquelabels(colors, n_rows, &map_ids, &num_clusters, stream,
-                               d_alloc);
-  d_alloc->deallocate(map_ids, num_clusters * sizeof(value_idx), stream);
-
+  rmm::device_uvector<value_idx> map_ids(0, stream);
+  int num_clusters =
+    raft::label::getUniquelabels(map_ids, colors, n_rows, stream);
   return num_clusters;
 }
 
@@ -197,15 +193,13 @@ struct LookupColorOp {
  * @param[in] X original dense data
  * @param[in] n_rows number of rows in original dense data
  * @param[in] n_cols number of columns in original dense data
- * @param[in] d_alloc device allocator to use
  * @param[in] stream cuda stream for which to order cuda operations
  */
 template <typename value_idx, typename value_t, typename red_op>
 void perform_1nn(cub::KeyValuePair<value_idx, value_t> *kvp,
                  value_idx *nn_colors, value_idx *colors, const value_t *X,
-                 size_t n_rows, size_t n_cols,
-                 std::shared_ptr<raft::mr::device::allocator> d_alloc,
-                 cudaStream_t stream, red_op reduction_op) {
+                 size_t n_rows, size_t n_cols, cudaStream_t stream,
+                 red_op reduction_op) {
   rmm::device_uvector<int> workspace(n_rows, stream);
   rmm::device_uvector<value_t> x_norm(n_rows, stream);
 
@@ -324,7 +318,6 @@ void connect_components(const raft::handle_t &handle,
                         size_t n_rows, size_t n_cols, red_op reduction_op,
                         raft::distance::DistanceType metric =
                           raft::distance::DistanceType::L2SqrtExpanded) {
-  auto d_alloc = handle.get_device_allocator();
   auto stream = handle.get_stream();
 
   RAFT_EXPECTS(metric == raft::distance::DistanceType::L2SqrtExpanded,
@@ -336,10 +329,9 @@ void connect_components(const raft::handle_t &handle,
 
   // Normalize colors so they are drawn from a monotonically increasing set
   raft::label::make_monotonic(colors.data(), colors.data(), n_rows, stream,
-                              d_alloc, true);
+                              true);
 
-  value_idx n_components =
-    get_n_components(colors.data(), n_rows, d_alloc, stream);
+  value_idx n_components = get_n_components(colors.data(), n_rows, stream);
 
   /**
    * First compute 1-nn for all colors where the color of each data point
@@ -351,7 +343,7 @@ void connect_components(const raft::handle_t &handle,
   rmm::device_uvector<value_idx> src_indices(n_rows, stream);
 
   perform_1nn(temp_inds_dists.data(), nn_colors.data(), colors.data(), X,
-              n_rows, n_cols, d_alloc, stream, reduction_op);
+              n_rows, n_cols, stream, reduction_op);
 
   /**
    * Sort data points by color (neighbors are not sorted)
@@ -380,7 +372,7 @@ void connect_components(const raft::handle_t &handle,
 
   size++;
 
-  raft::sparse::COO<value_t, value_idx> min_edges(d_alloc, stream);
+  raft::sparse::COO<value_t, value_idx> min_edges(stream);
   min_edges.allocate(size, n_rows, n_rows, true, stream);
 
   min_components_by_color(min_edges, out_index.data(), src_indices.data(),

--- a/cpp/include/raft/sparse/selection/knn_graph.cuh
+++ b/cpp/include/raft/sparse/selection/knn_graph.cuh
@@ -96,7 +96,6 @@ void knn_graph(const handle_t &handle, const value_t *X, size_t m, size_t n,
                raft::sparse::COO<value_t, value_idx> &out, int c = 15) {
   int k = build_k(m, c);
 
-  auto d_alloc = handle.get_device_allocator();
   auto stream = handle.get_stream();
 
   size_t nnz = m * k;

--- a/cpp/include/raft/spatial/knn/ann.hpp
+++ b/cpp/include/raft/spatial/knn/ann.hpp
@@ -22,14 +22,11 @@
 #include <faiss/gpu/GpuIndex.h>
 #include <faiss/gpu/StandardGpuResources.h>
 
-#include <raft/mr/device/allocator.hpp>
 #include <raft/mr/device/buffer.hpp>
 
 namespace raft {
 namespace spatial {
 namespace knn {
-
-using deviceAllocator = raft::mr::device::allocator;
 
 /**
  * @brief Flat C++ API function to build an approximate nearest neighbors index

--- a/cpp/include/raft/spatial/knn/detail/ann_quantized_faiss.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_quantized_faiss.cuh
@@ -46,7 +46,6 @@
 
 #include <cuml/common/device_buffer.hpp>
 #include <cuml/neighbors/knn.hpp>
-#include <raft/mr/device/allocator.hpp>
 
 #include <iostream>
 #include <set>
@@ -145,8 +144,7 @@ void approx_knn_build_index(raft::handle_t &handle,
   // perform preprocessing
   // k set to 0 (unused during preprocessing / revertion)
   std::unique_ptr<MetricProcessor<float>> query_metric_processor =
-    create_processor<float>(metric, n, D, 0, false, handle.get_stream(),
-                            handle.get_device_allocator());
+    create_processor<float>(metric, n, D, 0, false, handle.get_stream());
 
   query_metric_processor->preprocess(index_array);
 
@@ -183,7 +181,7 @@ void approx_knn_search(raft::handle_t &handle, float *distances,
   // perform preprocessing
   std::unique_ptr<MetricProcessor<float>> query_metric_processor =
     create_processor<float>(index->metric, n, index->index->d, k, false,
-                            handle.get_stream(), handle.get_device_allocator());
+                            handle.get_stream());
 
   query_metric_processor->preprocess(query_array);
   index->index->search(n, query_array, k, distances, indices);

--- a/cpp/include/raft/spatial/knn/detail/knn_brute_force_faiss.cuh
+++ b/cpp/include/raft/spatial/knn/detail/knn_brute_force_faiss.cuh
@@ -19,6 +19,8 @@
 #include <raft/cudart_utils.h>
 #include <raft/cuda_utils.cuh>
 
+#include <rmm/device_uvector.hpp>
+
 #include <faiss/gpu/GpuDistance.h>
 #include <faiss/gpu/GpuResources.h>
 #include <faiss/gpu/StandardGpuResources.h>
@@ -243,13 +245,12 @@ void brute_force_knn_impl(std::vector<float *> &input, std::vector<int> &sizes,
   int device;
   CUDA_CHECK(cudaGetDevice(&device));
 
-  raft::mr::device::buffer<int64_t> trans(allocator, userStream,
-                                          id_ranges->size());
+  rmm::device_uvector<int64_t> trans(id_ranges->size(), userStream);
   raft::update_device(trans.data(), id_ranges->data(), id_ranges->size(),
                       userStream);
 
-  raft::mr::device::buffer<float> all_D(allocator, userStream, 0);
-  raft::mr::device::buffer<int64_t> all_I(allocator, userStream, 0);
+  rmm::device_uvector<float> all_D(0, userStream);
+  rmm::device_uvector<int64_t> all_I(0, userStream);
 
   float *out_D = res_D;
   int64_t *out_I = res_I;

--- a/cpp/include/raft/spatial/knn/knn.hpp
+++ b/cpp/include/raft/spatial/knn/knn.hpp
@@ -18,14 +18,11 @@
 
 #include "detail/knn_brute_force_faiss.cuh"
 
-#include <raft/mr/device/allocator.hpp>
 #include <raft/mr/device/buffer.hpp>
 
 namespace raft {
 namespace spatial {
 namespace knn {
-
-using deviceAllocator = raft::mr::device::allocator;
 
 template <typename value_idx = int64_t, typename value_t = float>
 inline void knn_merge_parts(value_t *inK, value_idx *inV, value_t *outK,
@@ -72,8 +69,7 @@ inline void brute_force_knn(
   std::vector<cudaStream_t> int_streams = handle.get_internal_streams();
 
   detail::brute_force_knn_impl(input, sizes, D, search_items, n, res_I, res_D,
-                               k, handle.get_device_allocator(),
-                               handle.get_stream(), int_streams.data(),
+                               k, handle.get_stream(), int_streams.data(),
                                handle.get_num_internal_streams(), rowMajorIndex,
                                rowMajorQuery, translations, metric, metric_arg);
 }

--- a/cpp/test/label/merge_labels.cu
+++ b/cpp/test/label/merge_labels.cu
@@ -20,7 +20,6 @@
 #include <raft/cudart_utils.h>
 #include <thrust/device_ptr.h>
 #include <raft/handle.hpp>
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 #include "../test_utils.h"
 

--- a/cpp/test/lap/lap.cu
+++ b/cpp/test/lap/lap.cu
@@ -24,6 +24,8 @@
  */
 #include <gtest/gtest.h>
 
+#include <rmm/device_uvector.hpp>
+
 #include <omp.h>
 #include <iostream>
 #include <raft/lap/lap.cuh>
@@ -65,15 +67,12 @@ void hungarian_test(int problemsize, int costrange, int problemcount,
   for (int j = 0; j < problemcount; j++) {
     generateProblem(h_cost, batchsize, problemsize, costrange);
 
-    raft::mr::device::buffer<weight_t> elements_v(
-      handle.get_device_allocator(), handle.get_stream(),
-      batchsize * problemsize * problemsize);
-    raft::mr::device::buffer<vertex_t> row_assignment_v(
-      handle.get_device_allocator(), handle.get_stream(),
-      batchsize * problemsize);
-    raft::mr::device::buffer<vertex_t> col_assignment_v(
-      handle.get_device_allocator(), handle.get_stream(),
-      batchsize * problemsize);
+    rmm::device_uvector<weight_t> elements_v(
+      batchsize * problemsize * problemsize, handle.get_stream());
+    rmm::device_uvector<vertex_t> row_assignment_v(batchsize * problemsize,
+                                                   handle.get_stream());
+    rmm::device_uvector<vertex_t> col_assignment_v(batchsize * problemsize,
+                                                   handle.get_stream());
 
     raft::update_device(elements_v.data(), h_cost,
                         batchsize * problemsize * problemsize,

--- a/cpp/test/linalg/binary_op.cu
+++ b/cpp/test/linalg/binary_op.cu
@@ -17,8 +17,8 @@
 #include <gtest/gtest.h>
 #include <raft/cudart_utils.h>
 #include <raft/linalg/binary_op.cuh>
-#include <raft/mr/device/buffer.hpp>
 #include <raft/random/rng.cuh>
+#include <rmm/device_uvector.hpp>
 #include "../test_utils.h"
 #include "binary_op.cuh"
 
@@ -136,9 +136,9 @@ class BinaryOpAlignment : public ::testing::Test {
     // Test to trigger cudaErrorMisalignedAddress if veclen is incorrectly
     // chosen.
     int n = 1024;
-    mr::device::buffer<math_t> x(handle.get_device_allocator(), stream, n);
-    mr::device::buffer<math_t> y(handle.get_device_allocator(), stream, n);
-    mr::device::buffer<math_t> z(handle.get_device_allocator(), stream, n);
+    rmm::device_uvector<math_t> x(n, stream);
+    rmm::device_uvector<math_t> y(n, stream);
+    rmm::device_uvector<math_t> z(n, stream);
     CUDA_CHECK(cudaMemsetAsync(x.data(), 0, n * sizeof(math_t), stream));
     CUDA_CHECK(cudaMemsetAsync(y.data(), 0, n * sizeof(math_t), stream));
     raft::linalg::binaryOp(

--- a/cpp/test/linalg/cholesky_r1.cu
+++ b/cpp/test/linalg/cholesky_r1.cu
@@ -19,7 +19,6 @@
 #include <raft/linalg/cusolver_wrappers.h>
 #include <raft/handle.hpp>
 #include <raft/linalg/cholesky_r1_update.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <sstream>

--- a/cpp/test/linalg/cholesky_r1.cu
+++ b/cpp/test/linalg/cholesky_r1.cu
@@ -20,7 +20,8 @@
 #include <raft/handle.hpp>
 #include <raft/linalg/cholesky_r1_update.cuh>
 #include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
+#include <rmm/device_uvector.hpp>
+
 #include <sstream>
 #include <vector>
 #include "../test_utils.h"
@@ -31,12 +32,11 @@ template <typename math_t>
 class CholeskyR1Test : public ::testing::Test {
  protected:
   CholeskyR1Test()
-    : allocator(handle.get_device_allocator()),
-      G(allocator, handle.get_stream(), n_rows * n_rows),
-      L(allocator, handle.get_stream(), n_rows * n_rows),
-      L_exp(allocator, handle.get_stream(), n_rows * n_rows),
-      devInfo(allocator, handle.get_stream(), 1),
-      workspace(allocator, handle.get_stream()) {
+    : G(n_rows * n_rows, handle.get_stream()),
+      L(n_rows * n_rows, handle.get_stream()),
+      L_exp(n_rows * n_rows, handle.get_stream()),
+      devInfo(1, handle.get_stream()),
+      workspace(0, handle.get_stream()) {
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.set_stream(stream);
     raft::update_device(G.data(), G_host, n_rows * n_rows, stream);
@@ -105,7 +105,6 @@ class CholeskyR1Test : public ::testing::Test {
   }
 
   raft::handle_t handle;
-  std::shared_ptr<raft::mr::device::allocator> allocator;
   cusolverDnHandle_t solver_handle;
   cudaStream_t stream;
 
@@ -120,11 +119,11 @@ class CholeskyR1Test : public ::testing::Test {
 
   math_t G2_host[4] = {3, 4, 2, 1};
 
-  raft::mr::device::buffer<int> devInfo;
-  raft::mr::device::buffer<math_t> G;
-  raft::mr::device::buffer<math_t> L_exp;
-  raft::mr::device::buffer<math_t> L;
-  raft::mr::device::buffer<char> workspace;
+  rmm::device_uvector<int> devInfo;
+  rmm::device_uvector<math_t> G;
+  rmm::device_uvector<math_t> L_exp;
+  rmm::device_uvector<math_t> L;
+  rmm::device_uvector<char> workspace;
 };
 
 typedef ::testing::Types<float, double> FloatTypes;

--- a/cpp/test/linalg/map.cu
+++ b/cpp/test/linalg/map.cu
@@ -18,7 +18,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/linalg/eltwise.cuh>
 #include <raft/linalg/map.cuh>
-#include <raft/mr/device/buffer.hpp>
 #include <raft/random/rng.cuh>
 #include "../test_utils.h"
 

--- a/cpp/test/linalg/map_then_reduce.cu
+++ b/cpp/test/linalg/map_then_reduce.cu
@@ -19,6 +19,7 @@
 #include <limits>
 #include <raft/linalg/map_then_reduce.cuh>
 #include <raft/random/rng.cuh>
+#include <rmm/device_uvector.hpp>
 #include "../test_utils.h"
 
 namespace raft {
@@ -131,9 +132,7 @@ class MapGenericReduceTest : public ::testing::Test {
 
  protected:
   MapGenericReduceTest()
-    : allocator(handle.get_device_allocator()),
-      input(allocator, handle.get_stream(), n),
-      output(allocator, handle.get_stream(), 1) {
+    : input(n, handle.get_stream()), output(1, handle.get_stream()) {
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.set_stream(stream);
     initInput(input.data(), input.size(), stream);
@@ -172,9 +171,8 @@ class MapGenericReduceTest : public ::testing::Test {
   int n = 1237;
   raft::handle_t handle;
   cudaStream_t stream;
-  std::shared_ptr<raft::mr::device::allocator> allocator;
-  raft::mr::device::buffer<InType> input;
-  raft::mr::device::buffer<OutType> output;
+  rmm::device_uvector<InType> input;
+  rmm::device_uvector<OutType> output;
 };
 
 using IoTypePair =

--- a/cpp/test/matrix/matrix.cu
+++ b/cpp/test/matrix/matrix.cu
@@ -18,6 +18,7 @@
 #include <raft/cudart_utils.h>
 #include <raft/matrix/matrix.cuh>
 #include <raft/random/rng.cuh>
+#include <rmm/device_uvector.hpp>
 #include "../test_utils.h"
 
 namespace raft {
@@ -102,10 +103,9 @@ class MatrixCopyRowsTest : public ::testing::Test {
 
  protected:
   MatrixCopyRowsTest()
-    : allocator(handle.get_device_allocator()),
-      input(allocator, handle.get_stream(), n_cols * n_rows),
-      indices(allocator, handle.get_stream(), n_selected),
-      output(allocator, handle.get_stream(), n_cols * n_selected) {
+    : input(n_cols * n_rows, handle.get_stream()),
+      indices(n_selected, handle.get_stream()),
+      output(n_cols * n_selected, handle.get_stream()) {
     CUDA_CHECK(cudaStreamCreate(&stream));
     handle.set_stream(stream);
     raft::update_device(indices.data(), indices_host, n_selected, stream);
@@ -143,10 +143,9 @@ class MatrixCopyRowsTest : public ::testing::Test {
                                     14, 21, 22, 23, 27, 28, 29};
   raft::handle_t handle;
   cudaStream_t stream;
-  std::shared_ptr<raft::mr::device::allocator> allocator;
-  raft::mr::device::buffer<math_t> input;
-  raft::mr::device::buffer<math_t> output;
-  raft::mr::device::buffer<idx_array_t> indices;
+  rmm::device_uvector<math_t> input;
+  rmm::device_uvector<math_t> output;
+  rmm::device_uvector<idx_array_t> indices;
 };
 
 using TypeTuple =

--- a/cpp/test/sparse/add.cu
+++ b/cpp/test/sparse/add.cu
@@ -74,9 +74,6 @@ class CSRAddTest
   }
 
   void Run() {
-    std::shared_ptr<raft::mr::device::allocator> alloc(
-      new raft::mr::device::default_allocator);
-
     raft::update_device(ind_a, params.matrix_a.row_ind.data(), n_rows, stream);
     raft::update_device(ind_ptr_a, params.matrix_a.row_ind_ptr.data(), nnz_a,
                         stream);
@@ -96,7 +93,7 @@ class CSRAddTest
 
     Index_ nnz = linalg::csr_add_calc_inds<Type_f, 32>(
       ind_a, ind_ptr_a, values_a, nnz_a, ind_b, ind_ptr_b, values_b, nnz_b,
-      n_rows, ind_result, alloc, stream);
+      n_rows, ind_result, stream);
 
     ASSERT_TRUE(nnz == nnz_result);
     ASSERT_TRUE(raft::devArrMatch<Index_>(ind_verify, ind_result, n_rows,

--- a/cpp/test/sparse/convert_csr.cu
+++ b/cpp/test/sparse/convert_csr.cu
@@ -19,7 +19,6 @@
 #include <raft/random/rng.cuh>
 #include "../test_utils.h"
 
-#include <raft/mr/device/allocator.hpp>
 #include <raft/sparse/convert/csr.cuh>
 #include <raft/sparse/coo.cuh>
 
@@ -61,8 +60,6 @@ typedef SparseConvertCSRTest<float> SortedCOOToCSR;
 TEST_P(SortedCOOToCSR, Result) {
   cudaStream_t stream;
   cudaStreamCreate(&stream);
-  std::shared_ptr<raft::mr::device::allocator> alloc(
-    new raft::mr::device::default_allocator);
 
   int nnz = 8;
 
@@ -78,7 +75,7 @@ TEST_P(SortedCOOToCSR, Result) {
   raft::update_device(in, in_h, nnz, stream);
   raft::update_device(exp, exp_h, 4, stream);
 
-  convert::sorted_coo_to_csr<int>(in, nnz, out, 4, alloc, stream);
+  convert::sorted_coo_to_csr<int>(in, nnz, out, 4, stream);
 
   ASSERT_TRUE(raft::devArrMatch<int>(out, exp, 4, raft::Compare<int>()));
 

--- a/cpp/test/sparse/csr_row_slice.cu
+++ b/cpp/test/sparse/csr_row_slice.cu
@@ -19,8 +19,6 @@
 
 #include <gtest/gtest.h>
 #include <raft/sparse/cusparse_wrappers.h>
-#include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
 
 #include <raft/sparse/op/slice.h>
 
@@ -92,8 +90,6 @@ class CSRRowSliceTest
   void SetUp() override {
     params = ::testing::TestWithParam<
       CSRRowSliceInputs<value_idx, value_t>>::GetParam();
-    std::shared_ptr<raft::mr::device::allocator> alloc(
-      new raft::mr::device::default_allocator);
     CUDA_CHECK(cudaStreamCreate(&stream));
 
     make_data();

--- a/cpp/test/sparse/csr_to_dense.cu
+++ b/cpp/test/sparse/csr_to_dense.cu
@@ -16,8 +16,6 @@
 
 #include <cusparse_v2.h>
 #include <raft/cudart_utils.h>
-#include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
 
 #include <gtest/gtest.h>
 #include <raft/sparse/cusparse_wrappers.h>
@@ -77,8 +75,6 @@ class CSRToDenseTest
   void SetUp() override {
     params = ::testing::TestWithParam<
       CSRToDenseInputs<value_idx, value_t>>::GetParam();
-    std::shared_ptr<raft::mr::device::allocator> alloc(
-      new raft::mr::device::default_allocator);
     CUDA_CHECK(cudaStreamCreate(&stream));
     CUSPARSE_CHECK(cusparseCreate(&handle));
 

--- a/cpp/test/sparse/csr_transpose.cu
+++ b/cpp/test/sparse/csr_transpose.cu
@@ -20,8 +20,6 @@
 
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
-#include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
 
 #include <raft/sparse/linalg/transpose.h>
 
@@ -94,8 +92,6 @@ class CSRTransposeTest
   void SetUp() override {
     params = ::testing::TestWithParam<
       CSRTransposeInputs<value_idx, value_t>>::GetParam();
-    std::shared_ptr<raft::mr::device::allocator> alloc(
-      new raft::mr::device::default_allocator);
     CUDA_CHECK(cudaStreamCreate(&stream));
     CUSPARSE_CHECK(cusparseCreate(&handle));
 
@@ -103,7 +99,7 @@ class CSRTransposeTest
 
     raft::sparse::linalg::csr_transpose(
       handle, indptr, indices, data, out_indptr, out_indices, out_data,
-      params.nrows, params.ncols, params.nnz, alloc, stream);
+      params.nrows, params.ncols, params.nnz, stream);
 
     CUDA_CHECK(cudaStreamSynchronize(stream));
     CUSPARSE_CHECK(cusparseDestroy(handle));

--- a/cpp/test/sparse/dist_coo_spmv.cu
+++ b/cpp/test/sparse/dist_coo_spmv.cu
@@ -23,6 +23,7 @@
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/mr/device/allocator.hpp>
+#include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/convert/coo.cuh>
 #include <raft/sparse/distance/coo_spmv.cuh>
@@ -67,9 +68,8 @@ class SparseDistanceCOOSPMVTest
   template <typename reduce_f, typename accum_f, typename write_f>
   void compute_dist(reduce_f reduce_func, accum_f accum_func,
                     write_f write_func, bool rev = true) {
-    raft::mr::device::buffer<value_idx> coo_rows(
-      dist_config.allocator, dist_config.stream,
-      max(dist_config.b_nnz, dist_config.a_nnz));
+    rmm::device_uvector<value_idx> coo_rows(
+      max(dist_config.b_nnz, dist_config.a_nnz), dist_config.stream);
 
     raft::sparse::convert::csr_to_coo(dist_config.b_indptr, dist_config.b_nrows,
                                       coo_rows.data(), dist_config.b_nnz,

--- a/cpp/test/sparse/dist_coo_spmv.cu
+++ b/cpp/test/sparse/dist_coo_spmv.cu
@@ -22,7 +22,6 @@
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/linalg/unary_op.cuh>
-#include <raft/mr/device/allocator.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <raft/sparse/convert/coo.cuh>
@@ -150,8 +149,6 @@ class SparseDistanceCOOSPMVTest
   void SetUp() override {
     params = ::testing::TestWithParam<
       SparseDistanceCOOSPMVInputs<value_idx, value_t>>::GetParam();
-    std::shared_ptr<raft::mr::device::allocator> alloc(
-      new raft::mr::device::default_allocator);
     CUDA_CHECK(cudaStreamCreate(&stream));
 
     CUSPARSE_CHECK(cusparseCreate(&cusparseHandle));
@@ -172,7 +169,6 @@ class SparseDistanceCOOSPMVTest
     dist_config.a_indices = indices;
     dist_config.a_data = data;
     dist_config.handle = cusparseHandle;
-    dist_config.allocator = alloc;
     dist_config.stream = stream;
 
     int out_size = dist_config.a_nrows * dist_config.b_nrows;

--- a/cpp/test/sparse/dist_csr_spmv.cu
+++ b/cpp/test/sparse/dist_csr_spmv.cu
@@ -22,7 +22,6 @@
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
 #include <raft/linalg/unary_op.cuh>
-#include <raft/mr/device/allocator.hpp>
 
 #include <raft/sparse/distance/csr_spmv.cuh>
 #include <raft/sparse/distance/operators.cuh>
@@ -130,8 +129,6 @@ class SparseDistanceCSRSPMVTest
   void SetUp() override {
     params = ::testing::TestWithParam<
       SparseDistanceCSRSPMVInputs<value_idx, value_t>>::GetParam();
-    std::shared_ptr<raft::mr::device::allocator> alloc(
-      new raft::mr::device::default_allocator);
     CUDA_CHECK(cudaStreamCreate(&stream));
 
     CUSPARSE_CHECK(cusparseCreate(&cusparseHandle));
@@ -151,7 +148,6 @@ class SparseDistanceCSRSPMVTest
     dist_config.a_indices = indices;
     dist_config.a_data = data;
     dist_config.handle = cusparseHandle;
-    dist_config.allocator = alloc;
     dist_config.stream = stream;
 
     int out_size = dist_config.a_nrows * dist_config.b_nrows;

--- a/cpp/test/sparse/distance.cu
+++ b/cpp/test/sparse/distance.cu
@@ -21,7 +21,6 @@
 #include <raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/cusparse_wrappers.h>
-#include <raft/mr/device/allocator.hpp>
 
 #include <raft/sparse/distance/distance.cuh>
 
@@ -83,8 +82,6 @@ class SparseDistanceTest
   void SetUp() override {
     params = ::testing::TestWithParam<
       SparseDistanceInputs<value_idx, value_t>>::GetParam();
-    std::shared_ptr<raft::mr::device::allocator> alloc(
-      new raft::mr::device::default_allocator);
     CUDA_CHECK(cudaStreamCreate(&stream));
 
     CUSPARSE_CHECK(cusparseCreate(&cusparseHandle));
@@ -106,7 +103,6 @@ class SparseDistanceTest
     dist_config.a_indices = indices;
     dist_config.a_data = data;
     dist_config.handle = cusparseHandle;
-    dist_config.allocator = alloc;
     dist_config.stream = stream;
 
     int out_size = dist_config.a_nrows * dist_config.b_nrows;

--- a/cpp/test/sparse/filter.cu
+++ b/cpp/test/sparse/filter.cu
@@ -20,7 +20,6 @@
 #include "../test_utils.h"
 
 #include <raft/sparse/op/sort.h>
-#include <raft/mr/device/allocator.hpp>
 #include <raft/sparse/coo.cuh>
 #include <raft/sparse/op/filter.cuh>
 
@@ -53,13 +52,11 @@ typedef SparseFilterTests<float> COORemoveZeros;
 TEST_P(COORemoveZeros, Result) {
   cudaStream_t stream;
   cudaStreamCreate(&stream);
-  std::shared_ptr<raft::mr::device::allocator> alloc(
-    new raft::mr::device::default_allocator);
   params = ::testing::TestWithParam<SparseFilterInputs<float>>::GetParam();
 
   float *in_h_vals = new float[params.nnz];
 
-  COO<float> in(alloc, stream, params.nnz, 5, 5);
+  COO<float> in(stream, params.nnz, 5, 5);
 
   raft::random::Rng r(params.seed);
   r.uniform(in.vals(), params.nnz, float(-1.0), float(1.0), stream);
@@ -82,7 +79,7 @@ TEST_P(COORemoveZeros, Result) {
   raft::update_device(in.cols(), in_h_cols, params.nnz, stream);
   raft::update_device(in.vals(), in_h_vals, params.nnz, stream);
 
-  op::coo_sort<float>(&in, alloc, stream);
+  op::coo_sort<float>(&in, stream);
 
   int out_rows_ref_h[2] = {0, 3};
   int out_cols_ref_h[2] = {4, 1};
@@ -91,14 +88,14 @@ TEST_P(COORemoveZeros, Result) {
   out_vals_ref_h[0] = in_h_vals[4];
   out_vals_ref_h[1] = in_h_vals[1];
 
-  COO<float> out_ref(alloc, stream, 2, 5, 5);
-  COO<float> out(alloc, stream);
+  COO<float> out_ref(stream, 2, 5, 5);
+  COO<float> out(stream);
 
   raft::update_device(out_ref.rows(), *&out_rows_ref_h, 2, stream);
   raft::update_device(out_ref.cols(), *&out_cols_ref_h, 2, stream);
   raft::update_device(out_ref.vals(), out_vals_ref_h, 2, stream);
 
-  op::coo_remove_zeros<32, float>(&in, &out, alloc, stream);
+  op::coo_remove_zeros<32, float>(&in, &out, stream);
 
   ASSERT_TRUE(raft::devArrMatch<int>(out_ref.rows(), out.rows(), 2,
                                      raft::Compare<int>()));

--- a/cpp/test/sparse/knn.cu
+++ b/cpp/test/sparse/knn.cu
@@ -24,8 +24,6 @@
 
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
-#include <raft/mr/device/allocator.hpp>
-#include <raft/mr/device/buffer.hpp>
 
 namespace raft {
 namespace sparse {
@@ -95,8 +93,6 @@ class SparseKNNTest
   void SetUp() override {
     params =
       ::testing::TestWithParam<SparseKNNInputs<value_idx, value_t>>::GetParam();
-    std::shared_ptr<raft::mr::device::allocator> alloc(
-      new raft::mr::device::default_allocator);
     CUDA_CHECK(cudaStreamCreate(&stream));
 
     CUSPARSE_CHECK(cusparseCreate(&cusparseHandle));
@@ -110,8 +106,7 @@ class SparseKNNTest
     raft::sparse::selection::brute_force_knn<value_idx, value_t>(
       indptr, indices, data, nnz, n_rows, params.n_cols, indptr, indices, data,
       nnz, n_rows, params.n_cols, out_indices, out_dists, k, cusparseHandle,
-      alloc, stream, params.batch_size_index, params.batch_size_query,
-      params.metric);
+      stream, params.batch_size_index, params.batch_size_query, params.metric);
 
     CUDA_CHECK(cudaStreamSynchronize(stream));
   }

--- a/cpp/test/sparse/knn_graph.cu
+++ b/cpp/test/sparse/knn_graph.cu
@@ -64,10 +64,9 @@ class KNNGraphTest
 
     raft::handle_t handle;
 
-    auto alloc = handle.get_device_allocator();
     stream = handle.get_stream();
 
-    out = new raft::sparse::COO<value_t, value_idx>(alloc, stream);
+    out = new raft::sparse::COO<value_t, value_idx>(stream);
 
     allocate(X, params.X.size());
 

--- a/cpp/test/sparse/linkage.cu
+++ b/cpp/test/sparse/linkage.cu
@@ -21,7 +21,6 @@
 
 #include <raft/linalg/distance_type.h>
 #include <raft/linalg/transpose.h>
-#include <raft/mr/device/allocator.hpp>
 #include <raft/sparse/coo.cuh>
 #include <raft/sparse/hierarchy/single_linkage.hpp>
 #include <rmm/device_uvector.hpp>
@@ -106,13 +105,11 @@ __global__ void computeTheNumerator(const T* firstClusterArray,
 * @param firstClusterArray: the array of classes of type T
 * @param secondClusterArray: the array of classes of type T
 * @param size: the size of the data points of type uint64_t
-* @param allocator: object that takes care of temporary device memory allocation of type std::shared_ptr<MLCommon::deviceAllocator>
 * @param stream: the cudaStream object
 */
 template <typename T>
-double compute_rand_index(
-  T* firstClusterArray, T* secondClusterArray, uint64_t size,
-  std::shared_ptr<raft::mr::device::allocator> allocator, cudaStream_t stream) {
+double compute_rand_index(T* firstClusterArray, T* secondClusterArray,
+                          uint64_t size, cudaStream_t stream) {
   //rand index for size less than 2 is not defined
   ASSERT(size >= 2, "Rand Index for size less than 2 not defined!");
 
@@ -190,8 +187,7 @@ class LinkageTest : public ::testing::TestWithParam<LinkageInputs<T, IdxT>> {
     CUDA_CHECK(cudaStreamSynchronize(handle.get_stream()));
 
     score =
-      compute_rand_index(labels, labels_ref, params.n_row,
-                         handle.get_device_allocator(), handle.get_stream());
+      compute_rand_index(labels, labels_ref, params.n_row, handle.get_stream());
   }
 
   void SetUp() override { basicTest(); }

--- a/cpp/test/sparse/linkage.cu
+++ b/cpp/test/sparse/linkage.cu
@@ -117,7 +117,7 @@ double compute_rand_index(
   ASSERT(size >= 2, "Rand Index for size less than 2 not defined!");
 
   //allocating and initializing memory for a and b in the GPU
-  raft::mr::device::buffer<uint64_t> arr_buf(allocator, stream, 2);
+  rmm::device_uvector<uint64_t> arr_buf(2, stream);
   CUDA_CHECK(cudaMemsetAsync(arr_buf.data(), 0, 2 * sizeof(uint64_t), stream));
 
   //kernel configuration

--- a/cpp/test/sparse/reduce.cu
+++ b/cpp/test/sparse/reduce.cu
@@ -53,7 +53,6 @@ class SparseReduceTest
   void Run() {
     raft::handle_t handle;
 
-    auto d_alloc = handle.get_device_allocator();
     auto stream = handle.get_stream();
 
     rmm::device_uvector<value_idx> in_rows(params.in_rows.size(), stream);
@@ -76,7 +75,7 @@ class SparseReduceTest
     raft::update_device(out_vals.data(), params.out_vals.data(),
                         params.out_vals.size(), stream);
 
-    raft::sparse::COO<value_t, value_idx> out(d_alloc, stream);
+    raft::sparse::COO<value_t, value_idx> out(stream);
     raft::sparse::op::max_duplicates(handle, out, in_rows.data(),
                                      in_cols.data(), in_vals.data(),
                                      params.in_rows.size(), params.m, params.n);

--- a/cpp/test/sparse/selection.cu
+++ b/cpp/test/sparse/selection.cu
@@ -81,8 +81,6 @@ class SparseSelectionTest
   void SetUp() override {
     params = ::testing::TestWithParam<
       SparseSelectionInputs<value_idx, value_t>>::GetParam();
-    std::shared_ptr<raft::mr::device::allocator> alloc(
-      new raft::mr::device::default_allocator);
     CUDA_CHECK(cudaStreamCreate(&stream));
 
     n_rows = params.n_rows;

--- a/cpp/test/sparse/sort.cu
+++ b/cpp/test/sparse/sort.cu
@@ -20,7 +20,6 @@
 #include "../test_utils.h"
 
 #include <raft/sparse/op/sort.h>
-#include <raft/mr/device/allocator.hpp>
 
 #include <iostream>
 
@@ -55,8 +54,6 @@ TEST_P(COOSort, Result) {
   raft::random::Rng r(params.seed);
   cudaStream_t stream;
   CUDA_CHECK(cudaStreamCreate(&stream));
-  std::shared_ptr<raft::mr::device::allocator> alloc(
-    new raft::mr::device::default_allocator);
 
   raft::allocate(in_vals, params.nnz);
   r.uniform(in_vals, params.nnz, float(-1.0), float(1.0), stream);
@@ -80,7 +77,7 @@ TEST_P(COOSort, Result) {
   raft::update_device(in_cols, in_cols_h, params.nnz, stream);
   raft::update_device(verify, verify_h, params.nnz, stream);
 
-  op::coo_sort(params.m, params.n, params.nnz, in_rows, in_cols, in_vals, alloc,
+  op::coo_sort(params.m, params.n, params.nnz, in_rows, in_cols, in_vals,
                stream);
 
   ASSERT_TRUE(

--- a/cpp/test/spatial/haversine.cu
+++ b/cpp/test/spatial/haversine.cu
@@ -18,7 +18,6 @@
 #include <raft/linalg/distance_type.h>
 #include <iostream>
 #include <raft/spatial/knn/detail/haversine_distance.cuh>
-#include <rmm/device_buffer.hpp>
 #include <vector>
 #include "../test_utils.h"
 
@@ -30,8 +29,6 @@ template <typename value_idx, typename value_t>
 class HaversineKNNTest : public ::testing::Test {
  protected:
   void basicTest() {
-    auto alloc = std::make_shared<raft::mr::device::default_allocator>();
-
     // Allocate input
     raft::allocate(d_train_inputs, n * d);
 


### PR DESCRIPTION
This PR contributes to planned changes described in #97.
It removes references to RAFT's `device::allocator`. Removing the raft::mr namespace would only be possible once all references to it are removed from RAFT and other libraries using it.