### PR TITLE
Increase parallelism in allgatherv

### DIFF
--- a/cpp/include/raft/comms/detail/mpi_comms.hpp
+++ b/cpp/include/raft/comms/detail/mpi_comms.hpp
@@ -277,6 +277,7 @@ class mpi_comms : public comms_iface {
   {
     // From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" -
     // https://arxiv.org/pdf/1812.05964.pdf Listing 1 on page 4.
+    RAFT_NCCL_TRY(ncclGroupStart());
     for (int root = 0; root < size_; ++root) {
       RAFT_NCCL_TRY(
         ncclBroadcast(sendbuf,
@@ -287,6 +288,7 @@ class mpi_comms : public comms_iface {
                       nccl_comm_,
                       stream));
     }
+    RAFT_NCCL_TRY(ncclGroupEnd());
   }
 
   void gather(const void* sendbuff,

--- a/cpp/include/raft/comms/detail/mpi_comms.hpp
+++ b/cpp/include/raft/comms/detail/mpi_comms.hpp
@@ -275,6 +275,8 @@ class mpi_comms : public comms_iface {
                   datatype_t datatype,
                   cudaStream_t stream) const
   {
+    RAFT_EXPECTS(size_ <= 2048,
+                 "# NCCL operations between ncclGroupStart & ncclGroupEnd shouldn't exceed 2048.");
     // From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" -
     // https://arxiv.org/pdf/1812.05964.pdf Listing 1 on page 4.
     RAFT_NCCL_TRY(ncclGroupStart());

--- a/cpp/include/raft/comms/detail/std_comms.hpp
+++ b/cpp/include/raft/comms/detail/std_comms.hpp
@@ -367,6 +367,7 @@ class std_comms : public comms_iface {
   {
     // From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" -
     // https://arxiv.org/pdf/1812.05964.pdf Listing 1 on page 4.
+    RAFT_NCCL_TRY(ncclGroupStart());
     for (int root = 0; root < num_ranks_; ++root) {
       size_t dtype_size = get_datatype_size(datatype);
       RAFT_NCCL_TRY(ncclBroadcast(sendbuf,
@@ -377,6 +378,7 @@ class std_comms : public comms_iface {
                                   nccl_comm_,
                                   stream));
     }
+    RAFT_NCCL_TRY(ncclGroupEnd());
   }
 
   void gather(const void* sendbuff,

--- a/cpp/include/raft/comms/detail/std_comms.hpp
+++ b/cpp/include/raft/comms/detail/std_comms.hpp
@@ -367,6 +367,8 @@ class std_comms : public comms_iface {
   {
     // From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" -
     // https://arxiv.org/pdf/1812.05964.pdf Listing 1 on page 4.
+    RAFT_EXPECTS(size_ <= 2048,
+                 "# NCCL operations between ncclGroupStart & ncclGroupEnd shouldn't exceed 2048.");
     RAFT_NCCL_TRY(ncclGroupStart());
     for (int root = 0; root < num_ranks_; ++root) {
       size_t dtype_size = get_datatype_size(datatype);

--- a/cpp/include/raft/comms/detail/std_comms.hpp
+++ b/cpp/include/raft/comms/detail/std_comms.hpp
@@ -367,7 +367,7 @@ class std_comms : public comms_iface {
   {
     // From: "An Empirical Evaluation of Allgatherv on Multi-GPU Systems" -
     // https://arxiv.org/pdf/1812.05964.pdf Listing 1 on page 4.
-    RAFT_EXPECTS(size_ <= 2048,
+    RAFT_EXPECTS(num_ranks_ <= 2048,
                  "# NCCL operations between ncclGroupStart & ncclGroupEnd shouldn't exceed 2048.");
     RAFT_NCCL_TRY(ncclGroupStart());
     for (int root = 0; root < num_ranks_; ++root) {


### PR DESCRIPTION
allgatherv is implemented using multiple NCCL broadcast operations.

Previously, RAFT performed these broadcast operations sequentially creating a hot-spot around the root node in each broadcast operations.

These PR places multiple broadcast operations inside ncclGroupStart and ncclGroupEnd increasing the parallelism and more evenly stressing the communication interconnect. 