### PR TITLE
Make sure we keep the rapids-cmake and raft cal version in sync

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -31,3 +31,4 @@ function sed_runner() {
 }
 
 sed_runner 's/'"RAFT VERSION .* LANGUAGES"'/'"RAFT VERSION ${NEXT_FULL_TAG} LANGUAGES"'/g' cpp/CMakeLists.txt
+sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cmake"'/g' cpp/CMakeLists.txt


### PR DESCRIPTION
When we make a new raft version, we need to also bump the rapids-cmake version at the same time. Otherwise we will get the previous releases dependencies by mistake.
