### PR TITLE
[BUG] change default RNG type back to philox

### DIFF
--- a/cpp/include/raft/random/rng_state.hpp
+++ b/cpp/include/raft/random/rng_state.hpp
@@ -44,10 +44,11 @@ struct RngState {
   uint64_t seed{0};
   uint64_t base_subsequence{0};
   /**
-   * The generator type. PCGenerator has been extensively tested and is faster
-   * than Philox, thus we use it as the default.
+   * The generator type. For now, use Philox as default since PCGenerator
+   * caused issues in RAFT DivideTests and cugraph RMAT tests.
+   * This should be changed to GenPC as soon as all dependent tests are passing.
    */
-  GeneratorType type{GeneratorType::GenPC};
+  GeneratorType type{GeneratorType::GenPhilox};
 
   void advance(uint64_t max_uniq_subsequences_used,
                uint64_t max_numbers_generated_per_subsequence = 0)

--- a/cpp/include/raft/random/rng_state.hpp
+++ b/cpp/include/raft/random/rng_state.hpp
@@ -32,6 +32,10 @@ enum GeneratorType {
 
 /**
  * The RNG state used to keep RNG state around on the host.
+ *
+ * @note: The default generator type is GenPhilox for backward compatibility.
+ *        For best performance, you should always try to use GenPC first,
+ *        since the PC generator is up to 2x faster in many use cases.
  */
 struct RngState {
   explicit RngState(uint64_t _seed) : seed(_seed) {}

--- a/cpp/include/raft/random/rng_state.hpp
+++ b/cpp/include/raft/random/rng_state.hpp
@@ -48,9 +48,12 @@ struct RngState {
   uint64_t seed{0};
   uint64_t base_subsequence{0};
   /**
-   * The generator type. For now, use Philox as default since PCGenerator
-   * caused issues in RAFT DivideTests and cugraph RMAT tests.
-   * This should be changed to GenPC as soon as all dependent tests are passing.
+   * The generator type, either GenPC or GenPhilox (the default).
+   * GenPC should be preferred for performance.
+   *
+   * FIXME(mjoux): For now, we use Philox as default since PC generator
+   *               caused issues in RAFT DivideTests and cugraph RMAT tests.
+   *               Should be changed to GenPC when all tests are passing.
    */
   GeneratorType type{GeneratorType::GenPhilox};
 


### PR DESCRIPTION
<!--

Thank you for contributing to RAFT :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

As explained in code comments, it seems like we are seeing failures in RAFT DivideTests as well as cugraph RMAT tests due to usage of PC generator versus Philox.
I'm not sure whether we confirmed that the DivideTests issues are due to the generator, but at least in the case of cugraph RMAT tests, @kaatish confirmed that this was due to the generator type.

@vinaydes will be investigating these issues, but for the time being, it may be more cautious to switch back the default type to philox, and let users use PC on a case-by-case basis if performance improvements are necessary.