### PR TITLE
[REVIEW] Add missing thrust includes to transpose.cuh

### DIFF
--- a/cpp/include/raft/linalg/detail/transpose.cuh
+++ b/cpp/include/raft/linalg/detail/transpose.cuh
@@ -20,6 +20,8 @@
 
 #include <raft/handle.hpp>
 #include <rmm/exec_policy.hpp>
+#include <thrust/for_each.h>
+#include <thrust/iterator/counting_iterator.h>
 
 namespace raft {
 namespace linalg {


### PR DESCRIPTION
Including `raft/linalg/transpose.cuh` appears to work today, but a few weeks ago it didn't because of these missing includes. Either way, these should be here because they're used.

I can't figure out how to get include-what-you-use to process .cuh files, but that would be a nice check for all of the RAPIDS repos.