### PR TITLE
[FIX] Link to `cuco` and add faiss `EXCLUDE_FROM_ALL` option

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -33,6 +33,9 @@ project(RAFT VERSION 22.04.00 LANGUAGES CXX CUDA)
 # `Threads::Threads` is the same value in first run and subsequent runs.
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
+# Write the version header
+rapids_cmake_write_version_file(include/raft/version_config.hpp)
+
 ##############################################################################
 # - build type ---------------------------------------------------------------
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -28,6 +28,11 @@ rapids_cuda_init_architectures(RAFT)
 
 project(RAFT VERSION 22.04.00 LANGUAGES CXX CUDA)
 
+# Needed because GoogleBenchmark changes the state of FindThreads.cmake, causing subsequent runs to
+# have different values for the `Threads::Threads` target. Setting this flag ensures
+# `Threads::Threads` is the same value in first run and subsequent runs.
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
 ##############################################################################
 # - build type ---------------------------------------------------------------
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -70,6 +70,8 @@ option(RAFT_ENABLE_cuco_DEPENDENCY "Enable cuCollections dependency" ON)
 option(RAFT_ENABLE_nccl_DEPENDENCY "Enable NCCL dependency" OFF)
 option(RAFT_ENABLE_ucx_DEPENDENCY "Enable ucx dependency" OFF)
 
+option(RAFT_EXCLUDE_FAISS_FROM_ALL "Exclude FAISS targets from RAFT's 'all' target" ON)
+
 include(CMakeDependentOption)
 cmake_dependent_option(RAFT_USE_FAISS_STATIC "Build and statically link the FAISS library for nearest neighbors search on GPU" ON RAFT_COMPILE_LIBRARIES OFF)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -158,7 +158,7 @@ target_link_libraries(raft INTERFACE
         CUDA::cudart
         CUDA::cusparse
         rmm::rmm
-        $<$<BOOL:${cuco_ADDED}>:cuco::cuco>
+        $<$<BOOL:${RAFT_ENABLE_cuco_DEPENDENCY}>:cuco::cuco>
         std::mdspan)
 
 target_compile_definitions(raft INTERFACE $<$<BOOL:${NVTX}>:NVTX_ENABLED>)

--- a/cpp/cmake/thirdparty/get_faiss.cmake
+++ b/cpp/cmake/thirdparty/get_faiss.cmake
@@ -15,7 +15,7 @@
 #=============================================================================
 
 function(find_and_configure_faiss)
-    set(oneValueArgs VERSION PINNED_TAG BUILD_STATIC_LIBS)
+    set(oneValueArgs VERSION PINNED_TAG BUILD_STATIC_LIBS EXCLUDE_FROM_ALL)
     cmake_parse_arguments(PKG "${options}" "${oneValueArgs}"
                           "${multiValueArgs}" ${ARGN} )
 
@@ -36,7 +36,7 @@ function(find_and_configure_faiss)
           CPM_ARGS
             GIT_REPOSITORY   https://github.com/facebookresearch/faiss.git
             GIT_TAG          ${PKG_PINNED_TAG}
-            EXCLUDE_FROM_ALL TRUE
+            EXCLUDE_FROM_ALL ${PKG_EXCLUDE_FROM_ALL}
             OPTIONS
               "FAISS_ENABLE_PYTHON OFF"
               "CUDAToolkit_ROOT ${CUDAToolkit_LIBRARY_DIR}"
@@ -69,4 +69,5 @@ endfunction()
 
 find_and_configure_faiss(VERSION    1.7.0
                          PINNED_TAG  bde7c0027191f29c9dadafe4f6e68ca0ee31fb30
-                         BUILD_STATIC_LIBS ${RAFT_USE_FAISS_STATIC})
+                         BUILD_STATIC_LIBS ${RAFT_USE_FAISS_STATIC}
+                         EXCLUDE_FROM_ALL ${RAFT_EXCLUDE_FAISS_FROM_ALL})


### PR DESCRIPTION
This PR includes a few fixes to support source-only builds:
1. Defines linkage to `cuco::cuco` if the `RAFT_ENABLE_cuco_DEPENDENCY` variable is set, not if `cuco_ADDED` is true
2. Adds a flag to control the `EXCLUDE_FROM_ALL` for the faiss dependency. This flag can be off for conda builds, but true for C++-only source builds
3. Writes `version_config.hpp` header and fixes a potential GoogleBench issue