### PR TITLE
Making mdspan and thrust optional and turning off compile libraries by default

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -64,9 +64,12 @@ option(RAFT_COMPILE_NN_LIBRARY "Enable building raft nearest neighbors shared li
 option(RAFT_COMPILE_DIST_LIBRARY "Enable building raft distant shared library instantiations" OFF)
 option(RAFT_ENABLE_NN_DEPENDENCIES "Search for raft::nn dependencies like faiss" ${RAFT_COMPILE_LIBRARIES})
 
-option(RAFT_ENABLE_cuco_DEPENDENCY "Enable cuCollections dependency" ON)
+option(RAFT_ENABLE_cuco_DEPENDENCY "Enable cuCollections dependency" OFF)
 option(RAFT_ENABLE_mdspan_DEPENDENCY "Enable mdspan dependency" ON)
 option(RAFT_ENABLE_thrust_DEPENDENCY "Enable Thrust dependency" ON)
+if(raft IN_LIST raft_FIND_COMPONENTS)
+  set(RAFT_ENABLE_cuco_DEPENDENCY ON)
+endif()
 
 # Currently, UCX and NCCL are only needed to build Pyraft and so a simple find_package() is sufficient
 option(RAFT_ENABLE_nccl_DEPENDENCY "Enable NCCL dependency" OFF)
@@ -77,6 +80,7 @@ option(RAFT_EXCLUDE_FAISS_FROM_ALL "Exclude FAISS targets from RAFT's 'all' targ
 include(CMakeDependentOption)
 cmake_dependent_option(RAFT_USE_FAISS_STATIC "Build and statically link the FAISS library for nearest neighbors search on GPU" ON RAFT_COMPILE_LIBRARIES OFF)
 
+message(VERBOSE "RAFT: Building optional components: ${raft_FIND_COMPONENTS}")
 message(VERBOSE "RAFT: Build RAFT unit-tests: ${BUILD_TESTS}")
 message(VERBOSE "RAFT: Building raft C++ benchmarks: ${BUILD_BENCH}")
 message(VERBOSE "RAFT: Enable detection of conda environment for dependencies: ${DETECT_CONDA_ENV}")
@@ -153,6 +157,9 @@ target_include_directories(raft INTERFACE
         "$<BUILD_INTERFACE:${RAFT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:include>")
 
+# Keep RAFT as lightweight as possible.
+# Only CUDA libs, rmm, and mdspan should
+# be used in global target.
 target_link_libraries(raft INTERFACE
         $<$<BOOL:${NVTX}>:CUDA::nvToolsExt>
         CUDA::cublas
@@ -246,6 +253,7 @@ endif()
 
 target_link_libraries(raft_distance INTERFACE
     raft::raft
+    $<$<BOOL:${RAFT_ENABLE_cuco_DEPENDENCY}>:cuco::cuco>
     $<TARGET_NAME_IF_EXISTS:raft_distance_lib>
     $<TARGET_NAME_IF_EXISTS:raft::raft_distance_lib>
 )
@@ -289,6 +297,7 @@ endif()
 
 target_link_libraries(raft_nn INTERFACE
     raft::raft
+    $<$<BOOL:${RAFT_ENABLE_NN_DEPENDENCIES}>:faiss::faiss>
     $<TARGET_NAME_IF_EXISTS:raft_nn_lib>
     $<TARGET_NAME_IF_EXISTS:raft::raft_nn_lib>)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -48,7 +48,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 ##############################################################################
 # - User Options  ------------------------------------------------------------
 
-option(BUILD_TESTS "Build raft unit-tests" OFF)
+option(BUILD_TESTS "Build raft unit-tests" ON)
 option(BUILD_BENCH "Build raft C++ benchmark tests" OFF)
 option(CUDA_ENABLE_KERNELINFO "Enable kernel resource usage info" OFF)
 option(CUDA_ENABLE_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler)" OFF)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -154,7 +154,6 @@ target_include_directories(raft INTERFACE
         "$<INSTALL_INTERFACE:include>")
 
 target_link_libraries(raft INTERFACE
-        $<$<BOOL:${RAFT_ENABLE_cuco_DEPENDENCY}>:raft::Thrust>
         $<$<BOOL:${NVTX}>:CUDA::nvToolsExt>
         CUDA::cublas
         CUDA::curand
@@ -162,6 +161,7 @@ target_link_libraries(raft INTERFACE
         CUDA::cudart
         CUDA::cusparse
         rmm::rmm
+        $<$<BOOL:${RAFT_ENABLE_thrust_DEPENDENCY}>:raft::Thrust>
         $<$<BOOL:${RAFT_ENABLE_cuco_DEPENDENCY}>:cuco::cuco>
         $<$<BOOL:${RAFT_ENABLE_mdspan_DEPENDENCY}>:std::mdspan>
 )

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -48,7 +48,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 ##############################################################################
 # - User Options  ------------------------------------------------------------
 
-option(BUILD_TESTS "Build raft unit-tests" ON)
+option(BUILD_TESTS "Build raft unit-tests" OFF)
 option(BUILD_BENCH "Build raft C++ benchmark tests" OFF)
 option(CUDA_ENABLE_KERNELINFO "Enable kernel resource usage info" OFF)
 option(CUDA_ENABLE_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler)" OFF)
@@ -59,12 +59,14 @@ option(DISABLE_OPENMP "Disable OpenMP" OFF)
 option(NVTX "Enable nvtx markers" OFF)
 option(RAFT_STATIC_LINK_LIBRARIES "Statically link compiled libraft libraries")
 
-option(RAFT_COMPILE_LIBRARIES "Enable building raft shared library instantiations" ON)
+option(RAFT_COMPILE_LIBRARIES "Enable building raft shared library instantiations" OFF)
 option(RAFT_COMPILE_NN_LIBRARY "Enable building raft nearest neighbors shared library instantiations" OFF)
 option(RAFT_COMPILE_DIST_LIBRARY "Enable building raft distant shared library instantiations" OFF)
 option(RAFT_ENABLE_NN_DEPENDENCIES "Search for raft::nn dependencies like faiss" ${RAFT_COMPILE_LIBRARIES})
 
 option(RAFT_ENABLE_cuco_DEPENDENCY "Enable cuCollections dependency" ON)
+option(RAFT_ENABLE_mdspan_DEPENDENCY "Enable mdspan dependency" ON)
+option(RAFT_ENABLE_thrust_DEPENDENCY "Enable Thrust dependency" ON)
 
 # Currently, UCX and NCCL are only needed to build Pyraft and so a simple find_package() is sufficient
 option(RAFT_ENABLE_nccl_DEPENDENCY "Enable NCCL dependency" OFF)
@@ -152,7 +154,7 @@ target_include_directories(raft INTERFACE
         "$<INSTALL_INTERFACE:include>")
 
 target_link_libraries(raft INTERFACE
-        raft::Thrust
+        $<$<BOOL:${RAFT_ENABLE_cuco_DEPENDENCY}>:raft::Thrust>
         $<$<BOOL:${NVTX}>:CUDA::nvToolsExt>
         CUDA::cublas
         CUDA::curand
@@ -161,7 +163,8 @@ target_link_libraries(raft INTERFACE
         CUDA::cusparse
         rmm::rmm
         $<$<BOOL:${RAFT_ENABLE_cuco_DEPENDENCY}>:cuco::cuco>
-        std::mdspan)
+        $<$<BOOL:${RAFT_ENABLE_mdspan_DEPENDENCY}>:std::mdspan>
+)
 
 target_compile_definitions(raft INTERFACE $<$<BOOL:${NVTX}>:NVTX_ENABLED>)
 target_compile_features(raft INTERFACE cxx_std_17 $<BUILD_INTERFACE:cuda_std_17>)
@@ -349,7 +352,7 @@ Imported Targets:
 set(code_string
 [=[
 
-if(NOT TARGET raft::Thrust)
+if(RAFT_ENABLE_thrust_DEPENDENCY AND NOT TARGET raft::Thrust)
   thrust_create_target(raft::Thrust FROM_OPTIONS)
 endif()
 

--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -16,11 +16,12 @@
 
 function(find_and_configure_cuco VERSION)
 
-    if(RAFT_ENABLE_cuco_DEPENDENCY)
+    if(RAFT_ENABLE_cuco_DEPENDENCY OR RAFT_COMPILE_LIBRARIES OR
+            RAFT_COMPILE_DIST_LIBRARY)
         rapids_cpm_find(cuco ${VERSION}
           GLOBAL_TARGETS      cuco::cuco
-          BUILD_EXPORT_SET    raft-exports
-          INSTALL_EXPORT_SET  raft-exports
+          BUILD_EXPORT_SET    raft-distance-exports
+          INSTALL_EXPORT_SET  raft-distance-exports
           CPM_ARGS
             GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
             GIT_TAG        0ca860b824f5dc22cf8a41f09912e62e11f07d82

--- a/cpp/cmake/thirdparty/get_mdspan.cmake
+++ b/cpp/cmake/thirdparty/get_mdspan.cmake
@@ -13,17 +13,19 @@
 # =============================================================================
 
 function(find_and_configure_mdspan VERSION)
-  rapids_cpm_find(
-    mdspan ${VERSION}
-    GLOBAL_TARGETS std::mdspan
-    BUILD_EXPORT_SET    raft-exports
-    INSTALL_EXPORT_SET  raft-exports
-    CPM_ARGS
-      GIT_REPOSITORY https://github.com/rapidsai/mdspan.git
-      GIT_TAG b3042485358d2ee168ae2b486c98c2c61ec5aec1
-      OPTIONS "MDSPAN_ENABLE_CUDA ON"
-              "MDSPAN_CXX_STANDARD ON"
-  )
+  if(RAFT_ENABLE_mdspan_DEPENDENCY)
+    rapids_cpm_find(
+      mdspan ${VERSION}
+      GLOBAL_TARGETS std::mdspan
+      BUILD_EXPORT_SET    raft-exports
+      INSTALL_EXPORT_SET  raft-exports
+      CPM_ARGS
+        GIT_REPOSITORY https://github.com/rapidsai/mdspan.git
+        GIT_TAG b3042485358d2ee168ae2b486c98c2c61ec5aec1
+        OPTIONS "MDSPAN_ENABLE_CUDA ON"
+                "MDSPAN_CXX_STANDARD ON"
+    )
+  endif()
 endfunction()
 
 find_and_configure_mdspan(0.2.0)

--- a/cpp/cmake/thirdparty/get_thrust.cmake
+++ b/cpp/cmake/thirdparty/get_thrust.cmake
@@ -14,11 +14,13 @@
 
 # Use CPM to find or clone thrust
 function(find_and_configure_thrust)
-    include(${rapids-cmake-dir}/cpm/thrust.cmake)
+    if(RAFT_ENABLE_thrust_DEPENDENCY)
+        include(${rapids-cmake-dir}/cpm/thrust.cmake)
 
-    rapids_cpm_thrust( NAMESPACE raft
-                       BUILD_EXPORT_SET raft-exports
-                       INSTALL_EXPORT_SET raft-exports)
+        rapids_cpm_thrust( NAMESPACE raft
+                           BUILD_EXPORT_SET raft-exports
+                           INSTALL_EXPORT_SET raft-exports)
+    endif()
 endfunction()
 
 find_and_configure_thrust()

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -164,7 +164,6 @@ target_link_libraries(test_raft
         raft::raft
         raft::distance
         raft::nn
-        faiss::faiss
         GTest::gtest
         GTest::gtest_main
         Threads::Threads

--- a/cpp/test/spatial/fused_l2_knn.cu
+++ b/cpp/test/spatial/fused_l2_knn.cu
@@ -25,6 +25,10 @@
 #include <raft/spatial/knn/detail/fused_l2_knn.cuh>
 #include <raft/spatial/knn/knn.cuh>
 
+#if defined RAFT_NN_COMPILED
+#include <raft/spatial/knn/specializations.cuh>
+#endif
+
 #include <rmm/device_buffer.hpp>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
Changing the default options to not compile the shared libs by default. Also allowing Thrust and mdspan dependencies to be turned off for easier header-only integration when those aren't needed. 