### PR TITLE
[REVIEW] [ENH] Ability to use ccache to speedup local builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ ARGS=$*
 # script, and that this script resides in the repo dir!
 REPODIR=$(cd $(dirname $0); pwd)
 
-VALIDARGS="clean libraft pyraft pylibraft docs tests bench clean -v -g --install --compile-libs --compile-nn --compile-dist --allgpuarch --sccache --no-nvtx --show_depr_warn -h --buildfaiss --minimal-deps"
+VALIDARGS="clean libraft pyraft pylibraft docs tests bench clean -v -g --install --compile-libs --compile-nn --compile-dist --allgpuarch --sccache --ccache --no-nvtx --show_depr_warn -h --buildfaiss --minimal-deps"
 HELP="$0 [<target> ...] [<flag> ...] [--cmake-args=\"<args>\"]
  where <target> is:
    clean            - remove all existing build artifacts and configuration (start over)
@@ -33,7 +33,8 @@ HELP="$0 [<target> ...] [<flag> ...] [--cmake-args=\"<args>\"]
  and <flag> is:
    -v                          - verbose build mode
    -g                          - build for debug
-   --sccache                    - enable sccache
+   --sccache                   - enable sccache
+   --ccache                    - enable ccache
    --compile-libs              - compile shared libraries for all components
    --compile-nn                - compile shared library for nn component
    --compile-dist              - compile shared library for distance component
@@ -70,6 +71,7 @@ ENABLE_NN_DEPENDENCIES=OFF
 ENABLE_thrust_DEPENDENCY=ON
 
 SCCACHE_ARGS=""
+CCACHE_ARGS=""
 NVTX=ON
 CLEAN=0
 UNINSTALL=0
@@ -134,8 +136,17 @@ if hasArg --install; then
     INSTALL_TARGET="install"
 fi
 
+if hasArg --sccache && hasArg --ccache; then
+    echo "Cannot enable both sccache and ccache at the same time!"
+    exit 1
+fi
+
 if hasArg --sccache; then
   SCCACHE_ARGS="-DCMAKE_CUDA_COMPILER_LAUNCHER=sccache -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+fi
+
+if hasArg --ccache; then
+    CCACHE_ARGS="-DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
 fi
 
 if hasArg --minimal-deps; then
@@ -258,6 +269,7 @@ if (( ${NUMARGS} == 0 )) || hasArg libraft || hasArg docs || hasArg tests || has
           -DRAFT_USE_FAISS_STATIC=${BUILD_STATIC_FAISS} \
           -DRAFT_ENABLE_thrust_DEPENDENCY=${ENABLE_thrust_DEPENDENCY} \
           ${SCCACHE_ARGS} \
+          ${CCACHE_ARGS} \
           ${EXTRA_CMAKE_ARGS}
 
   if [[ ${CMAKE_TARGET} != "" ]]; then

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ ARGS=$*
 REPODIR=$(cd $(dirname $0); pwd)
 
 VALIDARGS="clean libraft pyraft pylibraft docs tests bench clean -v -g --install --compile-libs --compile-nn --compile-dist --allgpuarch --no-nvtx --show_depr_warn -h --buildfaiss --minimal-deps"
-HELP="$0 [<target> ...] [<flag> ...] [--cmake-args=\"<args>\"] [--ccache-tool=<tool>]
+HELP="$0 [<target> ...] [<flag> ...] [--cmake-args=\"<args>\"] [--cache-tool=<tool>]
  where <target> is:
    clean            - remove all existing build artifacts and configuration (start over)
    libraft          - build the raft C++ code only. Also builds the C-wrapper library

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ HELP="$0 [<target> ...] [<flag> ...] [--cmake-args=\"<args>\"] [--cache-tool=<to
    --no-nvtx                   - disable nvtx (profiling markers), but allow enabling it in downstream projects
    --show_depr_warn            - show cmake deprecation warnings
    --cmake-args=\\\"<args>\\\" - pass arbitrary list of CMake configuration options (escape all quotes in argument)
-   --ccache-tool=<tool>        - pass the build ccache tool (eg: ccache, sccache, distcc) that will be used
+   --cache-tool=<tool>         - pass the build cache tool (eg: ccache, sccache, distcc) that will be used
                                  to speedup the build process.
    -h                          - print this text
 
@@ -70,7 +70,7 @@ ENABLE_NN_DEPENDENCIES=OFF
 
 ENABLE_thrust_DEPENDENCY=ON
 
-CCACHE_ARGS=""
+CACHE_ARGS=""
 NVTX=ON
 CLEAN=0
 UNINSTALL=0
@@ -114,22 +114,22 @@ function cmakeArgs {
     fi
 }
 
