### PR TITLE
Fix components installation

### DIFF
--- a/cpp/cmake/modules/raft_export.cmake
+++ b/cpp/cmake/modules/raft_export.cmake
@@ -206,10 +206,14 @@ function(raft_export type project_name)
     install(DIRECTORY "${scratch_dir}/" DESTINATION "${install_location}"
             COMPONENT raft)
     foreach(comp nn distance)
-      set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export/${comp}/")
+      set(scratch_dir "${PROJECT_BINARY_DIR}/rapids-cmake/${project_name}/export/${comp}")
       file(MAKE_DIRECTORY "${scratch_dir}")
-      install(DIRECTORY "${scratch_dir}" DESTINATION "${install_location}"
+      install(DIRECTORY "${scratch_dir}/" DESTINATION "${install_location}"
         COMPONENT raft_${comp})
+      if(EXISTS "${scratch_dir}/raft-${comp}-dependencies.cmake")
+        install(FILES "${scratch_dir}/raft-${comp}-dependencies.cmake" DESTINATION "${install_location}"
+          COMPONENT raft)
+      endif()
     endforeach()
 
   else()


### PR DESCRIPTION
We need to install the `raft-${comp}-dependencies.cmake` files as part of the `raft` component