### PR TITLE
Add inline to nccl_sync_stream()

### DIFF
--- a/cpp/include/raft/comms/detail/util.hpp
+++ b/cpp/include/raft/comms/detail/util.hpp
@@ -65,9 +65,7 @@ namespace raft {
 namespace comms {
 namespace detail {
 
-constexpr size_t
-
-get_datatype_size(const datatype_t datatype)
+constexpr size_t get_datatype_size(const datatype_t datatype)
 {
   switch (datatype) {
     case datatype_t::CHAR: return sizeof(char);
@@ -82,9 +80,7 @@ get_datatype_size(const datatype_t datatype)
   }
 }
 
-constexpr ncclDataType_t
-
-get_nccl_datatype(const datatype_t datatype)
+constexpr ncclDataType_t get_nccl_datatype(const datatype_t datatype)
 {
   switch (datatype) {
     case datatype_t::CHAR: return ncclChar;
@@ -99,9 +95,7 @@ get_nccl_datatype(const datatype_t datatype)
   }
 }
 
-constexpr ncclRedOp_t
-
-get_nccl_op(const op_t op)
+constexpr ncclRedOp_t get_nccl_op(const op_t op)
 {
   switch (op) {
     case op_t::SUM: return ncclSum;
@@ -112,7 +106,7 @@ get_nccl_op(const op_t op)
   }
 }
 
-status_t nccl_sync_stream(ncclComm_t comm, cudaStream_t stream)
+inline status_t nccl_sync_stream(ncclComm_t comm, cudaStream_t stream)
 {
   cudaError_t cudaErr;
   ncclResult_t ncclErr, ncclAsyncErr;


### PR DESCRIPTION
Including `cpp/include/raft/comms/detail/util.hpp` more than once in separate files end up a link error:  "more than one definition ... ".

Add inline to fix this.
