### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -73,8 +73,8 @@ fi
 # Install the master version of dask, distributed, and dask-ml
 gpuci_logger "Install the master version of dask and distributed"
 set -x
-pip install "git+https://github.com/dask/distributed.git@2022.05.1" --upgrade --no-deps
-pip install "git+https://github.com/dask/dask.git@2022.05.1" --upgrade --no-deps
+pip install "git+https://github.com/dask/distributed.git@2022.05.2" --upgrade --no-deps
+pip install "git+https://github.com/dask/dask.git@2022.05.2" --upgrade --no-deps
 set +x
 
 # Install pre-built conda packages from previous CI step

--- a/conda/environments/raft_dev_cuda11.0.yml
+++ b/conda/environments/raft_dev_cuda11.0.yml
@@ -26,8 +26,8 @@ dependencies:
 - pip:
     - sphinx_markdown_tables
     - breathe
-    - git+https://github.com/dask/dask.git@2022.05.1
-    - git+https://github.com/dask/distributed.git@2022.05.1
+    - git+https://github.com/dask/dask.git@2022.05.2
+    - git+https://github.com/dask/distributed.git@2022.05.2
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/environments/raft_dev_cuda11.2.yml
+++ b/conda/environments/raft_dev_cuda11.2.yml
@@ -26,8 +26,8 @@ dependencies:
 - pip:
     - sphinx_markdown_tables
     - breathe
-    - git+https://github.com/dask/dask.git@2022.05.1
-    - git+https://github.com/dask/distributed.git@2022.05.1
+    - git+https://github.com/dask/dask.git@2022.05.2
+    - git+https://github.com/dask/distributed.git@2022.05.2
     
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/environments/raft_dev_cuda11.4.yml
+++ b/conda/environments/raft_dev_cuda11.4.yml
@@ -26,8 +26,8 @@ dependencies:
 - pip:
     - sphinx_markdown_tables
     - breathe
-    - git+https://github.com/dask/dask.git@2022.05.1
-    - git+https://github.com/dask/distributed.git@2022.05.1
+    - git+https://github.com/dask/dask.git@2022.05.2
+    - git+https://github.com/dask/distributed.git@2022.05.2
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/environments/raft_dev_cuda11.5.yml
+++ b/conda/environments/raft_dev_cuda11.5.yml
@@ -27,8 +27,8 @@ dependencies:
 - pip:
     - sphinx_markdown_tables
     - breathe
-    - git+https://github.com/dask/dask.git@2022.05.1
-    - git+https://github.com/dask/distributed.git@2022.05.1
+    - git+https://github.com/dask/dask.git@2022.05.2
+    - git+https://github.com/dask/distributed.git@2022.05.2
 
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/

--- a/conda/recipes/pyraft/meta.yaml
+++ b/conda/recipes/pyraft/meta.yaml
@@ -48,8 +48,8 @@ requirements:
     - ucx >={{ ucx_version }}
     - ucx-py {{ ucx_py_version }}
     - ucx-proc=*=gpu
-    - dask==2022.05.1
-    - distributed==2022.05.1
+    - dask==2022.05.2
+    - distributed==2022.05.2
     - cuda-python >=11.5,<12.0
     - joblib >=0.11
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.