### PR TITLE
Don't generate a gtest-config for build directories

### DIFF
--- a/cpp/cmake/thirdparty/get_gtest.cmake
+++ b/cpp/cmake/thirdparty/get_gtest.cmake
@@ -17,19 +17,7 @@
 function(find_and_configure_gtest )
 
     include(${rapids-cmake-dir}/cpm/gtest.cmake)
-    rapids_cpm_gtest(BUILD_EXPORT_SET raft-exports
-                     EXCLUDE_FROM_ALL TRUE)
-
-    if(GTest_ADDED)
-        rapids_export(BUILD GTest
-          VERSION ${GTest_VERSION}
-          EXPORT_SET GTestTargets
-          GLOBAL_TARGETS gtest gmock gtest_main gmock_main
-          NAMESPACE GTest::)
-
-        include("${rapids-cmake-dir}/export/find_package_root.cmake")
-        rapids_export_find_package_root(BUILD GTest [=[${CMAKE_CURRENT_LIST_DIR}]=] raft-exports)
-    endif()
+    rapids_cpm_gtest(EXCLUDE_FROM_ALL TRUE)
 
 endfunction()
 


### PR DESCRIPTION
Since the install rules are disabled due to not being in an install tree we need to also remove the build directory logic
