### PR TITLE
Fix wrong lda parameter in gemv

### DIFF
--- a/cpp/include/raft/linalg/gemv.h
+++ b/cpp/include/raft/linalg/gemv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,49 +26,116 @@ namespace raft {
 namespace linalg {
 
 template <typename math_t>
-void gemv(const raft::handle_t& handle, const math_t* a, int n_rows, int n_cols,
-          const math_t* x, int incx, math_t* y, int incy, bool trans_a,
-          math_t alpha, math_t beta, cudaStream_t stream) {
+void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows,
+          const int n_cols, const math_t *x, const int incx, math_t *y,
+          const int incy, const bool trans_a, const math_t alpha,
+          const math_t beta, cudaStream_t stream) {
   cublasHandle_t cublas_h = handle.get_cublas_handle();
-
   cublasOperation_t op_a = trans_a ? CUBLAS_OP_T : CUBLAS_OP_N;
-
-  // Unfortunately there is a clash of terminology
-  // in BLAS https://docs.nvidia.com/cuda/cublas/index.html is opposite to Machine Learning
-  // In blas:
-  //  m - number of rows in input matrix
-  //  n - number of columns in input matrix
-  //  lda - purpose of it  to have ability to operate on submatrices of matrix without copying.
-  //        If you're not think about it it's always should be equal to m
-  //  lda has deal with memory layout, but has nothing with the requirement for cuBLAS perform transpose
-
-  // In Machine Learning:
-  //  m - nunmber of columns in design matrix(number of features)
-  //  n - number of rows in designed matrix (number of train examples)
-
-  int m = n_rows;
-  int n = n_cols;
-  int lda = trans_a ? m : n;
-
-  CUBLAS_CHECK(cublasgemv(cublas_h, op_a, m, n, &alpha, a, lda, x, incx, &beta,
-                          y, incy, stream));
+  CUBLAS_CHECK(cublasgemv(cublas_h, op_a, n_rows, n_cols, &alpha, A, n_rows, x,
+                          incx, &beta, y, incy, stream));
 }
 
+/**
+ * y = alpha * op(A) * x + beta * y
+ *
+ * where
+ *
+ * @param A is a column-major matrix of size n_rows_a * n_cols_a.
+ *   op(A) is either the transpose operation (trans_a == true) or identity.
+ *
+ * @param lda is the leading dimension of A (number of rows); lda must be not smaller than n_rows_a.
+ *     set it when you need to use only the first n_rows_a rows of the matrix A, which has
+ *     (perhaps, due to padding) lda rows.
+ *
+ * @param x is a vector of size n_cols_a.
+ *
+ * @param y is a vector of size n_rows_a.
+ */
 template <typename math_t>
-void gemv(const raft::handle_t& handle, const math_t* a, int n_rows_a,
-          int n_cols_a, const math_t* x, math_t* y, bool trans_a, math_t alpha,
-          math_t beta, cudaStream_t stream) {
-  gemv(handle, a, n_rows_a, n_cols_a, x, 1, y, 1, trans_a, alpha, beta, stream);
+void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
+          const int n_cols_a, const math_t *x, math_t *y, const bool trans_a,
+          const math_t alpha, const math_t beta, cudaStream_t stream) {
+  gemv(handle, A, n_rows_a, n_cols_a, x, 1, y, 1, trans_a, alpha, beta, stream);
 }
 
+/**
+ * y = op(A) * x
+ *
+ * where
+ *
+ * @param A is a column-major matrix of size n_rows_a * n_cols_a.
+ *   op(A) is either the transpose operation (trans_a == true) or identity.
+ *
+ * @param x is a vector of size n_cols_a.
+ *
+ * @param y is a vector of size n_rows_a.
+ */
 template <typename math_t>
-void gemv(const raft::handle_t& handle, const math_t* a, int n_rows_a,
-          int n_cols_a, const math_t* x, math_t* y, bool trans_a,
+void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
+          const int n_cols_a, const math_t *x, math_t *y, const bool trans_a,
           cudaStream_t stream) {
   math_t alpha = math_t(1);
   math_t beta = math_t(0);
 
-  gemv(handle, a, n_rows_a, n_cols_a, x, 1, y, 1, trans_a, alpha, beta, stream);
+  gemv(handle, A, n_rows_a, n_cols_a, x, 1, y, 1, trans_a, alpha, beta, stream);
+}
+
+/**
+ * y = alpha * op(A) * x + beta * y
+ *
+ * where
+ *
+ * @param alpha is a scalar scale of Ax.
+ *
+ * @param beta is a scalar scale of y.
+ *
+ * @param A is a column-major matrix of size n_rows_a * n_cols_a.
+ *   op(A) is either the transpose operation (trans_a == true) or identity.
+ *
+ * @param lda is the leading dimension of A (number of rows); lda must be not smaller than n_rows_a.
+ *     set it when you need to use only the first n_rows_a rows of the matrix A, which has
+ *     (perhaps, due to padding) lda rows.
+ *
+ * @param x is a vector of size n_cols_a.
+ *
+ * @param y is a vector of size n_rows_a.
+ */
+template <typename math_t>
+void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
+          const int n_cols_a, const int lda, const math_t *x, math_t *y,
+          const bool trans_a, const math_t alpha, const math_t beta,
+          cudaStream_t stream) {
+  cublasHandle_t cublas_h = handle.get_cublas_handle();
+  cublasOperation_t op_a = trans_a ? CUBLAS_OP_T : CUBLAS_OP_N;
+  CUBLAS_CHECK(cublasgemv(cublas_h, op_a, n_rows_a, n_cols_a, &alpha, A, lda, x,
+                          1, &beta, y, 1, stream));
+}
+
+/**
+ * y = op(A) * x
+ *
+ * where
+ *
+ * @param A is a column-major matrix of size n_rows_a * n_cols_a.
+ *   op(A) is either the transpose operation (trans_a == true) or identity.
+ *
+ * @param lda is the leading dimension of A (number of rows); lda must be not smaller than n_rows_a.
+ *     set it when you need to use only the first n_rows_a rows of the matrix A, which has
+ *     (perhaps, due to padding) lda rows.
+ *
+ * @param x is a vector of size n_cols_a.
+ *
+ * @param y is a vector of size n_rows_a.
+ *
+ */
+template <typename math_t>
+void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
+          const int n_cols_a, const int lda, const math_t *x, math_t *y,
+          const bool trans_a, cudaStream_t stream) {
+  math_t alpha = math_t(1);
+  math_t beta = math_t(0);
+  gemv(handle, A, n_rows_a, n_cols_a, lda, x, y, trans_a, alpha, beta, stream);
 }
 
 };  // namespace linalg

