### PR TITLE
Fixing bad host->device copy

### DIFF
--- a/cpp/test/spatial/haversine.cu
+++ b/cpp/test/spatial/haversine.cu
@@ -77,9 +77,6 @@ class HaversineKNNTest : public ::testing::Test {
     raft::update_device<value_idx>(d_ref_I.data(), h_res_I.data(), n * n,
                                    stream);
 
-    std::vector<value_t *> input_vec = {d_train_inputs.data()};
-    std::vector<value_idx> sizes_vec = {n};
-
     raft::spatial::knn::detail::haversine_knn(
       d_pred_I.data(), d_pred_D.data(), d_train_inputs.data(),
       d_train_inputs.data(), n, n, k, stream);

--- a/cpp/test/spatial/haversine.cu
+++ b/cpp/test/spatial/haversine.cu
@@ -56,9 +56,9 @@ class HaversineKNNTest : public ::testing::Test {
       0.74932804, -1.33634042, 0.51486728, -1.65962873,
       0.53154002, -1.47049808, 0.72891737, -1.54095137};
 
-    h_train_inputs.resize(n * d);
-    raft::update_device(d_train_inputs.data(), h_train_inputs.data(), n * d,
-                        stream);
+    h_train_inputs.resize(d_train_inputs.size());
+    raft::update_device(d_train_inputs.data(), h_train_inputs.data(),
+                        d_train_inputs.size(), stream);
 
     std::vector<value_t> h_res_D = {
       0., 0.05041587, 0.18767063, 0.23048252, 0.35749438, 0.62925595,

--- a/cpp/test/spatial/haversine.cu
+++ b/cpp/test/spatial/haversine.cu
@@ -56,7 +56,7 @@ class HaversineKNNTest : public ::testing::Test {
       0.74932804, -1.33634042, 0.51486728, -1.65962873,
       0.53154002, -1.47049808, 0.72891737, -1.54095137};
 
-    h_train_inputs.resize(n);
+    h_train_inputs.resize(n * d);
     raft::update_device(d_train_inputs.data(), h_train_inputs.data(), n * d,
                         stream);
 

--- a/cpp/test/spatial/haversine.cu
+++ b/cpp/test/spatial/haversine.cu
@@ -31,11 +31,11 @@ class HaversineKNNTest : public ::testing::Test {
  public:
   HaversineKNNTest()
     : stream(handle.get_stream()),
-      d_train_inputs(n * d, stream),
-      d_ref_I(n * n, stream),
-      d_ref_D(n * n, stream),
-      d_pred_I(n * n, stream),
-      d_pred_D(n * n, stream) {}
+      d_train_inputs(0, stream),
+      d_ref_I(0, stream),
+      d_ref_D(0, stream),
+      d_pred_I(0, stream),
+      d_pred_D(0, stream) {}
 
  protected:
   void basicTest() {


### PR DESCRIPTION
A host vector in haversine knn test was being resized to `n` rather `n*d` before `n*d` elements were copied from it to a device vector. Not sure if this is causing the following issue in the test, but it's not correct nonetheless:

```
[----------] 1 test from HaversineKNNTestF
[ RUN      ] HaversineKNNTestF.Fit
unknown file: Failure
C++ exception with description "std::bad_alloc: CUDA error at: _deps/rmm-src/include/rmm/mr/device/cuda_memory_resource.hpp:70: cudaErrorMemoryAllocation out of memory" thrown in the test fixture's constructor.
[  FAILED  ] HaversineKNNTestF.Fit (0 ms)
[----------] 1 test from HaversineKNNTestF (0 ms total)
```

Since it was happening on host, the only thing I can think of is that somehow there is some host memory being used to determine the amount of device memory to allocate, which is grabbing a garbage value from somewhere. 