### PR TITLE
[FIX] Always add `raft::raft_nn_lib` and `raft::raft_distance_lib` aliases

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -286,9 +286,12 @@ if(RAFT_COMPILE_DIST_LIBRARY)
 
 endif()
 
+if(TARGET raft_distance_lib AND (NOT TARGET raft::raft_distance_lib))
+  add_library(raft::raft_distance_lib ALIAS raft_distance_lib)
+endif()
+
 target_link_libraries(raft_distance INTERFACE
     raft::raft
-    $<TARGET_NAME_IF_EXISTS:raft_distance_lib>
     $<TARGET_NAME_IF_EXISTS:raft::raft_distance_lib>
 )
 
@@ -341,9 +344,12 @@ if(RAFT_COMPILE_NN_LIBRARY)
           INTERFACE "RAFT_NN_COMPILED")
 endif()
 
+if(TARGET raft_nn_lib AND (NOT TARGET raft::raft_nn_lib))
+  add_library(raft::raft_nn_lib ALIAS raft_nn_lib)
+endif()
+
 target_link_libraries(raft_nn INTERFACE
     raft::raft
-    $<TARGET_NAME_IF_EXISTS:raft_nn_lib>
     $<TARGET_NAME_IF_EXISTS:raft::raft_nn_lib>)
 
 ##############################################################################


### PR DESCRIPTION
Always add `raft::raft_nn_lib` and `raft::raft_distance_lib` aliases so adding raft as a submodule provides the same library targets as using it as a package.

Here's an example of the differences between using RAFT as a submodule and using it as a package (preinstalled or otherwise):

```cmake
# Build raft from source
set(RAFT_COMPILE_LIBRARIES ON)
add_subdirectory(/raft/cpp)
if(TARGET raft_nn_lib) # FALSE
if(TARGET raft_distance_lib) # FALSE
if(TARGET raft::raft_nn_lib) # TRUE
if(TARGET raft::raft_distance_lib) # TRUE

# Find the RAFT package
set(raft_ROOT /raft/cpp/build)
find_package(raft)
if(TARGET raft_nn_lib) # FALSE
if(TARGET raft_distance_lib) # FALSE
if(TARGET raft::raft_nn_lib) # TRUE
if(TARGET raft::raft_distance_lib) # TRUE
```

The problem is exacerbated if we use `CPMFindPackage`, since the available raft targets will be different based on whether this is the first time we've configured or if we're re-configuring:
```cmake
if(EXISTS ${CMAKE_BINARY_DIR}/_deps/raft-build)
  set(raft_ROOT ${CMAKE_BINARY_DIR}/_deps/raft-build)
endif()
# Find or build RAFT from source
CPMFindPackage(NAME raft ...)
if(TARGET raft_nn_lib) # initial configure=TRUE, reconfigure=FALSE
if(TARGET raft_distance_lib) # initial configure=TRUE, reconfigure=FALSE
if(TARGET raft::raft_nn_lib) # initial configure=FALSE, reconfigure=TRUE
if(TARGET raft::raft_distance_lib) # initial configure=FALSE, reconfigure=TRUE
```