--- a/cpp/include/raft/linalg/gemv.h
+++ b/cpp/include/raft/linalg/gemv.h
@@ -48,9 +48,9 @@ void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows,
  *     set it when you need to use only the first n_rows_a rows of the matrix A, which has
  *     (perhaps, due to padding) lda rows.
  *
- * @param x is a vector of size n_cols_a.
+ * @param x is a vector of size `trans_a ? n_rows_a : n_cols_a`.
  *
- * @param y is a vector of size n_rows_a.
+ * @param y is a vector of size `trans_a ? n_cols_a : n_rows_a`.
  */
 template <typename math_t>
 void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
@@ -67,9 +67,9 @@ void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
  * @param A is a column-major matrix of size n_rows_a * n_cols_a.
  *   op(A) is either the transpose operation (trans_a == true) or identity.
  *
- * @param x is a vector of size n_cols_a.
+ * @param x is a vector of size `trans_a ? n_rows_a : n_cols_a`.
  *
- * @param y is a vector of size n_rows_a.
+ * @param y is a vector of size `trans_a ? n_cols_a : n_rows_a`.
  */
 template <typename math_t>
 void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
@@ -97,9 +97,9 @@ void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
  *     set it when you need to use only the first n_rows_a rows of the matrix A, which has
  *     (perhaps, due to padding) lda rows.
  *
