### PR TITLE
[FIX] Don't add gtest to build export set or generate a gtest-config.cmake

### DIFF
--- a/cpp/cmake/thirdparty/get_gtest.cmake
+++ b/cpp/cmake/thirdparty/get_gtest.cmake
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (c) 2021, NVIDIA CORPORATION.
+# Copyright (c) 2021-2022, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cpp/cmake/thirdparty/get_gtest.cmake
+++ b/cpp/cmake/thirdparty/get_gtest.cmake
@@ -15,22 +15,8 @@
 #=============================================================================
 
 function(find_and_configure_gtest )
-
     include(${rapids-cmake-dir}/cpm/gtest.cmake)
-    rapids_cpm_gtest(BUILD_EXPORT_SET raft-exports
-                     EXCLUDE_FROM_ALL TRUE)
-
-    if(GTest_ADDED)
-        rapids_export(BUILD GTest
-          VERSION ${GTest_VERSION}
-          EXPORT_SET GTestTargets
-          GLOBAL_TARGETS gtest gmock gtest_main gmock_main
-          NAMESPACE GTest::)
-
-        include("${rapids-cmake-dir}/export/find_package_root.cmake")
-        rapids_export_find_package_root(BUILD GTest [=[${CMAKE_CURRENT_LIST_DIR}]=] raft-exports)
-    endif()
-
+    rapids_cpm_gtest()
 endfunction()
 
 find_and_configure_gtest()


### PR DESCRIPTION
Fixes errors configuring RAFT now that rapids-cmake [is enforcing](https://github.com/rapidsai/rapids-cmake/pull/168) GTest v1.10.0.