### PR TITLE
Don't install component dependency files in raft-header only mode

### DIFF
--- a/cpp/cmake/modules/raft_export.cmake
+++ b/cpp/cmake/modules/raft_export.cmake
@@ -210,10 +210,6 @@ function(raft_export type project_name)
       file(MAKE_DIRECTORY "${scratch_dir}")
       install(DIRECTORY "${scratch_dir}" DESTINATION "${install_location}"
         COMPONENT raft_${comp})
-      if(EXISTS "${scratch_dir}/raft-${comp}-dependencies.cmake")
-        install(FILES "${scratch_dir}/raft-${comp}-dependencies.cmake" DESTINATION "${install_location}"
-          COMPONENT raft)
-      endif()
     endforeach()
 
   else()


### PR DESCRIPTION
Corrects the issues we are seeing in CI with failed `faiss:faiss` dependency