### PR TITLE
Restrict the use of `[[no_unique_address]]` to CXX 20 only.

### DIFF
--- a/cpp/include/raft/thirdparty/mdspan/include/experimental/__p0009_bits/config.hpp
+++ b/cpp/include/raft/thirdparty/mdspan/include/experimental/__p0009_bits/config.hpp
@@ -121,10 +121,8 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #  define _MDSPAN_PRESERVE_STANDARD_LAYOUT 1
 #endif
 
-// no unique address starts working in NVCC 11.6
-#if !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS) && \
-   (!defined(__NVCC__) || ((__CUDACC_VER_MAJOR__ > 11) && (__CUDACC_VER_MINOR__ > 5)))
-#  if (__has_cpp_attribute(no_unique_address) >= 201803L) && !defined(_MDSPAN_COMPILER_MSVC)
+#if !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#  if MDSPAN_HAS_CXX_20 && (__has_cpp_attribute(no_unique_address) >= 201803L)
 #    define _MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
 #    define _MDSPAN_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #  else


### PR DESCRIPTION
Close https://github.com/rapidsai/raft/issues/740 .

Found by @achirkin , the size of `mapping` is non-deterministic. This is caused by the macro definition around whether `no_unique_address` is supported with nvcc. This PR uses the standard cpp version to define the macro regardless of the compiler being used.