### PR TITLE
find_package(raft) can now be called multiple times safely

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -328,7 +328,9 @@ Imported Targets:
 
 set(code_string
 [=[
-thrust_create_target(raft::Thrust FROM_OPTIONS)
+if(NOT TARGET raft::Thrust)
+  thrust_create_target(raft::Thrust FROM_OPTIONS)
+endif()
 
 if(distance IN_LIST raft_FIND_COMPONENTS)
   enable_language(CUDA)


### PR DESCRIPTION
Previously it would try to add the `raft::Thrust` target multiple times, causing a CMake error as the target already existed.

This is required as find_package(X) can be invoked any number of times and will execute the `X-config.cmake` each time.
