### PR TITLE
[BUG] RNG API fixes

### DIFF
--- a/cpp/include/raft/random/detail/rng_device.cuh
+++ b/cpp/include/raft/random/detail/rng_device.cuh
@@ -29,19 +29,12 @@ namespace raft {
 namespace random {
 namespace detail {
 
-#if defined(__RNG_H_INCLUSION_DEPRECATED)
-#define POTENTIAL_DEPR \
-  [[deprecated("Include raft/random/rng_device.cuh to use the device-only API")]]
-#else
-#define POTENTIAL_DEPR
-#endif
-
 /**
  * The device state used to communicate RNG state from host to device.
  * As of now, it is just a templated version of `RngState`.
  */
 template <typename GenType>
-struct POTENTIAL_DEPR DeviceState {
+struct DeviceState {
   using gen_t                    = GenType;
   static constexpr auto GEN_TYPE = gen_t::GEN_TYPE;
 
@@ -55,37 +48,37 @@ struct POTENTIAL_DEPR DeviceState {
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR InvariantDistParams {
+struct InvariantDistParams {
   OutType const_val;
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR UniformDistParams {
+struct UniformDistParams {
   OutType start;
   OutType end;
 };
 
 template <typename OutType, typename DiffType>
-struct POTENTIAL_DEPR UniformIntDistParams {
+struct UniformIntDistParams {
   OutType start;
   OutType end;
   DiffType diff;
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR NormalDistParams {
+struct NormalDistParams {
   OutType mu;
   OutType sigma;
 };
 
 template <typename IntType>
-struct POTENTIAL_DEPR NormalIntDistParams {
+struct NormalIntDistParams {
   IntType mu;
   IntType sigma;
 };
 
 template <typename OutType, typename LenType>
-struct POTENTIAL_DEPR NormalTableDistParams {
+struct NormalTableDistParams {
   LenType n_rows;
   LenType n_cols;
   const OutType* mu_vec;
@@ -94,60 +87,59 @@ struct POTENTIAL_DEPR NormalTableDistParams {
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR BernoulliDistParams {
+struct BernoulliDistParams {
   OutType prob;
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR ScaledBernoulliDistParams {
+struct ScaledBernoulliDistParams {
   OutType prob;
   OutType scale;
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR GumbelDistParams {
+struct GumbelDistParams {
   OutType mu;
   OutType beta;
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR LogNormalDistParams {
+struct LogNormalDistParams {
   OutType mu;
   OutType sigma;
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR LogisticDistParams {
+struct LogisticDistParams {
   OutType mu;
   OutType scale;
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR ExponentialDistParams {
+struct ExponentialDistParams {
   OutType lambda;
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR RayleighDistParams {
+struct RayleighDistParams {
   OutType sigma;
 };
 
 template <typename OutType>
-struct POTENTIAL_DEPR LaplaceDistParams {
+struct LaplaceDistParams {
   OutType mu;
   OutType scale;
 };
 
 // Not really a distro, useful for sample without replacement function
 template <typename WeightsT, typename IdxT>
-struct POTENTIAL_DEPR SamplingParams {
+struct SamplingParams {
   IdxT* inIdxPtr;
   const WeightsT* wts;
 };
 
 template <typename Type>
-POTENTIAL_DEPR DI void box_muller_transform(
-  Type& val1, Type& val2, Type sigma1, Type mu1, Type sigma2, Type mu2)
+DI void box_muller_transform(Type& val1, Type& val2, Type sigma1, Type mu1, Type sigma2, Type mu2)
 {
   constexpr Type twoPi  = Type(2.0) * Type(3.141592654);
   constexpr Type minus2 = -Type(2.0);
@@ -160,27 +152,27 @@ POTENTIAL_DEPR DI void box_muller_transform(
 }
 
 template <typename Type>
-POTENTIAL_DEPR DI void box_muller_transform(Type& val1, Type& val2, Type sigma1, Type mu1)
+DI void box_muller_transform(Type& val1, Type& val2, Type sigma1, Type mu1)
 {
   box_muller_transform<Type>(val1, val2, sigma1, mu1, sigma1, mu1);
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   InvariantDistParams<OutType> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    InvariantDistParams<OutType> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   *val = params.const_val;
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   UniformDistParams<OutType> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    UniformDistParams<OutType> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   OutType res;
   gen.next(res);
@@ -188,11 +180,11 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   UniformIntDistParams<OutType, uint32_t> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    UniformIntDistParams<OutType, uint32_t> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   uint32_t x = 0;
   uint32_t s = params.diff;
@@ -211,11 +203,11 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   UniformIntDistParams<OutType, uint64_t> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    UniformIntDistParams<OutType, uint64_t> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   uint64_t x = 0;
   gen.next(x);
@@ -236,7 +228,7 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(
+DI void custom_next(
   GenType& gen, OutType* val, NormalDistParams<OutType> params, LenType idx = 0, LenType stride = 0)
 {
   OutType res1, res2;
@@ -253,11 +245,11 @@ POTENTIAL_DEPR DI void custom_next(
 }
 
 template <typename GenType, typename IntType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   IntType* val,
-                                   NormalIntDistParams<IntType> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    IntType* val,
+                    NormalIntDistParams<IntType> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   IntType res1_int, res2_int;
 
@@ -276,11 +268,11 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   NormalTableDistParams<OutType, LenType> params,
-                                   LenType idx,
-                                   LenType stride)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    NormalTableDistParams<OutType, LenType> params,
+                    LenType idx,
+                    LenType stride)
 {
   OutType res1, res2;
 
@@ -301,7 +293,7 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename Type, typename LenType>
-POTENTIAL_DEPR DI void custom_next(
+DI void custom_next(
   GenType& gen, OutType* val, BernoulliDistParams<Type> params, LenType idx = 0, LenType stride = 0)
 {
   Type res = 0;
@@ -310,11 +302,11 @@ POTENTIAL_DEPR DI void custom_next(
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   ScaledBernoulliDistParams<OutType> params,
-                                   LenType idx,
-                                   LenType stride)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    ScaledBernoulliDistParams<OutType> params,
+                    LenType idx,
+                    LenType stride)
 {
   OutType res = 0;
   gen.next(res);
@@ -322,7 +314,7 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(
+DI void custom_next(
   GenType& gen, OutType* val, GumbelDistParams<OutType> params, LenType idx = 0, LenType stride = 0)
 {
   OutType res = 0;
@@ -335,11 +327,11 @@ POTENTIAL_DEPR DI void custom_next(
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   LogNormalDistParams<OutType> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    LogNormalDistParams<OutType> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   OutType res1 = 0, res2 = 0;
   do {
@@ -353,11 +345,11 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   LogisticDistParams<OutType> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    LogisticDistParams<OutType> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   OutType res;
 
@@ -370,11 +362,11 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   ExponentialDistParams<OutType> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    ExponentialDistParams<OutType> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   OutType res;
   gen.next(res);
@@ -383,11 +375,11 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   RayleighDistParams<OutType> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    RayleighDistParams<OutType> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   OutType res;
   gen.next(res);
@@ -398,11 +390,11 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(GenType& gen,
-                                   OutType* val,
-                                   LaplaceDistParams<OutType> params,
-                                   LenType idx    = 0,
-                                   LenType stride = 0)
+DI void custom_next(GenType& gen,
+                    OutType* val,
+                    LaplaceDistParams<OutType> params,
+                    LenType idx    = 0,
+                    LenType stride = 0)
 {
   OutType res, out;
 
@@ -425,7 +417,7 @@ POTENTIAL_DEPR DI void custom_next(GenType& gen,
 }
 
 template <typename GenType, typename OutType, typename LenType>
-POTENTIAL_DEPR DI void custom_next(
+DI void custom_next(
   GenType& gen, OutType* val, SamplingParams<OutType, LenType> params, LenType idx, LenType stride)
 {
   OutType res;
@@ -442,7 +434,7 @@ POTENTIAL_DEPR DI void custom_next(
 
 /** Philox-based random number generator */
 // Courtesy: Jakub Szuppe
-struct POTENTIAL_DEPR PhiloxGenerator {
+struct PhiloxGenerator {
   static constexpr auto GEN_TYPE = GeneratorType::GenPhilox;
 
   /**
@@ -540,7 +532,7 @@ struct POTENTIAL_DEPR PhiloxGenerator {
 };
 
 /** PCG random number generator */
-struct POTENTIAL_DEPR PCGenerator {
+struct PCGenerator {
   static constexpr auto GEN_TYPE = GeneratorType::GenPC;
 
   /**

--- a/cpp/include/raft/random/detail/rng_impl.cuh
+++ b/cpp/include/raft/random/detail/rng_impl.cuh
@@ -55,43 +55,20 @@ namespace detail {
  * RAFT_CALL_RNG_FUNC(rng_state, (my_kernel<1, 2><<<1, 1>>>), 5);
  * @endcode
  */
-#define RAFT_CALL_RNG_FUNC(rng_state, func, ...)                                 \
-  switch ((rng_state).type) {                                                    \
-    case GeneratorType::GenPhilox: {                                             \
-      DeviceState<PhiloxGenerator> dev_state_philox{(rng_state)};                \
-      RAFT_DEPAREN(func)(dev_state_philox, ##__VA_ARGS__);                       \
-      break;                                                                     \
-    }                                                                            \
-    case GeneratorType::GenPC: {                                                 \
-      DeviceState<PCGenerator> dev_state_pc{(rng_state)};                        \
-      RAFT_DEPAREN(func)(dev_state_pc, ##__VA_ARGS__);                           \
-      break;                                                                     \
-    }                                                                            \
-    default: RAFT_FAIL("Unepxected generator type '%d'", int((rng_state).type)); \
+#define RAFT_CALL_RNG_FUNC(rng_state, func, ...)                                    \
+  switch ((rng_state).type) {                                                       \
+    case raft::random::GeneratorType::GenPhilox: {                                  \
+      raft::random::DeviceState<raft::random::PhiloxGenerator> r_phil{(rng_state)}; \
+      RAFT_DEPAREN(func)(r_phil, ##__VA_ARGS__);                                    \
+      break;                                                                        \
+    }                                                                               \
+    case raft::random::GeneratorType::GenPC: {                                      \
+      raft::random::DeviceState<raft::random::PCGenerator> r_pc{(rng_state)};       \
+      RAFT_DEPAREN(func)(r_pc, ##__VA_ARGS__);                                      \
+      break;                                                                        \
+    }                                                                               \
+    default: RAFT_FAIL("Unepxected generator type '%d'", int((rng_state).type));    \
   }
-
-/**
- * This function is useful if all template arguments to `func` can be inferred
- * by the compiler. Otherwise use the MACRO `RAFT_CALL_RNG_FUNC` which
- * can accept incomplete template specializations (or kernel calls) as the function
- */
-template <typename FuncT, typename... ArgsT>
-void call_rng_func(RngState const& rng_state, FuncT func, ArgsT... args)
-{
-  switch (rng_state.type) {
-    case GeneratorType::GenPhilox: {
-      DeviceState<PhiloxGenerator> dev_state_philox{rng_state};
-      func(dev_state_philox, args...);
-      break;
-    }
-    case GeneratorType::GenPC: {
-      DeviceState<PCGenerator> dev_state_pc{rng_state};
-      func(dev_state_pc, args...);
-      break;
-    }
-    default: RAFT_FAIL("Unepxected generator type '%d'", int(rng_state.type));
-  }
-}
 
 template <int ITEMS_PER_CALL, typename GenType, typename... ArgsT>
 void call_rng_kernel(DeviceState<GenType> const& dev_state,

--- a/cpp/include/raft/random/detail/rng_impl.cuh
+++ b/cpp/include/raft/random/detail/rng_impl.cuh
@@ -16,11 +16,10 @@
 
 #pragma once
 
-#include "rng_device.cuh"
-
 #include <raft/common/cub_wrappers.cuh>
 #include <raft/common/scatter.cuh>
 #include <raft/cudart_utils.h>
+#include <raft/random/rng_device.cuh>
 #include <raft/random/rng_state.hpp>
 
 namespace raft {

--- a/cpp/include/raft/random/detail/rng_impl_deprecated.cuh
+++ b/cpp/include/raft/random/detail/rng_impl_deprecated.cuh
@@ -41,6 +41,7 @@ class RngImpl {
  public:
   RngImpl(uint64_t seed, GeneratorType _t = GenPhilox)
     : state{seed, 0, _t},
+      type(_t),
       // simple heuristic to make sure all SMs will be occupied properly
       // and also not too many initialization calls will be made by each thread
       nBlocks(4 * getMultiProcessorCount())
@@ -293,6 +294,7 @@ class RngImpl {
   }
 
   RngState state;
+  GeneratorType type;
   /** number of blocks to launch */
   int nBlocks;
   static const int nThreads = 256;

--- a/cpp/include/raft/random/rng.cuh
+++ b/cpp/include/raft/random/rng.cuh
@@ -23,15 +23,8 @@
 #include "detail/rng_impl_deprecated.cuh"  // necessary for now (to be removed)
 #include "rng_state.hpp"
 
-#define __RNG_H_INCLUSION_DEPRECATED
-// we include this for now, but only for backward compatibility
-#include "rng_device.cuh"
-#undef __RNG_H_INCLUSION_DEPRECATED
-
 namespace raft {
 namespace random {
-
-using detail::call_rng_func;
 
 using detail::bernoulli;
 using detail::exponential;

--- a/cpp/include/raft/random/rng_device.cuh
+++ b/cpp/include/raft/random/rng_device.cuh
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "detail/rng_device.cuh"
+#include "rng.cuh"
 #include "rng_state.hpp"
 
 namespace raft {


### PR DESCRIPTION
<!--

Thank you for contributing to RAFT :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

After merging PR #609 , I realized that there were still a few bugs (all minor):
1. The deprecated `Rng` class had the `type` attribute removed. I added it back. This was used in cugraph-ops but not in other projects (cugraph, cuml).
2. The template function to call another function with the device state was actually unusable since you wouldn't be able to instantiate a function to call it with. So I removed that.
3. The macro used to call functions with a device state wasn't using fully namespace-qualified names, which made it unusable outside of RAFT.
4. Removed the deprecation warning of the new `rng_device.cuh` since it has to be included anyway through `rng.cuh`, so those deprecations didn't make sense.