### PR TITLE
Use shfl_xor in warpReduce for broadcast

### DIFF
--- a/cpp/include/raft/cuda_utils.cuh
+++ b/cpp/include/raft/cuda_utils.cuh
@@ -652,18 +652,20 @@ DI T shfl_xor(T val, int laneMask, int width = WarpSize, uint32_t mask = 0xfffff
 /**
  * @brief Warp-level sum reduction
  * @param val input value
- * @return only the lane0 will contain valid reduced result
+ * @tparam T Value type to be reduced
+ * @tparam Broadcast Boolean flag to broadcast reduction value to all lanes
+ * @return only the lane0 will contain valid reduced result unless Broadcast is true
  * @note Why not cub? Because cub doesn't seem to allow working with arbitrary
  *       number of warps in a block. All threads in the warp must enter this
  *       function together
  * @todo Expand this to support arbitrary reduction ops
  */
-template <typename T>
+template <typename T, bool Broadcast = false>
 DI T warpReduce(T val)
 {
 #pragma unroll
   for (int i = WarpSize / 2; i > 0; i >>= 1) {
-    T tmp = shfl(val, laneId() + i);
+    T tmp = Broadcast ? shfl_xor(val, i) : shfl(val, laneId() + i);
     val += tmp;
   }
   return val;

--- a/cpp/include/raft/cuda_utils.cuh
+++ b/cpp/include/raft/cuda_utils.cuh
@@ -653,19 +653,18 @@ DI T shfl_xor(T val, int laneMask, int width = WarpSize, uint32_t mask = 0xfffff
  * @brief Warp-level sum reduction
  * @param val input value
  * @tparam T Value type to be reduced
- * @tparam Broadcast Boolean flag to broadcast reduction value to all lanes
- * @return only the lane0 will contain valid reduced result unless Broadcast is true
+ * @return Reduction result. All lanes will have the valid result.
  * @note Why not cub? Because cub doesn't seem to allow working with arbitrary
  *       number of warps in a block. All threads in the warp must enter this
  *       function together
  * @todo Expand this to support arbitrary reduction ops
  */
-template <typename T, bool Broadcast = false>
+template <typename T>
 DI T warpReduce(T val)
 {
 #pragma unroll
   for (int i = WarpSize / 2; i > 0; i >>= 1) {
-    T tmp = Broadcast ? shfl_xor(val, i) : shfl(val, laneId() + i);
+    T tmp = shfl_xor(val, i);
     val += tmp;
   }
   return val;


### PR DESCRIPTION
Some applications might need the reduction result in all lanes of the warp. To prevent executing additional shuffle operations after the reduction, it is better to have an option to do the shuffle during reduction. The implementation uses `shfl_xor` to keep the valid results across results at each step of the reduction. For >SM_80 devices we can consider implicit reduction operations [B.21. Warp Reduce Functions](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#warp-reduce-functions)