### PR TITLE
Update Python classifiers.

### DIFF
--- a/python/pylibraft/setup.py
+++ b/python/pylibraft/setup.py
@@ -25,8 +25,8 @@ setup(name='pylibraft',
       classifiers=[
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9"
       ],
       author="NVIDIA Corporation",
       package_data={

--- a/python/raft/setup.py
+++ b/python/raft/setup.py
@@ -26,8 +26,8 @@ setup(name='raft',
       classifiers=[
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9"
       ],
       author="NVIDIA Corporation",
       package_data={


### PR DESCRIPTION
This PR updates Python version classifiers to use the versions of Python currently supported by RAPIDS (3.8, 3.9).