### PR TITLE
fix race in fusedL2knn smem read/write by adding a syncwarp

### DIFF
--- a/cpp/include/raft/spatial/knn/detail/fused_l2_knn.cuh
+++ b/cpp/include/raft/spatial/knn/detail/fused_l2_knn.cuh
@@ -446,6 +446,7 @@ __global__ __launch_bounds__(Policy::Nthreads, 2) void fusedL2kNN(const DataT* x
                   }
                 }
               }
+              __syncwarp();
               const int finalNumVals = raft::shfl(numValsWarpTopK[i], 31);
               loadWarpQShmem<Policy, Pair>(heapArr[i], &shDumpKV[0], rowId, numOfNN);
               updateSortedWarpQ<Pair, myWarpSelect::kNumWarpQRegisters>(


### PR DESCRIPTION
-- fix race in fusedL2knn smem read/write by adding a syncwarp reported by racecheck tool of compute-sanitizer.
-- this addresses issue - https://github.com/rapidsai/raft/issues/676