### PR TITLE
[FIX] Update conda environment pinnings and update-versions.sh.

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -38,11 +38,11 @@ sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cma
 sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cmake"'/g' python/pylibraft/CMakeLists.txt
 
 for FILE in conda/environments/*.yml; do
-  sed_runner "s/rmm=${CURRENT_SHORT_TAG}/rmm=${NEXT_SHORT_TAG}/g" ${FILE};
   sed_runner "s/dask-cuda=${CURRENT_SHORT_TAG}/dask-cuda=${NEXT_SHORT_TAG}/g" ${FILE};
   sed_runner "s/rapids-build-env=${CURRENT_SHORT_TAG}/rapids-build-env=${NEXT_SHORT_TAG}/g" ${FILE};
-  sed_runner "s/rapids-notebook-env=${CURRENT_SHORT_TAG}/rapids-notebook-env=${NEXT_SHORT_TAG}/g" ${FILE};
   sed_runner "s/rapids-doc-env=${CURRENT_SHORT_TAG}/rapids-doc-env=${NEXT_SHORT_TAG}/g" ${FILE};
+  sed_runner "s/rapids-notebook-env=${CURRENT_SHORT_TAG}/rapids-notebook-env=${NEXT_SHORT_TAG}/g" ${FILE};
+  sed_runner "s/rmm=${CURRENT_SHORT_TAG}/rmm=${NEXT_SHORT_TAG}/g" ${FILE};
   sed_runner "s/ucx-py=.*/ucx-py=${NEXT_UCX_PY_VERSION}/g" ${FILE};
 done
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -38,6 +38,11 @@ sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cma
 sed_runner 's/'"branch-.*\/RAPIDS.cmake"'/'"branch-${NEXT_SHORT_TAG}\/RAPIDS.cmake"'/g' python/pylibraft/CMakeLists.txt
 
 for FILE in conda/environments/*.yml; do
+  sed_runner "s/rmm=${CURRENT_SHORT_TAG}/rmm=${NEXT_SHORT_TAG}/g" ${FILE};
+  sed_runner "s/dask-cuda=${CURRENT_SHORT_TAG}/dask-cuda=${NEXT_SHORT_TAG}/g" ${FILE};
+  sed_runner "s/rapids-build-env=${CURRENT_SHORT_TAG}/rapids-build-env=${NEXT_SHORT_TAG}/g" ${FILE};
+  sed_runner "s/rapids-notebook-env=${CURRENT_SHORT_TAG}/rapids-notebook-env=${NEXT_SHORT_TAG}/g" ${FILE};
+  sed_runner "s/rapids-doc-env=${CURRENT_SHORT_TAG}/rapids-doc-env=${NEXT_SHORT_TAG}/g" ${FILE};
   sed_runner "s/ucx-py=.*/ucx-py=${NEXT_UCX_PY_VERSION}/g" ${FILE};
 done
 

--- a/conda/environments/raft_dev_cuda11.0.yml
+++ b/conda/environments/raft_dev_cuda11.0.yml
@@ -11,11 +11,11 @@ dependencies:
 - cython>=0.29,<0.30
 - cmake>=3.20.1,!=3.23.0
 - scikit-build>=0.13.1
-- rapids-build-env=22.02.*
-- rapids-notebook-env=22.02.*
-- rapids-doc-env=22.02.*
-- rmm=22.02.*
-- dask-cuda=22.02.*
+- rapids-build-env=22.08.*
+- rapids-notebook-env=22.08.*
+- rapids-doc-env=22.08.*
+- rmm=22.08.*
+- dask-cuda=22.08.*
 - ucx>=1.12.1
 - ucx-py=0.27.*
 - ucx-proc=*=gpu

--- a/conda/environments/raft_dev_cuda11.2.yml
+++ b/conda/environments/raft_dev_cuda11.2.yml
@@ -11,11 +11,11 @@ dependencies:
 - cython>=0.29,<0.30
 - cmake>=3.20.1,!=3.23.0
 - scikit-build>=0.13.1
-- rapids-build-env=22.02.*
-- rapids-notebook-env=22.02.*
-- rapids-doc-env=22.02.*
-- rmm=22.02.*
-- dask-cuda=22.02.*
+- rapids-build-env=22.08.*
+- rapids-notebook-env=22.08.*
+- rapids-doc-env=22.08.*
+- rmm=22.08.*
+- dask-cuda=22.08.*
 - ucx>=1.12.1
 - ucx-py=0.27.*
 - ucx-proc=*=gpu
@@ -28,7 +28,7 @@ dependencies:
     - breathe
     - git+https://github.com/dask/dask.git@main
     - git+https://github.com/dask/distributed.git@main
-    
+
 # rapids-build-env, notebook-env and doc-env are defined in
 # https://docs.rapids.ai/maintainers/depmgmt/
 

--- a/conda/environments/raft_dev_cuda11.4.yml
+++ b/conda/environments/raft_dev_cuda11.4.yml
@@ -11,11 +11,11 @@ dependencies:
 - cython>=0.29,<0.30
 - cmake>=3.20.1,!=3.23.0
 - scikit-build>=0.13.1
-- rapids-build-env=22.02.*
-- rapids-notebook-env=22.02.*
-- rapids-doc-env=22.02.*
-- rmm=22.02.*
-- dask-cuda=22.02.*
+- rapids-build-env=22.08.*
+- rapids-notebook-env=22.08.*
+- rapids-doc-env=22.08.*
+- rmm=22.08.*
+- dask-cuda=22.08.*
 - ucx>=1.12.1
 - ucx-py=0.27.*
 - ucx-proc=*=gpu

--- a/conda/environments/raft_dev_cuda11.5.yml
+++ b/conda/environments/raft_dev_cuda11.5.yml
@@ -12,11 +12,11 @@ dependencies:
 - cython>=0.29,<0.30
 - cmake>=3.20.1,!=3.23.0
 - scikit-build>=0.13.1
-- rapids-build-env=22.02.*
-- rapids-notebook-env=22.02.*
-- rapids-doc-env=22.02.*
-- rmm=22.02.*
-- dask-cuda=22.02.*
+- rapids-build-env=22.08.*
+- rapids-notebook-env=22.08.*
+- rapids-doc-env=22.08.*
+- rmm=22.08.*
+- dask-cuda=22.08.*
 - ucx>=1.12.1
 - ucx-py=0.27.*
 - ucx-proc=*=gpu


### PR DESCRIPTION
This PR complements / supersedes #710 by updating all the RAPIDS packages pinned to the current minor version. This PR also aligns the `update-version.sh` script with the [behavior of the same script from cuML](https://github.com/rapidsai/cuml/blob/branch-22.08/ci/release/update-version.sh), to keep this problem from reoccurring.