### PR TITLE
Fixing the unit test issue(s) in RAFT

### DIFF
--- a/cpp/test/linalg/divide.cu
+++ b/cpp/test/linalg/divide.cu
@@ -57,9 +57,7 @@ class DivideTest : public ::testing::TestWithParam<raft::linalg::UnaryOpInputs<T
   {
     raft::random::RngState r(params.seed);
     int len = params.len;
-    RAFT_CUDA_TRY(cudaStreamCreate(&stream));
     uniform(handle, r, in.data(), len, T(-1.0), T(1.0));
-    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
     naiveDivide(out_ref.data(), in.data(), params.scalar, len, stream);
     divideScalar(out.data(), in.data(), params.scalar, len, stream);
     handle.sync_stream(stream);

--- a/cpp/test/linalg/divide.cu
+++ b/cpp/test/linalg/divide.cu
@@ -59,6 +59,7 @@ class DivideTest : public ::testing::TestWithParam<raft::linalg::UnaryOpInputs<T
     int len = params.len;
     RAFT_CUDA_TRY(cudaStreamCreate(&stream));
     uniform(handle, r, in.data(), len, T(-1.0), T(1.0));
+    RAFT_CUDA_TRY(cudaStreamSynchronize(handle.get_stream()));
     naiveDivide(out_ref.data(), in.data(), params.scalar, len, stream);
     divideScalar(out.data(), in.data(), params.scalar, len, stream);
     handle.sync_stream(stream);


### PR DESCRIPTION
The call to `uniform()` is getting executed in `handle.get_stream()` and kernels/operations after `uniform()` are executed in separately created `stream`. This causes synchronization hazard. When default RNG was changed from Philox to PCG, the bug got exposed due to the relative difference in generation speed of PCG and Philox (PCG is faster). Adding a stream synchronization call fixes the issue.