-function ccacheTool {
-    # Check for multiple ccache options
-    if [[ $(echo $ARGS | { grep -Eo "\-\-ccache\-tool" || true; } | wc -l ) -gt 1 ]]; then
-        echo "Multiple --ccache-tool options were provided, please provide only one: ${ARGS}"
+function cacheTool {
+    # Check for multiple cache options
+    if [[ $(echo $ARGS | { grep -Eo "\-\-cache\-tool" || true; } | wc -l ) -gt 1 ]]; then
+        echo "Multiple --cache-tool options were provided, please provide only one: ${ARGS}"
         exit 1
     fi
-    # Check for ccache tool option
-    if [[ -n $(echo $ARGS | { grep -E "\-\-ccache\-tool" || true; } ) ]]; then
+    # Check for cache tool option
+    if [[ -n $(echo $ARGS | { grep -E "\-\-cache\-tool" || true; } ) ]]; then
         # There are possible weird edge cases that may cause this regex filter to output nothing and fail silently
         # the true pipe will catch any weird edge cases that may happen and will cause the program to fall back
         # on the invalid option error
-        CCACHE_TOOL=$(echo $ARGS | sed -e 's/.*--ccache-tool=//' -e 's/ .*//')
-        if [[ -n ${CCACHE_TOOL} ]]; then
-            # Remove the full CCACHE_TOOL argument from list of args so that it passes validArgs function
-            ARGS=${ARGS//--ccache-tool=$CCACHE_TOOL/}
-            CCACHE_ARGS="-DCMAKE_CUDA_COMPILER_LAUNCHER=${CCACHE_TOOL} -DCMAKE_C_COMPILER_LAUNCHER=${CCACHE_TOOL} -DCMAKE_CXX_COMPILER_LAUNCHER=${CCACHE_TOOL}"
+        CACHE_TOOL=$(echo $ARGS | sed -e 's/.*--cache-tool=//' -e 's/ .*//')
+        if [[ -n ${CACHE_TOOL} ]]; then
+            # Remove the full CACHE_TOOL argument from list of args so that it passes validArgs function
+            ARGS=${ARGS//--cache-tool=$CACHE_TOOL/}
+            CACHE_ARGS="-DCMAKE_CUDA_COMPILER_LAUNCHER=${CACHE_TOOL} -DCMAKE_C_COMPILER_LAUNCHER=${CACHE_TOOL} -DCMAKE_CXX_COMPILER_LAUNCHER=${CACHE_TOOL}"
         fi
     fi
 }
@@ -142,7 +142,7 @@ fi
 # Check for valid usage
 if (( ${NUMARGS} != 0 )); then
     cmakeArgs
-    ccacheTool
+    cacheTool
     for a in ${ARGS}; do
         if ! (echo " ${VALIDARGS} " | grep -q " ${a} "); then
             echo "Invalid option: ${a}"
@@ -275,7 +275,7 @@ if (( ${NUMARGS} == 0 )) || hasArg libraft || hasArg docs || hasArg tests || has
           -DRAFT_COMPILE_DIST_LIBRARY=${COMPILE_DIST_LIBRARY} \
           -DRAFT_USE_FAISS_STATIC=${BUILD_STATIC_FAISS} \
           -DRAFT_ENABLE_thrust_DEPENDENCY=${ENABLE_thrust_DEPENDENCY} \
-          ${CCACHE_ARGS} \
+          ${CACHE_ARGS} \
           ${EXTRA_CMAKE_ARGS}
 
   if [[ ${CMAKE_TARGET} != "" ]]; then

--- a/conda/environments/raft_dev_cuda11.0.yml
+++ b/conda/environments/raft_dev_cuda11.0.yml
@@ -22,6 +22,7 @@ dependencies:
 - doxygen>=1.8.20
 - libfaiss>=1.7.0
 - faiss-proc=*=cuda
+- ccache
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/raft_dev_cuda11.2.yml
+++ b/conda/environments/raft_dev_cuda11.2.yml
@@ -22,6 +22,7 @@ dependencies:
 - doxygen>=1.8.20
 - libfaiss>=1.7.0
 - faiss-proc=*=cuda
+- ccache
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/raft_dev_cuda11.4.yml
+++ b/conda/environments/raft_dev_cuda11.4.yml
@@ -22,6 +22,7 @@ dependencies:
 - doxygen>=1.8.20
 - libfaiss>=1.7.0
 - faiss-proc=*=cuda
+- ccache
 - pip
 - pip:
     - sphinx_markdown_tables

--- a/conda/environments/raft_dev_cuda11.5.yml
+++ b/conda/environments/raft_dev_cuda11.5.yml
@@ -23,6 +23,7 @@ dependencies:
 - doxygen>=1.8.20
 - libfaiss>=1.7.0
 - faiss-proc=*=cuda
+- ccache
 - pip
 - pip:
     - sphinx_markdown_tables


### PR DESCRIPTION
I noticed that we have support for `sccache` in `build.sh` for building RAFT, but no `ccache` (especially if one wants to do local builds). This PR adds support for the latter. Also includes changes to install `ccache` in raft dev conda env.

Let me know in case you have any concerns with adding this.