### PR TITLE
Fix using incorrect macro RAFT_CHECK_CUDA in place of RAFT_CUDA_TRY

### DIFF
--- a/cpp/test/sparse/csr_row_slice.cu
+++ b/cpp/test/sparse/csr_row_slice.cu
@@ -124,7 +124,7 @@ class CSRRowSliceTest : public ::testing::TestWithParam<CSRRowSliceInputs<value_
                                              out_data.data(),
                                              stream);
 
-    RAFT_CHECK_CUDA(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
   }
 
   void compare()

--- a/cpp/test/sparse/csr_to_dense.cu
+++ b/cpp/test/sparse/csr_to_dense.cu
@@ -83,7 +83,7 @@ class CSRToDenseTest : public ::testing::TestWithParam<CSRToDenseInputs<value_id
     std::vector<value_t> out_ref_h = params.out_ref_h;
 
     update_device(out_ref.data(), out_ref_h.data(), out_ref_h.size(), stream);
-    RAFT_CHECK_CUDA(cudaStreamSynchronize(stream));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
   }
 
   void SetUp() override


### PR DESCRIPTION
Fix the incorrect macro slipped in during refactoring in https://github.com/rapidsai/raft/commit/2ecdd34a6f0b878fe91312bf0156a3e70240fc7f (build fails when in debug mode).