### PR TITLE
fix nans in naive kl divergence kernel introduced by div by 0.

### DIFF
--- a/cpp/test/distance/distance_base.cuh
+++ b/cpp/test/distance/distance_base.cuh
@@ -260,9 +260,8 @@ __global__ void naiveKLDivergenceDistanceKernel(
     auto a            = x[xidx];
     auto b            = y[yidx];
     bool b_zero       = (b == 0);
-    const auto m      = (!b_zero) * (a / b);
-    const bool m_zero = (m == 0);
-    acc += (a * (!m_zero) * log(m + m_zero));
+    bool a_zero       = (a == 0);
+    acc += a * (log(a + a_zero) - log(b + b_zero));
   }
   acc          = 0.5f * acc;
   int outidx   = isRowMajor ? midx * n + nidx : midx + m * nidx;
@@ -450,10 +449,6 @@ class DistanceTest : public ::testing::TestWithParam<DistanceInputs<DataType>> {
     }
     naiveDistance(
       dist_ref.data(), x.data(), y.data(), m, n, k, distanceType, isRowMajor, metric_arg, stream);
-    //    size_t worksize = raft::distance::getWorkspaceSize<distanceType, DataType, DataType,
-    //    DataType>(
-    //      x.data(), y.data(), m, n, k);
-    //    rmm::device_uvector<char> workspace(worksize, stream);
 
     DataType threshold = -10000.f;
 

--- a/cpp/test/distance/distance_base.cuh
+++ b/cpp/test/distance/distance_base.cuh
@@ -255,12 +255,12 @@ __global__ void naiveKLDivergenceDistanceKernel(
   if (midx >= m || nidx >= n) return;
   OutType acc = OutType(0);
   for (int i = 0; i < k; ++i) {
-    int xidx          = isRowMajor ? i + midx * k : i * m + midx;
-    int yidx          = isRowMajor ? i + nidx * k : i * n + nidx;
-    auto a            = x[xidx];
-    auto b            = y[yidx];
-    bool b_zero       = (b == 0);
-    bool a_zero       = (a == 0);
+    int xidx    = isRowMajor ? i + midx * k : i * m + midx;
+    int yidx    = isRowMajor ? i + nidx * k : i * n + nidx;
+    auto a      = x[xidx];
+    auto b      = y[yidx];
+    bool b_zero = (b == 0);
+    bool a_zero = (a == 0);
     acc += a * (log(a + a_zero) - log(b + b_zero));
   }
   acc          = 0.5f * acc;


### PR DESCRIPTION
-- This address issue https://github.com/rapidsai/raft/issues/716
-- remove redundant commented code as well.