### PR TITLE
Only run doc builds for x86_64 [skip-ci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -63,8 +63,12 @@ gpuci_mamba_retry install -y -c conda-forge -c rapidsai -c rapidsai-nightly -c n
       "dask-cuda=${MINOR_VERSION}" \
       "ucx-py=${UCX_PY_VERSION}" \
       "rapids-build-env=${MINOR_VERSION}.*" \
-      "rapids-notebook-env=${MINOR_VERSION}.*" \
-      "rapids-doc-env=${MINOR_VERSION}.*"
+      "rapids-notebook-env=${MINOR_VERSION}.*"
+
+if [ "$(arch)" = "x86_64" ]; then
+    gpuci_mamba_retry install -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+        "rapids-doc-env=${MINOR_VERSION}.*"
+fi
 
 # Install the master version of dask, distributed, and dask-ml
 gpuci_logger "Install the master version of dask and distributed"
@@ -134,5 +138,7 @@ gpuci_logger "Python pytest for pylibraft"
 cd "$WORKSPACE/python/pylibraft"
 python -m pytest --cache-clear --junitxml="$WORKSPACE/junit-pylibraft.xml" -v -s
 
-gpuci_logger "Building docs"
-"$WORKSPACE/build.sh" docs -v
+if [ "$(arch)" = "x86_64" ]; then
+  gpuci_logger "Building docs"
+  "$WORKSPACE/build.sh" docs -v
+fi


### PR DESCRIPTION
We don't have arm64 packages for `rapids-doc-env`, so only run the doc builds for x86_64