### PR TITLE
Update with rapids cmake new features

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -90,12 +90,12 @@ include(cmake/modules/ConfigureCUDA.cmake)
 ##############################################################################
 # - Requirements -------------------------------------------------------------
 
-if (NOT DISABLE_OPENMP OR NOT ${DISABLE_OPENMP})
+if (NOT DISABLE_OPENMP)
   find_package(OpenMP)
   if(OPENMP_FOUND)
     message(VERBOSE "RAFT: OpenMP found in ${OpenMP_CXX_INCLUDE_DIRS}")
-  endif(OPENMP_FOUND)
-endif(NOT DISABLE_OPENMP OR NOT ${DISABLE_OPENMP})
+  endif()
+endif()
 
 # add third party dependencies using CPM
 rapids_cpm_init()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -113,7 +113,7 @@ endif()
 
 ##############################################################################
 # - install targets-----------------------------------------------------------
-
+rapids_cmake_install_lib_dir( lib_dir )
 add_library(raft INTERFACE)
 add_library(raft::raft ALIAS raft)
 target_include_directories(raft INTERFACE "$<BUILD_INTERFACE:${RAFT_SOURCE_DIR}/include>"
@@ -133,7 +133,7 @@ INTERFACE
 target_compile_features(raft INTERFACE cxx_std_17 $<BUILD_INTERFACE:cuda_std_17>)
 
 install(TARGETS raft
-        DESTINATION lib
+        DESTINATION ${lib_dir}
         EXPORT raft-exports
         )
 

--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -16,10 +16,6 @@
 
 function(find_and_configure_cuco VERSION)
 
-    if(TARGET cuco::cuco)
-      return()
-    endif()
-
     rapids_cpm_find(cuco ${VERSION}
       GLOBAL_TARGETS      cuco::cuco
       BUILD_EXPORT_SET    raft-exports

--- a/cpp/cmake/thirdparty/get_gtest.cmake
+++ b/cpp/cmake/thirdparty/get_gtest.cmake
@@ -14,30 +14,11 @@
 # limitations under the License.
 #=============================================================================
 
-function(find_and_configure_gtest VERSION)
+function(find_and_configure_gtest )
 
-    if(TARGET GTest::gtest)
-        return()
-    endif()
-
-    rapids_cpm_find(GTest ${VERSION}
-        GLOBAL_TARGETS  gest gtest_main GTest::gtest GTest::gtest_main
-        CPM_ARGS
-            GIT_REPOSITORY  https://github.com/google/googletest.git
-            GIT_TAG         release-${VERSION}
-            GIT_SHALLOW     TRUE
-            OPTIONS         "INSTALL_GTEST OFF"
-            # googletest >= 1.10.0 provides a cmake config file -- use it if it exists
-            FIND_PACKAGE_ARGUMENTS "CONFIG"
-    )
-
-    if(NOT TARGET GTest::gtest)
-        add_library(GTest::gtest ALIAS gtest)
-        add_library(GTest::gtest_main ALIAS gtest_main)
-    endif()
+    include(${rapids-cmake-dir}/cpm/gtest.cmake)
+    rapids_cpm_gtest()
 
 endfunction()
 
-set(RAFT_MIN_VERSION_gtest 1.10.0)
-
-find_and_configure_gtest(${RAFT_MIN_VERSION_gtest})
+find_and_configure_gtest()

--- a/cpp/cmake/thirdparty/get_nccl.cmake
+++ b/cpp/cmake/thirdparty/get_nccl.cmake
@@ -16,7 +16,7 @@
 
 function(find_and_configure_nccl)
 
-    if(TARGET nccl::nccl)
+    if(TARGET NCCL::NCCL)
         return()
     endif()
 

--- a/cpp/cmake/thirdparty/get_rmm.cmake
+++ b/cpp/cmake/thirdparty/get_rmm.cmake
@@ -16,6 +16,12 @@
 
 function(find_and_configure_rmm VERSION)
 
+    # No way to override the version rapids-cmake pulls
+    # so we need to manually checkout when needing a diverged
+    # version
+    # include(${rapids-cmake-dir}/cpm/rmm.cmake)
+    # rapids_cpm_rmm()
+
     if(${VERSION} MATCHES [=[([0-9]+)\.([0-9]+)\.([0-9]+)]=])
         set(MAJOR_AND_MINOR "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
     else()

--- a/cpp/cmake/thirdparty/get_rmm.cmake
+++ b/cpp/cmake/thirdparty/get_rmm.cmake
@@ -14,36 +14,15 @@
 # limitations under the License.
 #=============================================================================
 
-function(find_and_configure_rmm VERSION)
+function(find_and_configure_rmm)
 
-    # No way to override the version rapids-cmake pulls
-    # so we need to manually checkout when needing a diverged
-    # version
-    # include(${rapids-cmake-dir}/cpm/rmm.cmake)
-    # rapids_cpm_rmm()
-
-    if(${VERSION} MATCHES [=[([0-9]+)\.([0-9]+)\.([0-9]+)]=])
-        set(MAJOR_AND_MINOR "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
-    else()
-        set(MAJOR_AND_MINOR "${VERSION}")
-    endif()
-
-    rapids_cpm_find(rmm ${VERSION}
+    include(${rapids-cmake-dir}/cpm/rmm.cmake)
+    rapids_cpm_rmm(
         GLOBAL_TARGETS      rmm::rmm
         BUILD_EXPORT_SET    raft-exports
         INSTALL_EXPORT_SET  raft-exports
-        CPM_ARGS
-            GIT_REPOSITORY  https://github.com/rapidsai/rmm.git
-            GIT_TAG         23bbe745af1d988224b5498f7b8e3fe3720532d4
-            GIT_SHALLOW     FALSE
-            OPTIONS         "BUILD_TESTS OFF"
-                            "BUILD_BENCHMARKS OFF"
-                            "CUDA_STATIC_RUNTIME ${CUDA_STATIC_RUNTIME}"
-                            "DISABLE_DEPRECATION_WARNING ${DISABLE_DEPRECATION_WARNING}"
     )
 
 endfunction()
 
-set(RAFT_MIN_VERSION_rmm "${RAFT_VERSION_MAJOR}.${RAFT_VERSION_MINOR}.00")
-
-find_and_configure_rmm(${RAFT_MIN_VERSION_rmm})
+find_and_configure_rmm()

--- a/cpp/cmake/thirdparty/get_rmm.cmake
+++ b/cpp/cmake/thirdparty/get_rmm.cmake
@@ -16,10 +16,6 @@
 
 function(find_and_configure_rmm VERSION)
 
-    if(TARGET rmm::rmm)
-        return()
-    endif()
-
     if(${VERSION} MATCHES [=[([0-9]+)\.([0-9]+)\.([0-9]+)]=])
         set(MAJOR_AND_MINOR "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
     else()

--- a/cpp/cmake/thirdparty/get_thrust.cmake
+++ b/cpp/cmake/thirdparty/get_thrust.cmake
@@ -13,18 +13,15 @@
 # =============================================================================
 
 # Use CPM to find or clone thrust
-function(find_and_configure_thrust VERSION)
+function(find_and_configure_thrust)
+  include(${rapids-cmake-dir}/cpm/thrust.cmake)
 
-  rapids_cpm_find(
-    Thrust ${VERSION}
+  rapids_cpm_thrust(
+    NAMESPACE raft
     BUILD_EXPORT_SET raft-exports
     INSTALL_EXPORT_SET raft-exports
-    CPM_ARGS
-    GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
-    GIT_TAG ${VERSION}
-    GIT_SHALLOW TRUE
-    OPTIONS "THRUST_INSTALL OFF")
+  )
 
 endfunction()
 
-find_and_configure_thrust(1.12.0)
+find_and_configure_thrust()

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -126,7 +126,7 @@ PRIVATE
   FAISS::FAISS
   GTest::gtest
   GTest::gtest_main
-  OpenMP::OpenMP_CXX
   Threads::Threads
+  $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX>
   $<TARGET_NAME_IF_EXISTS:conda_env>
 )


### PR DESCRIPTION
This combines some general CMake style cleanup and brings new rapids-cmake features to RAFT including:

- Usage of `rapids_cmake_install_lib_dir` to make sure we install raft correctly on non-debain based distro's ( lib64 ), while also handling conda installation requirements ( always lib no matter the distro )
- Usage of `rapids_cpm` pre-configured pacakges
- Removal of early termination before `rapids_cpm_find` since a better solution now exists ( https://github.com/rapidsai/rapids-cmake/issues/49 )
