### PR TITLE
[REVIEW] Adding dev conda environment files. 

### DIFF
--- a/conda/environments/raft_dev_cuda11.0.yml
+++ b/conda/environments/raft_dev_cuda11.0.yml
@@ -1,0 +1,33 @@
+name: raft_dev
+channels:
+- rapidsai
+- nvidia
+- rapidsai-nightly
+- conda-forge
+dependencies:
+- cudatoolkit=11.0
+- clang=11.1.0
+- clang-tools=11.1.0
+- rapids-build-env=22.02.*
+- rapids-notebook-env=22.02.*
+- rapids-doc-env=22.02.*
+- rmm=22.02.*
+- dask-cuda=22.02.*
+- ucx-py=0.23
+- ucx-proc=*=gpu
+- doxygen>=1.8.20
+- libfaiss>=1.7.0
+- faiss-proc=*=cuda
+- pip
+- pip:
+    - sphinx_markdown_tables
+    - git+https://github.com/dask/dask.git@2021.11.2
+    - git+https://github.com/dask/distributed.git@2021.11.2
+
+# rapids-build-env, notebook-env and doc-env are defined in
+# https://docs.rapids.ai/maintainers/depmgmt/
+
+# To install different versions of packages contained in those meta packages,
+# it is recommended to remove those meta packages (without removing the actual
+# packages contained in the environment) first with:
+# conda remove --force rapids-build-env rapids-notebook-env rapids-doc-env

--- a/conda/environments/raft_dev_cuda11.2.yml
+++ b/conda/environments/raft_dev_cuda11.2.yml
@@ -1,0 +1,33 @@
+name: raft_dev
+channels:
+- rapidsai
+- nvidia
+- rapidsai-nightly
+- conda-forge
+dependencies:
+- cudatoolkit=11.2
+- clang=11.1.0
+- clang-tools=11.1.0
+- rapids-build-env=22.02.*
+- rapids-notebook-env=22.02.*
+- rapids-doc-env=22.02.*
+- rmm=22.02.*
+- dask-cuda=22.02.*
+- ucx-py=0.23
+- ucx-proc=*=gpu
+- doxygen>=1.8.20
+- libfaiss>=1.7.0
+- faiss-proc=*=cuda
+- pip
+- pip:
+    - sphinx_markdown_tables
+    - git+https://github.com/dask/dask.git@2021.11.2
+    - git+https://github.com/dask/distributed.git@2021.11.2
+
+# rapids-build-env, notebook-env and doc-env are defined in
+# https://docs.rapids.ai/maintainers/depmgmt/
+
+# To install different versions of packages contained in those meta packages,
+# it is recommended to remove those meta packages (without removing the actual
+# packages contained in the environment) first with:
+# conda remove --force rapids-build-env rapids-notebook-env rapids-doc-env

--- a/conda/environments/raft_dev_cuda11.4.yml
+++ b/conda/environments/raft_dev_cuda11.4.yml
@@ -1,0 +1,33 @@
+name: raft_dev
+channels:
+- rapidsai
+- nvidia
+- rapidsai-nightly
+- conda-forge
+dependencies:
+- cudatoolkit=11.4
+- clang=11.1.0
+- clang-tools=11.1.0
+- rapids-build-env=22.02.*
+- rapids-notebook-env=22.02.*
+- rapids-doc-env=22.02.*
+- rmm=22.02.*
+- dask-cuda=22.02.*
+- ucx-py=0.23
+- ucx-proc=*=gpu
+- doxygen>=1.8.20
+- libfaiss>=1.7.0
+- faiss-proc=*=cuda
+- pip
+- pip:
+    - sphinx_markdown_tables
+    - git+https://github.com/dask/dask.git@2021.11.2
+    - git+https://github.com/dask/distributed.git@2021.11.2
+
+# rapids-build-env, notebook-env and doc-env are defined in
+# https://docs.rapids.ai/maintainers/depmgmt/
+
+# To install different versions of packages contained in those meta packages,
+# it is recommended to remove those meta packages (without removing the actual
+# packages contained in the environment) first with:
+# conda remove --force rapids-build-env rapids-notebook-env rapids-doc-env

--- a/conda/environments/raft_dev_cuda11.5.yml
+++ b/conda/environments/raft_dev_cuda11.5.yml
@@ -1,0 +1,33 @@
+name: raft_dev
+channels:
+- rapidsai
+- nvidia
+- rapidsai-nightly
+- conda-forge
+dependencies:
+- cudatoolkit=11.5
+- clang=11.1.0
+- clang-tools=11.1.0
+- rapids-build-env=22.02.*
+- rapids-notebook-env=22.02.*
+- rapids-doc-env=22.02.*
+- rmm=22.02.*
+- dask-cuda=22.02.*
+- ucx-py=0.23
+- ucx-proc=*=gpu
+- doxygen>=1.8.20
+- libfaiss>=1.7.0
+- faiss-proc=*=cuda
+- pip
+- pip:
+    - sphinx_markdown_tables
+    - git+https://github.com/dask/dask.git@2021.11.2
+    - git+https://github.com/dask/distributed.git@2021.11.2
+
+# rapids-build-env, notebook-env and doc-env are defined in
+# https://docs.rapids.ai/maintainers/depmgmt/
+
+# To install different versions of packages contained in those meta packages,
+# it is recommended to remove those meta packages (without removing the actual
+# packages contained in the environment) first with:
+# conda remove --force rapids-build-env rapids-notebook-env rapids-doc-env


### PR DESCRIPTION
With the recent update of the default clang-format version breaking the style checks in a few projects, I realized other projects are explicitly pinning this version while RAFT is not. Now that RAFT is beginning to act more independently of other projects, it's time for it to provide its own dev conda environment files. This will also get the directories in place for the conda recipes, which will be coming in the next couple versions. 