### PR TITLE
Debug cpu build

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -3,7 +3,7 @@
 #########################################
 #  RAFT CPU conda build script for CI   #
 #########################################
-set -e
+set -ex
 
 # Set path and build parallel level
 # openmpi dir is required on CentOS for finding MPI libs from cmake


### PR DESCRIPTION
Trying to figure out why the Python conda packages below are being during the `cuda` build :thinking:.

- https://github.com/rapidsai/raft/blob/3a431f149975c51d8d18434e0b3431a368e57127/ci/cpu/build.sh#L114