### PR TITLE
Improve row-major meanvar kernel via minimizing atomicCAS locks

### DIFF
--- a/cpp/test/stats/meanvar.cu
+++ b/cpp/test/stats/meanvar.cu
@@ -81,25 +81,18 @@ class MeanVarTest : public ::testing::TestWithParam<MeanVarInputs<T>> {
   rmm::device_uvector<T> data, mean_act, vars_act;
 };
 
-const std::vector<MeanVarInputs<float>> inputsf = {{1.f, 2.f, 1024, 32, true, false, 1234ULL},
-                                                   {1.f, 2.f, 1024, 64, true, false, 1234ULL},
-                                                   {1.f, 2.f, 1024, 128, true, false, 1234ULL},
-                                                   {1.f, 2.f, 1024, 256, true, false, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 32, false, false, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 64, false, false, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 128, false, false, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 256, false, false, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 256, false, false, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 257, false, false, 1234ULL},
-                                                   {1.f, 2.f, 1024, 32, true, true, 1234ULL},
-                                                   {1.f, 2.f, 1024, 64, true, true, 1234ULL},
-                                                   {1.f, 2.f, 1024, 128, true, true, 1234ULL},
-                                                   {1.f, 2.f, 1024, 256, true, true, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 32, false, true, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 64, false, true, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 128, false, true, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 256, false, true, 1234ULL},
-                                                   {-1.f, 2.f, 1024, 257, false, true, 1234ULL}};
+const std::vector<MeanVarInputs<float>> inputsf = {
+  {1.f, 2.f, 1024, 32, true, false, 1234ULL},    {1.f, 2.f, 1024, 64, true, false, 1234ULL},
+  {1.f, 2.f, 1024, 128, true, false, 1234ULL},   {1.f, 2.f, 1024, 256, true, false, 1234ULL},
+  {-1.f, 2.f, 1024, 32, false, false, 1234ULL},  {-1.f, 2.f, 1024, 64, false, false, 1234ULL},
+  {-1.f, 2.f, 1024, 128, false, false, 1234ULL}, {-1.f, 2.f, 1024, 256, false, false, 1234ULL},
+  {-1.f, 2.f, 1024, 256, false, false, 1234ULL}, {-1.f, 2.f, 1024, 257, false, false, 1234ULL},
+  {1.f, 2.f, 1024, 32, true, true, 1234ULL},     {1.f, 2.f, 1024, 64, true, true, 1234ULL},
+  {1.f, 2.f, 1024, 128, true, true, 1234ULL},    {1.f, 2.f, 1024, 256, true, true, 1234ULL},
+  {-1.f, 2.f, 1024, 32, false, true, 1234ULL},   {-1.f, 2.f, 1024, 64, false, true, 1234ULL},
+  {-1.f, 2.f, 1024, 128, false, true, 1234ULL},  {-1.f, 2.f, 1024, 256, false, true, 1234ULL},
+  {-1.f, 2.f, 1024, 257, false, true, 1234ULL},  {-1.f, 2.f, 700, 13, false, true, 1234ULL},
+  {10.f, 2.f, 500000, 811, false, true, 1234ULL}};
 
 const std::vector<MeanVarInputs<double>> inputsd = {{1.0, 2.0, 1024, 32, true, false, 1234ULL},
                                                     {1.0, 2.0, 1024, 64, true, false, 1234ULL},


### PR DESCRIPTION
Map the row-major kernel grid onto the data more efficiently. In particular, make sure there is only one `atomicCAS` lock per thread block to avoid any possible deadlocks caused by branch divergence within the critical section.