### PR TITLE
Add broadcast with const input iterator

### DIFF
--- a/cpp/include/raft/comms/comms.hpp
+++ b/cpp/include/raft/comms/comms.hpp
@@ -114,6 +114,10 @@ class comms_iface {
   virtual void bcast(void* buff, size_t count, datatype_t datatype, int root,
                      cudaStream_t stream) const = 0;
 
+  virtual void bcast(const void* sendbuff, void* recvbuff, size_t count,
+                     datatype_t datatype, int root,
+                     cudaStream_t stream) const = 0;
+
   virtual void reduce(const void* sendbuff, void* recvbuff, size_t count,
                       datatype_t datatype, op_t op, int root,
                       cudaStream_t stream) const = 0;
@@ -279,6 +283,23 @@ class comms_t {
   template <typename value_t>
   void bcast(value_t* buff, size_t count, int root, cudaStream_t stream) const {
     impl_->bcast(static_cast<void*>(buff), count, get_type<value_t>(), root,
+                 stream);
+  }
+
+  /**
+   * Broadcast data from one rank to the rest
+   * @tparam value_t datatype of underlying buffers
+   * @param sendbuff buffer containing data to broadcast (only used in root)
+   * @param recvbuff buffer to receive broadcasted data
+   * @param count number of elements if buff
+   * @param root the rank initiating the broadcast
+   * @param stream CUDA stream to synchronize operation
+   */
+  template <typename value_t>
+  void bcast(const value_t* sendbuff, value_t* recvbuff, size_t count, int root,
+             cudaStream_t stream) const {
+    impl_->bcast(static_cast<const void*>(sendbuff),
+                 static_cast<void*>(recvbuff), count, get_type<value_t>(), root,
                  stream);
   }
 

--- a/cpp/include/raft/comms/mpi_comms.hpp
+++ b/cpp/include/raft/comms/mpi_comms.hpp
@@ -202,6 +202,13 @@ class mpi_comms : public comms_iface {
                            nccl_comm_, stream));
   }
 
+  void bcast(const void* sendbuff, void* recvbuff, size_t count,
+             datatype_t datatype, int root, cudaStream_t stream) const {
+    NCCL_TRY(ncclBroadcast(sendbuff, recvbuff, count,
+                           get_nccl_datatype(datatype), root, nccl_comm_,
+                           stream));
+  }
+
   void reduce(const void* sendbuff, void* recvbuff, size_t count,
               datatype_t datatype, op_t op, int root,
               cudaStream_t stream) const {

--- a/cpp/include/raft/comms/std_comms.hpp
+++ b/cpp/include/raft/comms/std_comms.hpp
@@ -307,6 +307,13 @@ class std_comms : public comms_iface {
                            nccl_comm_, stream));
   }
 
+  void bcast(const void *sendbuff, void *recvbuff, size_t count,
+             datatype_t datatype, int root, cudaStream_t stream) const {
+    NCCL_TRY(ncclBroadcast(sendbuff, recvbuff, count,
+                           get_nccl_datatype(datatype), root, nccl_comm_,
+                           stream));
+  }
+
   void reduce(const void *sendbuff, void *recvbuff, size_t count,
               datatype_t datatype, op_t op, int root,
               cudaStream_t stream) const {


### PR DESCRIPTION
The current ```bcast``` function takes a single ```value_t*``` pointer (MPI style) for both input (if root) and output (if non-root).

This does not compile if we have ```const value_t*``` pointer for input. This PR adds a ```bcast``` function that takes separate ```const value_t*``` input and ```value_t```` output pointers (NCCL style).