### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/conda/recipes/libraft_distance/meta.yaml
+++ b/conda/recipes/libraft_distance/meta.yaml
@@ -36,7 +36,7 @@ build:
 
 requirements:
   build:
-    - cmake>=3.20.1
+    - cmake>=3.20.1,<3.23
   host:
     - libraft-headers {{ version }}
     - nccl>=2.9.9

--- a/conda/recipes/libraft_headers/meta.yaml
+++ b/conda/recipes/libraft_headers/meta.yaml
@@ -36,7 +36,7 @@ build:
 
 requirements:
   build:
-    - cmake>=3.20.1
+    - cmake>=3.20.1,<3.23
   host:
     - nccl>=2.9.9
     - cudatoolkit {{ cuda_version }}.*

--- a/conda/recipes/libraft_nn/meta.yaml
+++ b/conda/recipes/libraft_nn/meta.yaml
@@ -36,7 +36,7 @@ build:
 
 requirements:
   build:
-    - cmake>=3.20.1
+    - cmake>=3.20.1,<3.23
   host:
     - libraft-headers {{ version }}
     - cudatoolkit {{ cuda_version }}.*


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.