### PR TITLE
Warnings are errors

### DIFF
--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -26,8 +26,8 @@ endif()
 list(APPEND RAFT_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
 
 # set warnings as errors
-# list(APPEND RAFT_CUDA_FLAGS -Werror=cross-execution-space-call)
-# list(APPEND RAFT_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations)
+list(APPEND RAFT_CUDA_FLAGS -Werror=cross-execution-space-call)
+list(APPEND RAFT_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations)
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling / memchecking
 if(CUDA_ENABLE_LINEINFO)

--- a/cpp/include/raft/distance/pairwise_distance_base.cuh
+++ b/cpp/include/raft/distance/pairwise_distance_base.cuh
@@ -20,6 +20,8 @@
 #include <raft/linalg/norm.cuh>
 #include <raft/vectorized.cuh>
 
+#include <cstddef>
+
 namespace raft {
 namespace distance {
 
@@ -312,20 +314,20 @@ __global__ __launch_bounds__(
 }
 
 template <typename P, typename IdxT, typename T>
-dim3 launchConfigGenerator(IdxT m, IdxT n, size_t sMemSize, T func) {
+dim3 launchConfigGenerator(IdxT m, IdxT n, std::size_t sMemSize, T func) {
   const auto numSMs = raft::getMultiProcessorCount();
   int numBlocksPerSm = 0;
   dim3 grid;
 
   CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
     &numBlocksPerSm, func, P::Nthreads, sMemSize));
-  int minGridSize = numSMs * numBlocksPerSm;
-  int yChunks = raft::ceildiv<int>(m, P::Mblk);
-  int xChunks = raft::ceildiv<int>(n, P::Nblk);
+  std::size_t minGridSize = numSMs * numBlocksPerSm;
+  std::size_t yChunks = raft::ceildiv<int>(m, P::Mblk);
+  std::size_t xChunks = raft::ceildiv<int>(n, P::Nblk);
   grid.y = yChunks > minGridSize ? minGridSize : yChunks;
   grid.x = (minGridSize - grid.y) <= 0 ? 1 : xChunks;
   if (grid.x != 1) {
-    int i = 1;
+    std::size_t i = 1;
     while (grid.y * i < minGridSize) {
       i++;
     }

--- a/cpp/include/raft/lap/lap_functions.cuh
+++ b/cpp/include/raft/lap/lap_functions.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  * Copyright 2020 KETAN DATE & RAKESH NAGI
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,19 +24,17 @@
  */
 #pragma once
 
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-#include <thrust/device_ptr.h>
-#include <thrust/reduce.h>
-#include <thrust/scan.h>
 #include "d_structs.h"
 
 #include <raft/cudart_utils.h>
 #include <raft/handle.hpp>
+#include <raft/lap/lap_kernels.cuh>
 #include <raft/mr/device/buffer.hpp>
 
-#include <raft/lap/lap_kernels.cuh>
+#include <thrust/reduce.h>
+#include <thrust/scan.h>
+
+#include <cstddef>
 
 namespace raft {
 namespace lap {

--- a/cpp/include/raft/lap/lap_kernels.cuh
+++ b/cpp/include/raft/lap/lap_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  * Copyright 2020 KETAN DATE & RAKESH NAGI
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,18 +24,15 @@
  */
 #pragma once
 
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
-#include <thrust/device_ptr.h>
-#include <thrust/reduce.h>
-#include <thrust/scan.h>
 #include "d_structs.h"
 
 #include <raft/cudart_utils.h>
 #include <raft/handle.hpp>
 #include <raft/mr/device/buffer.hpp>
 
+#include <thrust/for_each.h>
+
+#include <cstddef>
 namespace raft {
 namespace lap {
 namespace detail {

--- a/cpp/include/raft/mr/allocator.hpp
+++ b/cpp/include/raft/mr/allocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
 
 namespace raft {
 namespace mr {

--- a/cpp/include/raft/mr/buffer_base.hpp
+++ b/cpp/include/raft/mr/buffer_base.hpp
@@ -16,8 +16,11 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
 #include <raft/cudart_utils.h>
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
 #include <memory>
 #include <utility>
 

--- a/cpp/include/raft/mr/device/allocator.hpp
+++ b/cpp/include/raft/mr/device/allocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,11 @@
 
 #pragma once
 
-#include <cstddef>
 #include <raft/mr/allocator.hpp>
+
 #include <rmm/mr/device/per_device_resource.hpp>
+
+#include <cstddef>
 
 namespace raft {
 namespace mr {

--- a/cpp/include/raft/mr/host/allocator.hpp
+++ b/cpp/include/raft/mr/host/allocator.hpp
@@ -16,11 +16,12 @@
 
 #pragma once
 
-#include <cstddef>
-
-#include <cuda_runtime.h>
 #include <raft/cudart_utils.h>
 #include <raft/mr/allocator.hpp>
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
 
 namespace raft {
 namespace mr {

--- a/cpp/include/raft/sparse/op/sort.h
+++ b/cpp/include/raft/sparse/op/sort.h
@@ -16,25 +16,22 @@
 
 #pragma once
 
-#include <cusparse_v2.h>
-
 #include <raft/cudart_utils.h>
 #include <raft/sparse/cusparse_wrappers.h>
+#include <raft/sparse/utils.h>
 #include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <raft/mr/device/buffer.hpp>
+#include <raft/sparse/coo.cuh>
 
 #include <thrust/device_ptr.h>
 #include <thrust/scan.h>
 
+#include <cusparse_v2.h>
+
 #include <cuda_runtime.h>
-#include <stdio.h>
 
 #include <algorithm>
-#include <iostream>
-
-#include <raft/sparse/utils.h>
-#include <raft/sparse/coo.cuh>
 
 namespace raft {
 namespace sparse {
@@ -106,8 +103,6 @@ void coo_sort(COO<T> *const in,
 template <typename value_idx, typename value_t>
 void coo_sort_by_weight(value_idx *rows, value_idx *cols, value_t *data,
                         value_idx nnz, cudaStream_t stream) {
-  thrust::device_ptr<value_idx> t_rows = thrust::device_pointer_cast(rows);
-  thrust::device_ptr<value_idx> t_cols = thrust::device_pointer_cast(cols);
   thrust::device_ptr<value_t> t_data = thrust::device_pointer_cast(data);
 
   auto first = thrust::make_zip_iterator(thrust::make_tuple(rows, cols));

--- a/cpp/test/eigen_solvers.cu
+++ b/cpp/test/eigen_solvers.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
+#include <raft/handle.hpp>
+#include <raft/spectral/partition.hpp>
+
 #include <gtest/gtest.h>
+
+#include <cstddef>
 #include <iostream>
 #include <memory>
-#include <raft/handle.hpp>
-
-#include <raft/spectral/partition.hpp>
 
 namespace raft {
 
@@ -37,8 +39,6 @@ TEST(Raft, EigenSolvers) {
   value_type* vs{nullptr};
   index_type nnz = 0;
   index_type nrows = 0;
-  auto stream = h.get_stream();
-  auto t_exe_pol = thrust::cuda::par.on(stream);
 
   sparse_matrix_t<index_type, value_type> sm1{h, ro, ci, vs, nrows, nnz};
   ASSERT_EQ(nullptr, sm1.row_offsets_);
@@ -53,7 +53,7 @@ TEST(Raft, EigenSolvers) {
   //
   value_type* eigvals{nullptr};
   value_type* eigvecs{nullptr};
-  unsigned long long seed{100110021003};
+  std::uint64_t seed{100110021003};
 
   eigen_solver_config_t<index_type, value_type> cfg{
     neigvs, maxiter, restart_iter, tol, reorthog, seed};

--- a/cpp/test/mst.cu
+++ b/cpp/test/mst.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-#include <bits/stdc++.h>
-
-#include <gtest/gtest.h>
-#include <iostream>
-#include <rmm/device_buffer.hpp>
-#include <vector>
+#include "test_utils.h"
 
 #include <raft/cudart_utils.h>
 #include <raft/handle.hpp>
-
 #include <raft/sparse/mst/mst.cuh>
 
-#include "test_utils.h"
+#include <rmm/device_buffer.hpp>
+
+#include <gtest/gtest.h>
+
+#include <bits/stdc++.h>
+
+#include <cstddef>
+#include <vector>
 
 template <typename vertex_t, typename edge_t, typename weight_t>
 struct CSRHost {
@@ -55,25 +56,25 @@ namespace mst {
 // Returns total weight of MST
 template <typename vertex_t, typename edge_t, typename weight_t>
 weight_t prims(CSRHost<vertex_t, edge_t, weight_t> &csr_h) {
-  auto n_vertices = csr_h.offsets.size() - 1;
+  std::size_t n_vertices = csr_h.offsets.size() - 1;
 
   bool active_vertex[n_vertices];
   //  bool mst_set[csr_h.n_edges];
   weight_t curr_edge[n_vertices];
 
-  for (auto i = 0; i < n_vertices; i++) {
+  for (std::size_t i = 0; i < n_vertices; i++) {
     active_vertex[i] = false;
-    curr_edge[i] = INT_MAX;
+    curr_edge[i] = static_cast<weight_t>(std::numeric_limits<int>::max());
   }
   curr_edge[0] = 0;
 
   // function to pick next min vertex-edge
   auto min_vertex_edge = [](auto *curr_edge, auto *active_vertex,
                             auto n_vertices) {
-    weight_t min = INT_MAX;
-    vertex_t min_vertex;
+    auto min = static_cast<weight_t>(std::numeric_limits<int>::max());
+    vertex_t min_vertex{};
 
-    for (auto v = 0; v < n_vertices; v++) {
+    for (std::size_t v = 0; v < n_vertices; v++) {
       if (!active_vertex[v] && curr_edge[v] < min) {
         min = curr_edge[v];
         min_vertex = v;
@@ -84,7 +85,7 @@ weight_t prims(CSRHost<vertex_t, edge_t, weight_t> &csr_h) {
   };
 
   // iterate over n vertices
-  for (auto v = 0; v < n_vertices - 1; v++) {
+  for (std::size_t v = 0; v < n_vertices - 1; v++) {
     // pick min vertex-edge
     auto curr_v = min_vertex_edge(curr_edge, active_vertex, n_vertices);
 
@@ -106,7 +107,7 @@ weight_t prims(CSRHost<vertex_t, edge_t, weight_t> &csr_h) {
 
   // find sum of MST
   weight_t total_weight = 0;
-  for (auto v = 1; v < n_vertices; v++) {
+  for (std::size_t v = 1; v < n_vertices; v++) {
     total_weight += curr_edge[v];
   }
 

--- a/cpp/test/sparse/linkage.cu
+++ b/cpp/test/sparse/linkage.cu
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <raft/cudart_utils.h>
-#include <raft/cuda_utils.cuh>
-#include <vector>
+#include "../test_utils.h"
 
+#include <raft/cudart_utils.h>
 #include <raft/linalg/distance_type.h>
 #include <raft/linalg/transpose.h>
+#include <raft/cuda_utils.cuh>
 #include <raft/mr/device/allocator.hpp>
 #include <raft/sparse/coo.cuh>
 #include <raft/sparse/hierarchy/single_linkage.hpp>
+
 #include <rmm/device_uvector.hpp>
 
-#include "../test_utils.h"
+#include <gtest/gtest.h>
+
+#include <vector>
 
 namespace raft {
 

--- a/cpp/test/spatial/knn.cu
+++ b/cpp/test/spatial/knn.cu
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <raft/linalg/distance_type.h>
-#include <iostream>
-#include <raft/spatial/knn/knn.hpp>
-#include <rmm/device_buffer.hpp>
-#include <vector>
 #include "../test_utils.h"
+
+#include <raft/linalg/distance_type.h>
+#include <raft/spatial/knn/knn.hpp>
+
+#include <rmm/device_buffer.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <iostream>
+#include <vector>
 
 namespace raft {
 namespace spatial {
@@ -37,8 +42,7 @@ __global__ void build_actual_output(int *output, int n_rows, int k,
   int element = threadIdx.x + blockDim.x * blockIdx.x;
   if (element >= n_rows * k) return;
 
-  int ind = (int)indices[element];
-  output[element] = idx_labels[ind];
+  output[element] = idx_labels[indices[element]];
 }
 
 __global__ void build_expected_output(int *output, int n_rows, int k,
@@ -101,8 +105,8 @@ class KNNTest : public ::testing::TestWithParam<KNNInputs> {
     k_ = params_.k;
 
     std::vector<float> row_major_input;
-    for (int i = 0; i < params_.input.size(); ++i) {
-      for (int j = 0; j < params_.input[i].size(); ++j) {
+    for (std::size_t i = 0; i < params_.input.size(); ++i) {
+      for (std::size_t j = 0; j < params_.input[i].size(); ++j) {
         row_major_input.push_back(params_.input[i][j]);
       }
     }


### PR DESCRIPTION
This PR fixes current RAFT C++/CUDA compilation warnings and turns on -Wall to treat warnings as errors.

Fixes #225
Fixes #289 