### PR TITLE
[gpuCI] Forward-merge branch-21.08 to branch-21.10 [skip ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -59,8 +59,8 @@ gpuci_conda_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvid
 # Install the master version of dask, distributed, and dask-ml
 gpuci_logger "Install the master version of dask and distributed"
 set -x
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+pip install "git+https://github.com/dask/distributed.git@2021.07.1" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git@2021.07.1" --upgrade --no-deps
 set +x
 
 

--- a/ci/local/old-gpubuild.sh
+++ b/ci/local/old-gpubuild.sh
@@ -81,8 +81,8 @@ fi
 
 # Install the master version of dask, distributed, and dask-ml
 set -x
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
+pip install "git+https://github.com/dask/distributed.git@2021.07.1" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git@2021.07.1" --upgrade --no-deps
 set +x
 
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.08` that creates a PR to keep `branch-21.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.