### PR TITLE
Change build.sh to find C++ library by default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -196,6 +196,11 @@ if [[ ${CMAKE_TARGET} == "" ]]; then
     CMAKE_TARGET="all"
 fi
 
+# Append `-DFIND_RAFT_CPP=ON` to CMAKE_ARGS unless a user specified the option.
+if [[ "${CMAKE_ARGS}" != *"DFIND_RAFT_CPP"* ]]; then
+    CMAKE_ARGS="${CMAKE_ARGS} -DFIND_RAFT_CPP=ON"
+fi
+
 # If clean given, run it prior to any other steps
 if (( ${CLEAN} == 1 )); then
     # If the dirs to clean are mounted dirs in a container, the

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -103,9 +103,9 @@ export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 gpuci_logger "Build C++ and Python targets"
 # These should link against the existing shared libs
 if hasArg --skip-tests; then
-  "$WORKSPACE/build.sh" pyraft pylibraft libraft -v --cmake-args=\"-DFIND_RAFT_CPP=ON\"
+  "$WORKSPACE/build.sh" pyraft pylibraft libraft -v
 else
-  "$WORKSPACE/build.sh" pyraft pylibraft libraft tests bench -v --cmake-args=\"-DFIND_RAFT_CPP=ON\"
+  "$WORKSPACE/build.sh" pyraft pylibraft libraft tests bench -v
 fi
 
 gpuci_logger "sccache stats"

--- a/conda/recipes/pylibraft/build.sh
+++ b/conda/recipes/pylibraft/build.sh
@@ -2,4 +2,4 @@
 #!/usr/bin/env bash
 
 # This assumes the script is executed from the root of the repo directory
-./build.sh pylibraft --install --no-nvtx --cmake-args=\"-DFIND_RAFT_CPP=ON\"
+./build.sh pylibraft --install --no-nvtx

--- a/conda/recipes/pyraft/build.sh
+++ b/conda/recipes/pyraft/build.sh
@@ -3,4 +3,4 @@
 # Copyright (c) 2022, NVIDIA CORPORATION.
 
 # This assumes the script is executed from the root of the repo directory
-./build.sh pyraft --install --no-nvtx --cmake-args=\"-DFIND_RAFT_CPP=ON\"
+./build.sh pyraft --install --no-nvtx


### PR DESCRIPTION
<!--

Thank you for contributing to RAFT :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
Discussions with the team indicated a general preference for having build.sh default to finding the C++ library by default (and erroring if one is not found) rather than building a new copy of libcuspatial when building cuspatial Python.