### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -23,7 +23,7 @@ function(find_and_configure_cuco VERSION)
           INSTALL_EXPORT_SET  raft-exports
           CPM_ARGS
             GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
-            GIT_TAG        0ca860b824f5dc22cf8a41f09912e62e11f07d82
+            GIT_TAG        6ec8b6dcdeceea07ab4456d32461a05c18864411
             OPTIONS        "BUILD_TESTS OFF"
                            "BUILD_BENCHMARKS OFF"
                            "BUILD_EXAMPLES OFF"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.