### PR TITLE
Ensure that the correct cusolver version exists when running tests

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -47,6 +47,7 @@ conda activate rapids
 gpuci_logger "Installing packages needed for RAFT"
 gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
       "cudatoolkit=${CUDA_REL}" \
+      "libcusolver>=11.2.1" \
       "cudf=${MINOR_VERSION}" \
       "rmm=${MINOR_VERSION}" \
       "dask-cudf=${MINOR_VERSION}" \


### PR DESCRIPTION
cusolver changed SOVERSION's during the CUDA 11.X release cycle, and therefore we need to ensure that we have the same ABI as compiled against when running tests. 