### PR TITLE
[REVIEW] Reverting default knn distance to L2Unexpanded for now.

### DIFF
--- a/cpp/include/raft/spatial/knn/knn.hpp
+++ b/cpp/include/raft/spatial/knn/knn.hpp
@@ -135,7 +135,7 @@ inline void brute_force_knn(raft::handle_t const& handle,
                             bool rowMajorIndex                 = true,
                             bool rowMajorQuery                 = true,
                             std::vector<int64_t>* translations = nullptr,
-                            distance::DistanceType metric      = distance::DistanceType::L2Expanded,
+                            distance::DistanceType metric      = distance::DistanceType::L2Unexpanded,
                             float metric_arg                   = 2.0f)
 {
   ASSERT(input.size() == sizes.size(), "input and sizes vectors must be the same size");

--- a/cpp/include/raft/spatial/knn/knn.hpp
+++ b/cpp/include/raft/spatial/knn/knn.hpp
@@ -135,8 +135,8 @@ inline void brute_force_knn(raft::handle_t const& handle,
                             bool rowMajorIndex                 = true,
                             bool rowMajorQuery                 = true,
                             std::vector<int64_t>* translations = nullptr,
-                            distance::DistanceType metric      = distance::DistanceType::L2Unexpanded,
-                            float metric_arg                   = 2.0f)
+                            distance::DistanceType metric = distance::DistanceType::L2Unexpanded,
+                            float metric_arg              = 2.0f)
 {
   ASSERT(input.size() == sizes.size(), "input and sizes vectors must be the same size");
 


### PR DESCRIPTION
I believe the new expanded knn changes might need some further investigation. Before we started using the fused l2 knn, both unexpanded and expanded variants mapped to the same (expanded) distance computation in FAISS and the cuml tests passed consistently. For some reason, the new expanded fused l2 knn version is causing test failures within cuml. We should figure out if this is from assertions which are too tight or from a possible bug.