### PR TITLE
Call initialize() in mpi_comms_t constructor.

### DIFF
--- a/cpp/include/raft/comms/detail/mpi_comms.hpp
+++ b/cpp/include/raft/comms/detail/mpi_comms.hpp
@@ -127,6 +127,8 @@ class mpi_comms : public comms_iface {
 
     // initializing NCCL
     RAFT_NCCL_TRY(ncclCommInitRank(&nccl_comm_, size_, id, rank_));
+  
+    initialize();
   }
 
   void initialize()


### PR DESCRIPTION
initialize() call was missing in mpi_comms_t constructor. `buf_` didn't get properly initialized to `status_.data()`.