### PR TITLE
Updated dask and distributed to >=2022.02.1

### DIFF
--- a/conda/recipes/pyraft/meta.yaml
+++ b/conda/recipes/pyraft/meta.yaml
@@ -44,8 +44,8 @@ requirements:
     - rmm {{ minor_version }}
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
-    - dask>=2021.11.1,<=2021.11.2
-    - distributed>=2021.11.1,<=2022.01.0
+    - dask>=2022.02.1
+    - distributed>=2022.02.1
     - cuda-python >=11.5,<12.0
     - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
This updates pyraft to the version pins for dask and distributed to match those of other RAPIDS packages (cuml, cugraph, etc.)

cc @galipremsagar 