### PR TITLE
Enable components installation using CMake

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -330,36 +330,45 @@ include(CPack)
 
 install(TARGETS raft
         DESTINATION ${lib_dir}
+        COMPONENT raft
         EXPORT raft-exports)
 
 install(TARGETS raft_distance
         DESTINATION ${lib_dir}
+        COMPONENT raft_distance
         EXPORT raft-distance-exports)
+
 install(TARGETS raft_nn
         DESTINATION ${lib_dir}
+        COMPONENT raft_nn
         EXPORT raft-nn-exports)
 
 if(TARGET raft_distance_lib)
   install(TARGETS raft_distance_lib
           DESTINATION ${lib_dir}
+          COMPONENT raft_distance
           EXPORT raft-distance-lib-exports)
 endif()
 
 if(TARGET raft_nn_lib)
   install(TARGETS raft_nn_lib
           DESTINATION ${lib_dir}
+          COMPONENT raft_nn
           EXPORT raft-nn-lib-exports)
 endif()
 
 
 install(DIRECTORY include/raft
+        COMPONENT raft
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Temporary install of raft.hpp while the file is removed
 install(FILES include/raft.hpp
+        COMPONENT raft
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/raft)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/raft/version_config.hpp
+        COMPONENT raft
         DESTINATION include/raft)
 
 ##############################################################################
@@ -435,19 +444,23 @@ raft_export(BUILD raft
 include("${rapids-cmake-dir}/export/write_dependencies.cmake")
 
 set(raft_components distance nn)
+set(raft_install_comp distance nn)
 if(TARGET raft_distance_lib)
   list(APPEND raft_components distance-lib)
+  list(APPEND raft_install_comp distance)
 endif()
 if(TARGET raft_nn_lib)
   list(APPEND raft_components  nn-lib)
+  list(APPEND raft_install_comp nn)
 endif()
 
-foreach(comp IN LISTS raft_components)
+foreach(comp install_comp IN ZIP_LISTS raft_components raft_install_comp)
   install(
           EXPORT raft-${comp}-exports
           FILE raft-${comp}-targets.cmake
           NAMESPACE raft::
           DESTINATION "${lib_dir}/cmake/raft"
+          COMPONENT raft_${install_comp}
   )
   export(
           EXPORT raft-${comp}-exports
@@ -458,7 +471,7 @@ foreach(comp IN LISTS raft_components)
           BUILD raft-${comp}-exports "${PROJECT_BINARY_DIR}/raft-${comp}-dependencies.cmake"
   )
   rapids_export_write_dependencies(
-          INSTALL raft-${comp}-exports "${PROJECT_BINARY_DIR}/rapids-cmake/raft/export/raft-${comp}-dependencies.cmake"
+          INSTALL raft-${comp}-exports "${PROJECT_BINARY_DIR}/rapids-cmake/raft/export/${install_comp}/raft-${comp}-dependencies.cmake"
   )
 
 endforeach()

--- a/cpp/cmake/modules/raft_export.cmake
+++ b/cpp/cmake/modules/raft_export.cmake
@@ -172,7 +172,7 @@ function(raft_export type project_name)
     rapids_cmake_install_lib_dir(install_location)
     set(install_location "${install_location}/cmake/${project_name}")
 
-    set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export")
+    set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export/raft/")
 
     configure_package_config_file("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/config.cmake.in"
             "${scratch_dir}/${project_name}-config.cmake"
@@ -185,7 +185,8 @@ function(raft_export type project_name)
     endif()
 
     install(EXPORT ${RAPIDS_EXPORT_SET} FILE ${project_name}-targets.cmake
-            NAMESPACE ${RAPIDS_PROJECT_VERSION} DESTINATION "${install_location}")
+            NAMESPACE ${RAPIDS_PROJECT_VERSION} DESTINATION "${install_location}"
+            COMPONENT raft)
 
     if(TARGET rapids_export_install_${RAPIDS_EXPORT_SET})
       include("${rapids-cmake-dir}/export/write_dependencies.cmake")
@@ -202,7 +203,13 @@ function(raft_export type project_name)
     endif()
 
     # Install everything we have generated
-    install(DIRECTORY "${scratch_dir}/" DESTINATION "${install_location}")
+    install(DIRECTORY "${scratch_dir}/" DESTINATION "${install_location}"
+            COMPONENT raft)
+    foreach(comp nn distance)
+      set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export/${comp}/")
+      install(DIRECTORY "${scratch_dir}" DESTINATION "${install_location}"
+        COMPONENT raft_${comp})
+    endforeach()
 
   else()
     set(install_location "${PROJECT_BINARY_DIR}")

--- a/cpp/cmake/modules/raft_export.cmake
+++ b/cpp/cmake/modules/raft_export.cmake
@@ -207,6 +207,7 @@ function(raft_export type project_name)
             COMPONENT raft)
     foreach(comp nn distance)
       set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export/${comp}/")
+      file(MAKE_DIRECTORY "${scratch_dir}")
       install(DIRECTORY "${scratch_dir}" DESTINATION "${install_location}"
         COMPONENT raft_${comp})
     endforeach()


### PR DESCRIPTION
Enable components installation using CMake. This feature will be used to merge all CPP conda recipes into one, doing a top level build for all the libs, and only installing the right component while packaging.