### PR TITLE
Revert print vector changes because of std::vector<bool>

### DIFF
--- a/cpp/include/raft/core/cudart_utils.hpp
+++ b/cpp/include/raft/core/cudart_utils.hpp
@@ -36,7 +36,6 @@
 #include <iomanip>
 #include <iostream>
 #include <mutex>
-#include <vector>
 
 ///@todo: enable once logging has been enabled in raft
 //#include "logger.hpp"
@@ -303,10 +302,10 @@ void print_device_vector(const char* variable_name,
                          size_t componentsCount,
                          OutStream& out)
 {
-  std::vector<T> host_mem(componentsCount);
-  CUDA_CHECK(
-    cudaMemcpy(host_mem.data(), devMem, componentsCount * sizeof(T), cudaMemcpyDeviceToHost));
-  print_host_vector(variable_name, host_mem.data(), componentsCount, out);
+  T* host_mem = new T[componentsCount];
+  CUDA_CHECK(cudaMemcpy(host_mem, devMem, componentsCount * sizeof(T), cudaMemcpyDeviceToHost));
+  print_host_vector(variable_name, host_mem, componentsCount, out);
+  delete[] host_mem;
 }
 
 /**


### PR DESCRIPTION
The specialization of `std::vector` when `T=bool` is unfortunately causing compilation issue in cuml because the `data()` function member is not implemented. And the elements may not be stored contiguously.

(Link to the CI failure: https://gpuci.gpuopenanalytics.com/job/rapidsai/job/gpuci/job/cuml/job/prb/job/cuml-cpu-cuda-build-arm64/CUDA=11.5/1364/console)
cc @achirkin 