### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/cpp/include/raft/linalg/detail/gemm.hpp
+++ b/cpp/include/raft/linalg/detail/gemm.hpp
@@ -61,7 +61,7 @@ void gemm(const raft::handle_t& handle,
           const math_t* B,
           const int ldb,
           const math_t* beta,
-          const math_t* C,
+          math_t* C,
           const int ldc,
           cudaStream_t stream)
 {

--- a/cpp/include/raft/linalg/gemm.cuh
+++ b/cpp/include/raft/linalg/gemm.cuh
@@ -58,7 +58,7 @@ void gemm(const raft::handle_t& handle,
           const math_t* B,
           const int ldb,
           const math_t* beta,
-          const math_t* C,
+          math_t* C,
           const int ldc,
           cudaStream_t stream)
 {

--- a/cpp/include/raft/linalg/gemm.hpp
+++ b/cpp/include/raft/linalg/gemm.hpp
@@ -63,7 +63,7 @@ void gemm(const raft::handle_t& handle,
           const math_t* B,
           const int ldb,
           const math_t* beta,
-          const math_t* C,
+          math_t* C,
           const int ldc,
           cudaStream_t stream)
 {


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.