- * @param x is a vector of size n_cols_a.
+ * @param x is a vector of size `trans_a ? n_rows_a : n_cols_a`.
  *
- * @param y is a vector of size n_rows_a.
+ * @param y is a vector of size `trans_a ? n_cols_a : n_rows_a`.
  */
 template <typename math_t>
 void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
@@ -124,9 +124,9 @@ void gemv(const raft::handle_t &handle, const math_t *A, const int n_rows_a,
  *     set it when you need to use only the first n_rows_a rows of the matrix A, which has
  *     (perhaps, due to padding) lda rows.
  *
- * @param x is a vector of size n_cols_a.
+ * @param x is a vector of size `trans_a ? n_rows_a : n_cols_a`.
  *
- * @param y is a vector of size n_rows_a.
+ * @param y is a vector of size `trans_a ? n_cols_a : n_rows_a`.
  *
  */
 template <typename math_t>

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(test_raft
     test/linalg/eig.cu
     test/linalg/eig_sel.cu
     test/linalg/gemm_layout.cu
+    test/linalg/gemv.cu
     test/linalg/map.cu
     test/linalg/map_then_reduce.cu
     test/linalg/matrix_vector_op.cu

--- a/cpp/test/linalg/gemv.cu
+++ b/cpp/test/linalg/gemv.cu
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2019-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <raft/linalg/gemv.h>
+#include <raft/cuda_utils.cuh>
+#include <raft/random/rng.cuh>
+#include "../test_utils.h"
+
+namespace raft {
+namespace linalg {
+
+template <typename T>
+struct GemvInputs {
+  int n_rows;
+  int n_cols;
+  int lda;
+  bool trans_a;
+  unsigned long long int seed;
+};
+
+// Reference GEMV implementation.
+template <typename T>
+__global__ void naiveGemv(T *y, const T *A, const T *x, const int n_rows,
+                          const int n_cols, const int lda, const bool trans_a) {
+  int istart = blockIdx.x * blockDim.x + threadIdx.x;
+  int istep = blockDim.x * gridDim.x;
+
+  if (!trans_a) {
+    for (int i = istart; i < n_rows; i += istep) {
+      T t = T(0.0);
+      for (int j = 0; j < n_cols; j++) {
+        t += A[i + lda * j] * x[j];
+      }
+      y[i] = t;
+    }
+  } else {
+    for (int i = istart; i < n_cols; i += istep) {
+      T t = T(0.0);
+      for (int j = 0; j < n_rows; j++) {
+        t += A[lda * i + j] * x[j];
+      }
+      y[i] = t;
+    }
+  }
+}
+
+template <typename T>
+class GemvTest : public ::testing::TestWithParam<GemvInputs<T>> {
+ protected:
+  void SetUp() override {
+    params = ::testing::TestWithParam<GemvInputs<T>>::GetParam();
+
+    raft::handle_t handle;
+    cudaStream_t stream = handle.get_stream();
+
+    raft::random::Rng r(params.seed);
+
+    // We compute y = op(A) * x and compare against reference result
+
+    T *A = NULL;  // Argument A
+    T *x = NULL;  // Argument x
+
+    size_t aElems = params.lda * params.n_cols;
+    size_t xElems = params.trans_a ? params.n_rows : params.n_cols;
+    size_t yElems = params.trans_a ? params.n_cols : params.n_rows;
+
+    CUDA_CHECK(cudaMalloc(&A, aElems * sizeof(T)));
+    CUDA_CHECK(cudaMalloc(&x, xElems * sizeof(T)));
+    CUDA_CHECK(cudaMalloc(&refy, yElems * sizeof(T)));
+    CUDA_CHECK(cudaMalloc(&y, yElems * sizeof(T)));
+
+    r.uniform(x, xElems, T(-10.0), T(10.0), stream);
+    r.uniform(A, aElems, T(-10.0), T(10.0), stream);
+
+    dim3 blocks(raft::ceildiv<int>(yElems, 256), 1, 1);
+    dim3 threads(256, 1, 1);
+
+    naiveGemv<<<blocks, threads>>>(refy, A, x, params.n_rows, params.n_cols,
+                                   params.lda, params.trans_a);
+
+    gemv(handle, A, params.n_rows, params.n_cols, params.lda, x, y,
+         params.trans_a, stream);
+  }
+
+  void TearDown() override {
+    CUDA_CHECK(cudaFree(refy));
+    CUDA_CHECK(cudaFree(y));
+  }
+
+ protected:
+  GemvInputs<T> params;
+  T *refy = NULL;  // Reference result for comparison
+  T *y = NULL;     // Computed result
+};
+
+const std::vector<GemvInputs<float>> inputsf = {
+  {80, 70, 80, true, 76433ULL},    {80, 100, 80, true, 426646ULL},
+  {20, 100, 20, true, 37703ULL},   {100, 60, 200, true, 538004ULL},
+  {50, 10, 60, false, 73012ULL},   {90, 90, 90, false, 538147ULL},
+  {30, 100, 30, false, 412352ULL}, {40, 80, 100, false, 297941ULL}};
+
+const std::vector<GemvInputs<double>> inputsd = {
+  {10, 70, 10, true, 535648ULL},  {30, 30, 30, true, 956681ULL},
+  {70, 80, 70, true, 875083ULL},  {80, 90, 200, true, 50744ULL},
+  {90, 90, 90, false, 506321ULL}, {40, 100, 70, false, 638418ULL},
+  {80, 50, 80, false, 701529ULL}, {50, 80, 60, false, 893038ULL}};
+
+typedef GemvTest<float> GemvTestF;
+TEST_P(GemvTestF, Result) {
+  ASSERT_TRUE(raft::devArrMatch(refy, y,
+                                params.trans_a ? params.n_cols : params.n_rows,
+                                raft::CompareApprox<float>(1e-4)));
+}
+
+typedef GemvTest<double> GemvTestD;
+TEST_P(GemvTestD, Result) {
+  ASSERT_TRUE(raft::devArrMatch(refy, y,
+                                params.trans_a ? params.n_cols : params.n_rows,
+                                raft::CompareApprox<float>(1e-6)));
+}
+
+INSTANTIATE_TEST_SUITE_P(GemmLayoutTests, GemvTestF,
+                         ::testing::ValuesIn(inputsf));
+
+INSTANTIATE_TEST_SUITE_P(GemmLayoutTests, GemvTestD,
+                         ::testing::ValuesIn(inputsd));
+
+}  // end namespace linalg
+}  // end namespace raft

--- a/cpp/test/linalg/gemv.cu
+++ b/cpp/test/linalg/gemv.cu
@@ -135,11 +135,9 @@ TEST_P(GemvTestD, Result) {
                                 raft::CompareApprox<float>(1e-6)));
 }
 
-INSTANTIATE_TEST_SUITE_P(GemmLayoutTests, GemvTestF,
-                         ::testing::ValuesIn(inputsf));
+INSTANTIATE_TEST_SUITE_P(GemvTests, GemvTestF, ::testing::ValuesIn(inputsf));
 
-INSTANTIATE_TEST_SUITE_P(GemmLayoutTests, GemvTestD,
-                         ::testing::ValuesIn(inputsd));
+INSTANTIATE_TEST_SUITE_P(GemvTests, GemvTestD, ::testing::ValuesIn(inputsd));
 
 }  // end namespace linalg
 }  // end namespace raft


### PR DESCRIPTION
Fix wrong `lda` parameter in raft::linalg::gemv. lda should always be along `n_rows` direction, independently of `trans_a`. I also took a liberty to add couple more overloads and documentation.
