### PR TITLE
Fix clang-format style errors

### DIFF
--- a/cpp/include/raft/sparse/selection/knn_graph.hpp
+++ b/cpp/include/raft/sparse/selection/knn_graph.hpp
@@ -16,10 +16,6 @@
 
 #pragma once
 
-#include <cstdint>
-#include <raft/linalg/distance_type.h>
-#include <raft/sparse/coo.hpp>
-#include <raft/sparse/selection/detail/knn_graph.cuh>
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/coo.hpp>
 #include <raft/sparse/selection/detail/knn_graph.cuh>

--- a/cpp/include/raft/sparse/selection/knn_graph.hpp
+++ b/cpp/include/raft/sparse/selection/knn_graph.hpp
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <raft/linalg/distance_type.h>
 #include <cstdint>
+#include <raft/linalg/distance_type.h>
 #include <raft/sparse/coo.hpp>
 #include <raft/sparse/selection/detail/knn_graph.cuh>
 

--- a/cpp/include/raft/sparse/selection/knn_graph.hpp
+++ b/cpp/include/raft/sparse/selection/knn_graph.hpp
@@ -21,6 +21,7 @@
 #include <raft/sparse/selection/detail/knn_graph.cuh>
 
 #include <cstdint>
+
 namespace raft {
 namespace sparse {
 namespace selection {

--- a/cpp/include/raft/sparse/selection/knn_graph.hpp
+++ b/cpp/include/raft/sparse/selection/knn_graph.hpp
@@ -20,7 +20,11 @@
 #include <raft/linalg/distance_type.h>
 #include <raft/sparse/coo.hpp>
 #include <raft/sparse/selection/detail/knn_graph.cuh>
+#include <raft/linalg/distance_type.h>
+#include <raft/sparse/coo.hpp>
+#include <raft/sparse/selection/detail/knn_graph.cuh>
 
+#include <cstdint>
 namespace raft {
 namespace sparse {
 namespace selection {

--- a/cpp/include/raft/spatial/knn/specializations/ball_cover.hpp
+++ b/cpp/include/raft/spatial/knn/specializations/ball_cover.hpp
@@ -18,8 +18,8 @@
 
 #include <cstdint>
 
-#include <raft/spatial/knn/ball_cover_common.h>
 #include <raft/spatial/knn/ball_cover.hpp>
+#include <raft/spatial/knn/ball_cover_common.h>
 #include <raft/spatial/knn/specializations/detail/ball_cover_lowdim.hpp>
 
 namespace raft {

--- a/cpp/include/raft/spatial/knn/specializations/ball_cover.hpp
+++ b/cpp/include/raft/spatial/knn/specializations/ball_cover.hpp
@@ -21,7 +21,11 @@
 #include <raft/spatial/knn/ball_cover.hpp>
 #include <raft/spatial/knn/ball_cover_common.h>
 #include <raft/spatial/knn/specializations/detail/ball_cover_lowdim.hpp>
+#include <raft/spatial/knn/ball_cover.hpp>
+#include <raft/spatial/knn/ball_cover_common.h>
+#include <raft/spatial/knn/specializations/detail/ball_cover_lowdim.hpp>
 
+#include <cstdint>
 namespace raft {
 namespace spatial {
 namespace knn {

--- a/cpp/include/raft/spatial/knn/specializations/ball_cover.hpp
+++ b/cpp/include/raft/spatial/knn/specializations/ball_cover.hpp
@@ -21,6 +21,7 @@
 #include <raft/spatial/knn/specializations/detail/ball_cover_lowdim.hpp>
 
 #include <cstdint>
+
 namespace raft {
 namespace spatial {
 namespace knn {

--- a/cpp/include/raft/spatial/knn/specializations/ball_cover.hpp
+++ b/cpp/include/raft/spatial/knn/specializations/ball_cover.hpp
@@ -16,11 +16,6 @@
 
 #pragma once
 
-#include <cstdint>
-
-#include <raft/spatial/knn/ball_cover.hpp>
-#include <raft/spatial/knn/ball_cover_common.h>
-#include <raft/spatial/knn/specializations/detail/ball_cover_lowdim.hpp>
 #include <raft/spatial/knn/ball_cover.hpp>
 #include <raft/spatial/knn/ball_cover_common.h>
 #include <raft/spatial/knn/specializations/detail/ball_cover_lowdim.hpp>

--- a/cpp/src/nn/specializations/ball_cover.cu
+++ b/cpp/src/nn/specializations/ball_cover.cu
@@ -24,6 +24,7 @@
 #include <raft/spatial/knn/specializations/knn.hpp>
 
 #include <cstdint>
+
 namespace raft {
 namespace spatial {
 namespace knn {

--- a/cpp/src/nn/specializations/ball_cover.cu
+++ b/cpp/src/nn/specializations/ball_cover.cu
@@ -17,7 +17,16 @@
 #include <cstdint>
 #include <raft/spatial/knn/ball_cover.hpp>
 #include <raft/spatial/knn/ball_cover_common.h>
+#include <raft/spatial/knn/ball_cover.hpp>
+#include <raft/spatial/knn/ball_cover_common.h>
 
+// Ignore upstream specializations to avoid unnecessary recompiling
+#include <raft/distance/specializations.hpp>
+#include <raft/spatial/knn/specializations/detail/ball_cover_lowdim.hpp>
+#include <raft/spatial/knn/specializations/fused_l2_knn.hpp>
+#include <raft/spatial/knn/specializations/knn.hpp>
+
+#include <cstdint>
 // Ignore upstream specializations to avoid unnecessary recompiling
 #include <raft/distance/specializations.hpp>
 #include <raft/spatial/knn/specializations/detail/ball_cover_lowdim.hpp>

--- a/cpp/src/nn/specializations/ball_cover.cu
+++ b/cpp/src/nn/specializations/ball_cover.cu
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <raft/spatial/knn/ball_cover_common.h>
 #include <cstdint>
 #include <raft/spatial/knn/ball_cover.hpp>
+#include <raft/spatial/knn/ball_cover_common.h>
 
 // Ignore upstream specializations to avoid unnecessary recompiling
 #include <raft/distance/specializations.hpp>

--- a/cpp/src/nn/specializations/ball_cover.cu
+++ b/cpp/src/nn/specializations/ball_cover.cu
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#include <cstdint>
-#include <raft/spatial/knn/ball_cover.hpp>
-#include <raft/spatial/knn/ball_cover_common.h>
 #include <raft/spatial/knn/ball_cover.hpp>
 #include <raft/spatial/knn/ball_cover_common.h>
 
@@ -27,12 +24,6 @@
 #include <raft/spatial/knn/specializations/knn.hpp>
 
 #include <cstdint>
-// Ignore upstream specializations to avoid unnecessary recompiling
-#include <raft/distance/specializations.hpp>
-#include <raft/spatial/knn/specializations/detail/ball_cover_lowdim.hpp>
-#include <raft/spatial/knn/specializations/fused_l2_knn.hpp>
-#include <raft/spatial/knn/specializations/knn.hpp>
-
 namespace raft {
 namespace spatial {
 namespace knn {


### PR DESCRIPTION
Looks like a few style errors slipped through in one of the last commits preventing other PR from passing their CI checks. This PR fixes that.