### PR TITLE
[FEA] Enable building static libs

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -58,7 +58,6 @@ option(DETECT_CONDA_ENV "Enable detection of conda environment for dependencies"
 option(DISABLE_DEPRECATION_WARNINGS "Disable depreaction warnings " ON)
 option(DISABLE_OPENMP "Disable OpenMP" OFF)
 option(NVTX "Enable nvtx markers" OFF)
-option(RAFT_STATIC_LINK_LIBRARIES "Statically link compiled libraft libraries")
 
 option(RAFT_COMPILE_LIBRARIES "Enable building raft shared library instantiations" ON)
 option(RAFT_COMPILE_NN_LIBRARY "Enable building raft nearest neighbors shared library instantiations" OFF)
@@ -178,11 +177,6 @@ SECTIONS
 ]=])
 endif()
 
-set(RAFT_LIB_TYPE SHARED)
-if(${RAFT_STATIC_LINK_LIBRARIES})
-  set(RAFT_LIB_TYPE STATIC)
-endif()
-
 ##############################################################################
 # - raft_distance ------------------------------------------------------------
 add_library(raft_distance INTERFACE)
@@ -194,7 +188,7 @@ endif()
 set_target_properties(raft_distance PROPERTIES EXPORT_NAME distance)
 
 if(RAFT_COMPILE_LIBRARIES OR RAFT_COMPILE_DIST_LIBRARY)
-  add_library(raft_distance_lib ${RAFT_LIB_TYPE}
+  add_library(raft_distance_lib
     src/distance/pairwise_distance.cu
     src/distance/specializations/detail/canberra.cu
     src/distance/specializations/detail/chebyshev.cu
@@ -227,7 +221,17 @@ if(RAFT_COMPILE_LIBRARIES OR RAFT_COMPILE_DIST_LIBRARY)
     src/distance/specializations/detail/lp_unexpanded_float_float_float_uint32.cu
     src/distance/specializations/detail/lp_unexpanded_float_float_float_int.cu
   )
-  set_target_properties(raft_distance_lib PROPERTIES OUTPUT_NAME raft_distance)
+  set_target_properties(
+    raft_distance_lib
+    PROPERTIES OUTPUT_NAME                         raft_distance
+               BUILD_RPATH                         "\$ORIGIN"
+               INSTALL_RPATH                       "\$ORIGIN"
+               CXX_STANDARD                        17
+               CXX_STANDARD_REQUIRED               ON
+               CUDA_STANDARD                       17
+               CUDA_STANDARD_REQUIRED              ON
+               POSITION_INDEPENDENT_CODE           ON
+               INTERFACE_POSITION_INDEPENDENT_CODE ON)
 
   target_link_libraries(raft_distance_lib PRIVATE raft::raft)
   target_compile_options(raft_distance_lib
@@ -259,7 +263,7 @@ endif()
 set_target_properties(raft_nn PROPERTIES EXPORT_NAME nn)
 
 if(RAFT_COMPILE_LIBRARIES OR RAFT_COMPILE_NN_LIBRARY)
-  add_library(raft_nn_lib ${RAFT_LIB_TYPE}
+  add_library(raft_nn_lib
           src/nn/specializations/ball_cover.cu
           src/nn/specializations/detail/ball_cover_lowdim_pass_one_2d.cu
           src/nn/specializations/detail/ball_cover_lowdim_pass_two_2d.cu
@@ -271,7 +275,17 @@ if(RAFT_COMPILE_LIBRARIES OR RAFT_COMPILE_NN_LIBRARY)
           src/nn/specializations/fused_l2_knn_int_float_false.cu
           src/nn/specializations/knn.cu
           )
-  set_target_properties(raft_nn_lib PROPERTIES OUTPUT_NAME raft_nn)
+  set_target_properties(
+    raft_nn_lib
+    PROPERTIES OUTPUT_NAME                         raft_nn
+               BUILD_RPATH                         "\$ORIGIN"
+               INSTALL_RPATH                       "\$ORIGIN"
+               CXX_STANDARD                        17
+               CXX_STANDARD_REQUIRED               ON
+               CUDA_STANDARD                       17
+               CUDA_STANDARD_REQUIRED              ON
+               POSITION_INDEPENDENT_CODE           ON
+               INTERFACE_POSITION_INDEPENDENT_CODE ON)
 
   target_link_libraries(raft_nn_lib PUBLIC faiss::faiss PRIVATE raft::raft)
   target_compile_options(raft_nn_lib

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 ##############################################################################
 # - User Options  ------------------------------------------------------------
 
+option(BUILD_SHARED_LIBS "Build raft shared libraries" ON)
 option(BUILD_TESTS "Build raft unit-tests" ON)
 option(BUILD_BENCH "Build raft C++ benchmark tests" OFF)
 option(CUDA_ENABLE_KERNELINFO "Enable kernel resource usage info" OFF)

--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -26,6 +26,8 @@ endif()
 list(APPEND RAFT_CUDA_FLAGS --expt-extended-lambda --expt-relaxed-constexpr)
 list(APPEND RAFT_CXX_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
 list(APPEND RAFT_CUDA_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
+# make sure we produce smallest binary size
+list(APPEND RAFT_CUDA_FLAGS -Xfatbin=-compress-all)
 
 # set warnings as errors
 if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2.0)

--- a/cpp/cmake/thirdparty/get_cuco.cmake
+++ b/cpp/cmake/thirdparty/get_cuco.cmake
@@ -23,7 +23,7 @@ function(find_and_configure_cuco VERSION)
           INSTALL_EXPORT_SET  raft-exports
           CPM_ARGS
             GIT_REPOSITORY https://github.com/NVIDIA/cuCollections.git
-            GIT_TAG        6ec8b6dcdeceea07ab4456d32461a05c18864411
+            GIT_TAG        fb58a38701f1c24ecfe07d8f1f208bbe80930da5
             OPTIONS        "BUILD_TESTS OFF"
                            "BUILD_BENCHMARKS OFF"
                            "BUILD_EXAMPLES OFF"
@@ -33,4 +33,4 @@ function(find_and_configure_cuco VERSION)
 endfunction()
 
 # cuCollections doesn't have a version yet
-find_and_configure_cuco(0.0)
+find_and_configure_cuco(0.0.1)


### PR DESCRIPTION
This PR allows building libcugraphops static libs via CMake option [`-DBUILD_SHARED_LIBS=ON|OFF`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).

~I was seeing a linker error due to not having `-fPIC` enabled, but I wouldn't have expected this to affect static libs. I'll investigate some more and turn it off if possible, but for now `-fPIC` is enabled.~