### PR TITLE
fix logic bug in include_checker.py utility

### DIFF
--- a/cpp/scripts/include_checker.py
+++ b/cpp/scripts/include_checker.py
@@ -44,7 +44,7 @@ def list_all_source_file(file_regex, srcdirs):
     for srcdir in srcdirs:
         for root, dirs, files in os.walk(srcdir):
             for f in files:
-                if re.search(file_regex, f):
+                if not re.search(exclusion_regex, f) and re.search(file_regex, f):
                     src = os.path.join(root, f)
                     all_files.append(src)
     return all_files

--- a/cpp/scripts/include_checker.py
+++ b/cpp/scripts/include_checker.py
@@ -44,7 +44,7 @@ def list_all_source_file(file_regex, srcdirs):
     for srcdir in srcdirs:
         for root, dirs, files in os.walk(srcdir):
             for f in files:
-                if not re.search(file_regex, f) and re.search(file_regex, f):
+                if re.search(file_regex, f):
                     src = os.path.join(root, f)
                     all_files.append(src)
     return all_files

--- a/cpp/scripts/include_checker.py
+++ b/cpp/scripts/include_checker.py
@@ -44,7 +44,7 @@ def list_all_source_file(file_regex, srcdirs):
     for srcdir in srcdirs:
         for root, dirs, files in os.walk(srcdir):
             for f in files:
-                if not re.search(exclusion_regex, f) and re.search(file_regex, f):
+                if not re.search(exclusion_regex, root) and re.search(file_regex, f):
                     src = os.path.join(root, f)
                     all_files.append(src)
     return all_files


### PR DESCRIPTION
Hi, I noticed an issue in the include style checker when I was trying to adapt it for use in another project.

As far as I can tell, the current logic results in no source files actually being checked! Fortunately, the script also passes after the proposed change, so the includes were already in good shape :)

I verified the fix here by changing a <...>-style import to a double-quote one in one of the source files and it was detected.

I don't know if this file originates in RAFT or if it is also in other RAPIDS projects as well? If the later, the fix will need to be propagated to other repositories.