### PR TITLE
Serialization for commonly used types

### DIFF
--- a/cpp/include/raft/core/serialization.hpp
+++ b/cpp/include/raft/core/serialization.hpp
@@ -80,7 +80,7 @@ auto deserialize(T* p, const void* in, ContextArgs&&... args) -> size_t
  * @tparam T type of the serializable object
  * @tparam ContextArgs types of context required for serialization
  *
- * @param[out] p an unitialized host pointer to a location where the object should be created.
+ * @param[out] p an uninitialized host pointer to a location where the object should be created.
  * @param in a vector where the state should be read from.
  * @param args context required for serialization
  * @return the number of bytes read from the vector

--- a/cpp/include/raft/core/serialization.hpp
+++ b/cpp/include/raft/core/serialization.hpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <raft/core/handle.hpp>
+#include <raft/detail/serialization.hpp>
+
+#include <vector>
+
+namespace raft {
+
+/**
+ * @brief Write a serializable state of an object to memory.
+ *
+ * @tparam Type of the serializable object
+ *
+ * @param handle provides a GPU context for objects, whos state depends on it
+ * @param obj the object to be serialized
+ * @param[out] out a host pointer to the location where to store the state;
+ *   when `nullptr`, the actual data is not written (only the size-to-written is calculated).
+ * @return the number of bytes (to be) written by the pointer
+ */
+template <typename T>
+auto serialize(const handle_t& handle, const T& obj, void* out) -> size_t
+{
+  return detail::call_serialize<T>(handle, obj, reinterpret_cast<uint8_t*>(out));
+}
+
+/**
+ * @brief Write a serializable state of an object to a host vector.
+ *
+ * @tparam Type of the serializable object
+ *
+ * @param handle provides a GPU context for objects, whos state depends on it
+ * @param obj the object to be serialized
+ * @return the serialized state
+ */
+template <typename T>
+auto serialize(const handle_t& handle, const T& obj) -> std::vector<uint8_t>
+{
+  return detail::call_serialize<T>(handle, obj);
+}
+
+/**
+ * @brief Read a serializable state of an object from memory.
+ *
+ * @tparam Type of the serializable object
+ *
+ * @param handle provides a GPU context for objects, whos state depends on it.
+ * @param[out] p an unitialized host pointer to a location where the object should be created.
+ * @param[in] in a host pointer to the location where the state should be read from.
+ */
+template <typename T>
+void deserialize(const handle_t& handle, T* p, const void* in)
+{
+  return detail::call_deserialize<T>(handle, p, reinterpret_cast<const uint8_t*>(in));
+}
+
+/**
+ * @brief Read a serializable state of an object from a vector.
+ *
+ * @tparam Type of the serializable object
+ *
+ * @param handle provides a GPU context for objects, whos state depends on it.
+ * @param[out] p an unitialized host pointer to a location where the object should be created.
+ * @param in a vector where the state should be read from.
+ */
+template <typename T>
+void deserialize(const handle_t& handle, T* p, const std::vector<uint8_t>& in)
+{
+  return detail::call_deserialize<T>(handle, p, in);
+}
+
+/**
+ * @brief Read a serializable state of an object.
+ *
+ * @tparam Type of the serializable object
+ *
+ * @param handle provides a GPU context for objects, whos state depends on it.
+ * @param[in] in a host pointer to the location where the state should be read from.
+ * @return the deserialized object;
+ */
+template <typename T>
+auto deserialize(const handle_t& handle, const void* in) -> T
+{
+  return detail::call_deserialize<T>(handle, reinterpret_cast<const uint8_t*>(in));
+}
+
+/**
+ * @brief Read a serializable state of an object.
+ *
+ * @tparam Type of the serializable object
+ *
+ * @param handle provides a GPU context for objects, whos state depends on it.
+ * @param in a vector where the state should be read from.
+ * @return the deserialized object;
+ */
+template <typename T>
+auto deserialize(const handle_t& handle, const std::vector<uint8_t>& in) -> T
+{
+  return detail::call_deserialize<T>(handle, in);
+}
+
+}  // namespace raft

--- a/cpp/include/raft/core/serialization.hpp
+++ b/cpp/include/raft/core/serialization.hpp
@@ -25,93 +25,103 @@ namespace raft {
 /**
  * @brief Write a serializable state of an object to memory.
  *
- * @tparam Type of the serializable object
+ * @tparam T type of the serializable object
+ * @tparam ContextArgs types of context required for serialization
  *
- * @param handle provides a GPU context for objects, whos state depends on it
- * @param obj the object to be serialized
  * @param[out] out a host pointer to the location where to store the state;
  *   when `nullptr`, the actual data is not written (only the size-to-written is calculated).
+ * @param obj the object to be serialized
+ * @param args context required for serialization
  * @return the number of bytes (to be) written by the pointer
  */
-template <typename T>
-auto serialize(const handle_t& handle, const T& obj, void* out) -> size_t
+template <typename T, typename... ContextArgs>
+auto serialize(uint8_t* out, const T& obj, ContextArgs&&... args) -> size_t
 {
-  return detail::call_serialize<T>(handle, obj, reinterpret_cast<uint8_t*>(out));
+  return detail::call_serialize<T, ContextArgs...>(out, obj, std::forward<ContextArgs>(args)...);
 }
 
 /**
  * @brief Write a serializable state of an object to a host vector.
  *
- * @tparam Type of the serializable object
+ * @tparam T type of the serializable object
+ * @tparam ContextArgs types of context required for serialization
  *
- * @param handle provides a GPU context for objects, whos state depends on it
  * @param obj the object to be serialized
+ * @param args context required for serialization
  * @return the serialized state
  */
-template <typename T>
-auto serialize(const handle_t& handle, const T& obj) -> std::vector<uint8_t>
+template <typename T, typename... ContextArgs>
+auto serialize(const T& obj, ContextArgs&&... args) -> std::vector<uint8_t>
 {
-  return detail::call_serialize<T>(handle, obj);
+  return detail::call_serialize<T, ContextArgs...>(obj, std::forward<ContextArgs>(args)...);
 }
 
 /**
  * @brief Read a serializable state of an object from memory.
  *
- * @tparam Type of the serializable object
+ * @tparam T type of the serializable object
+ * @tparam ContextArgs types of context required for serialization
  *
- * @param handle provides a GPU context for objects, whos state depends on it.
  * @param[out] p an unitialized host pointer to a location where the object should be created.
  * @param[in] in a host pointer to the location where the state should be read from.
+ * @param args context required for serialization
+ * @return the number of bytes read by the pointer
  */
-template <typename T>
-void deserialize(const handle_t& handle, T* p, const void* in)
+template <typename T, typename... ContextArgs>
+auto deserialize(T* p, const void* in, ContextArgs&&... args) -> size_t
 {
-  return detail::call_deserialize<T>(handle, p, reinterpret_cast<const uint8_t*>(in));
+  return detail::call_deserialize<T, ContextArgs...>(
+    p, reinterpret_cast<const uint8_t*>(in), std::forward<ContextArgs>(args)...);
 }
 
 /**
  * @brief Read a serializable state of an object from a vector.
  *
- * @tparam Type of the serializable object
+ * @tparam T type of the serializable object
+ * @tparam ContextArgs types of context required for serialization
  *
- * @param handle provides a GPU context for objects, whos state depends on it.
  * @param[out] p an unitialized host pointer to a location where the object should be created.
  * @param in a vector where the state should be read from.
+ * @param args context required for serialization
+ * @return the number of bytes read from the vector
  */
-template <typename T>
-void deserialize(const handle_t& handle, T* p, const std::vector<uint8_t>& in)
+template <typename T, typename... ContextArgs>
+auto deserialize(T* p, const std::vector<uint8_t>& in, ContextArgs&&... args) -> size_t
 {
-  return detail::call_deserialize<T>(handle, p, in);
+  return detail::call_deserialize<T, ContextArgs...>(p, in, std::forward<ContextArgs>(args)...);
 }
 
 /**
  * @brief Read a serializable state of an object.
  *
- * @tparam Type of the serializable object
+ * @tparam T type of the serializable object
+ * @tparam ContextArgs types of context required for serialization
  *
- * @param handle provides a GPU context for objects, whos state depends on it.
  * @param[in] in a host pointer to the location where the state should be read from.
+ * @param args context required for serialization
  * @return the deserialized object;
  */
-template <typename T>
-auto deserialize(const handle_t& handle, const void* in) -> T
+template <typename T, typename... ContextArgs>
+auto deserialize(const void* in, ContextArgs&&... args) -> T
 {
-  return detail::call_deserialize<T>(handle, reinterpret_cast<const uint8_t*>(in));
+  return detail::call_deserialize<T, ContextArgs...>(reinterpret_cast<const uint8_t*>(in),
+                                                     std::forward<ContextArgs>(args)...);
 }
 
 /**
  * @brief Read a serializable state of an object.
  *
- * @tparam Type of the serializable object
+ * @tparam T type of the serializable object
+ * @tparam ContextArgs types of context required for serialization
  *
- * @param handle provides a GPU context for objects, whos state depends on it.
  * @param in a vector where the state should be read from.
+ * @param args context required for serialization
  * @return the deserialized object;
  */
-template <typename T>
-auto deserialize(const handle_t& handle, const std::vector<uint8_t>& in) -> T
+template <typename T, typename... ContextArgs>
+auto deserialize(const std::vector<uint8_t>& in, ContextArgs&&... args) -> T
 {
-  return detail::call_deserialize<T>(handle, in);
+  return detail::call_deserialize<T, ContextArgs...>(in, std::forward<ContextArgs>(args)...);
 }
 
 }  // namespace raft

--- a/cpp/include/raft/core/serialization.hpp
+++ b/cpp/include/raft/core/serialization.hpp
@@ -62,7 +62,7 @@ auto serialize(const T& obj, ContextArgs&&... args) -> std::vector<uint8_t>
  * @tparam T type of the serializable object
  * @tparam ContextArgs types of context required for serialization
  *
- * @param[out] p an unitialized host pointer to a location where the object should be created.
+ * @param[out] p an uninitialized host pointer to a location where the object should be created.
  * @param[in] in a host pointer to the location where the state should be read from.
  * @param args context required for serialization
  * @return the number of bytes read by the pointer

--- a/cpp/include/raft/detail/serialization.hpp
+++ b/cpp/include/raft/detail/serialization.hpp
@@ -43,6 +43,8 @@ namespace raft::detail {
  *
  * `serial::from_bytes` constructs a new object by a given _uninitialized_ pointer (a.k.a. placement
  * new), reads the state from memory (`in`), and returns the number of bytes read.
+ * NB: If `serial::from_bytes` throws an exception, it's assumed that the output pointer is still
+ * uninitialized.
  *
  * _See below this file for examples_.
  *

--- a/cpp/include/raft/detail/serialization.hpp
+++ b/cpp/include/raft/detail/serialization.hpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <raft/core/handle.hpp>
+#include <raft/core/mdarray.hpp>
+
+#include <type_traits>
+#include <vector>
+
+namespace raft::detail {
+
+template <typename T>
+struct serialize;
+
+template <typename T>
+struct deserialize;
+
+template <typename T>
+auto call_serialize(const handle_t& handle, const T& obj, uint8_t* out) -> size_t
+{
+  return serialize<T>::run(handle, obj, out);
+}
+
+template <typename T>
+auto call_serialize(const handle_t& handle, const T& obj) -> std::vector<uint8_t>
+{
+  std::vector<uint8_t> v(call_serialize(handle, obj, nullptr));
+  call_serialize<T>(handle, obj, v.data());
+  return v;
+}
+
+template <typename T>
+void call_deserialize(const handle_t& handle, T* p, const uint8_t* in)
+{
+  return detail::deserialize<T>::run(handle, p, in);
+}
+
+template <typename T>
+void call_deserialize(const handle_t& handle, T* p, const std::vector<uint8_t>& in)
+{
+  return call_deserialize<T>(handle, p, in.data());
+}
+
+template <typename T>
+auto call_deserialize(const handle_t& handle, const uint8_t* in) -> T
+{
+  union res {
+    uint8_t bytes[sizeof(T)];  // NOLINT
+    T value;
+    res(const handle_t& handle, const uint8_t* in) { call_deserialize(handle, &value, in); }
+    ~res() { value.~T(); }  // NOLINT
+  };
+  // using a union to avoid initialization of T and force copy elision.
+  return res(handle, in).value;
+}
+
+template <typename T>
+auto call_deserialize(const handle_t& handle, const std::vector<uint8_t>& in) -> T
+{
+  return call_deserialize<T>(handle, in.data());
+}
+
+template <typename T>
+struct serialize {
+  // Default implementation for all arithmetic types: just write the value by the pointer.
+  template <typename S = T>
+  static auto run(const handle_t& handle, const S& obj, uint8_t* out)
+    -> std::enable_if_t<std::is_arithmetic_v<S>, size_t>
+  {
+    if (out) { *reinterpret_cast<T*>(out) = obj; }
+    return sizeof(obj);
+  }
+
+  // SFINAE-style failure
+  template <typename S = T>
+  static auto run(const handle_t& handle, const S& obj, uint8_t* out)
+    -> std::enable_if_t<!std::is_arithmetic_v<S>, size_t>
+  {
+    static_assert(!std::is_same_v<T, S>, "Serialization is not implemented for this type.");
+    return 0;
+  }
+};
+
+template <typename T>
+struct deserialize {
+  // Default implementation for all arithmetic types: just read the value by the pointer.
+  template <typename S = T>
+  static auto run(const handle_t& handle, T* p, const uint8_t* in)
+    -> std::enable_if_t<std::is_arithmetic_v<S>>
+  {
+    *p = *reinterpret_cast<const T*>(in);
+  }
+
+  // SFINAE-style failure
+  template <typename S = T>
+  static auto run(const handle_t& handle, T* p, const uint8_t* in)
+    -> std::enable_if_t<!std::is_arithmetic_v<S>>
+  {
+    static_assert(!std::is_same_v<T, S>, "Deserialization is not implemented for this type.");
+  }
+};
+
+template <typename IndexType, size_t... ExtentsPack>
+struct serialize<extents<IndexType, ExtentsPack...>> {
+  using obj_t = extents<IndexType, ExtentsPack...>;
+  static auto run(const handle_t& handle, const obj_t& obj, uint8_t* out) -> size_t
+  {
+    if (out) { *reinterpret_cast<obj_t*>(out) = obj; }
+    return sizeof(obj_t);
+  }
+};
+
+template <typename IndexType, size_t... ExtentsPack>
+struct deserialize<extents<IndexType, ExtentsPack...>> {
+  using obj_t = extents<IndexType, ExtentsPack...>;
+  static void run(const handle_t& handle, obj_t* p, const uint8_t* in)
+  {
+    new (p) obj_t{*reinterpret_cast<const obj_t*>(in)};
+  }
+};
+
+template <typename ElementType, typename Extents, typename LayoutPolicy>
+struct serialize<mdarray<ElementType,
+                         Extents,
+                         LayoutPolicy,
+                         detail::device_accessor<detail::device_uvector_policy<ElementType>>>> {
+  using obj_t = mdarray<ElementType,
+                        Extents,
+                        LayoutPolicy,
+                        detail::device_accessor<detail::device_uvector_policy<ElementType>>>;
+  static auto run(const handle_t& handle, const obj_t& obj, uint8_t* out) -> size_t
+  {
+    auto extents_size = call_serialize(handle, obj.extents(), out);
+    auto total_size   = obj.size() * sizeof(ElementType);
+    if (out) {
+      out += extents_size;
+      raft::copy(
+        reinterpret_cast<ElementType*>(out), obj.data_handle(), obj.size(), handle.get_stream());
+    }
+    return total_size;
+  }
+};
+
+template <typename ElementType, typename Extents, typename LayoutPolicy>
+struct deserialize<mdarray<ElementType,
+                           Extents,
+                           LayoutPolicy,
+                           detail::device_accessor<detail::device_uvector_policy<ElementType>>>> {
+  using obj_t = mdarray<ElementType,
+                        Extents,
+                        LayoutPolicy,
+                        detail::device_accessor<detail::device_uvector_policy<ElementType>>>;
+  static void run(const handle_t& handle, obj_t* p, const uint8_t* in)
+  {
+    auto exts         = call_deserialize<Extents>(handle, in);
+    auto extents_size = call_serialize(handle, exts, nullptr);
+    in += extents_size;
+    typename obj_t::mapping_type layout{exts};
+    typename obj_t::container_policy_type policy{handle.get_stream()};
+    new (p) obj_t{layout, policy};
+    raft::copy(
+      p->data_handle(), reinterpret_cast<const ElementType*>(in), p->size(), handle.get_stream());
+  }
+};
+
+}  // namespace raft::detail

--- a/cpp/include/raft/detail/serialization.hpp
+++ b/cpp/include/raft/detail/serialization.hpp
@@ -83,7 +83,7 @@ struct serial {
   static auto to_bytes(uint8_t* out, const S& obj)
     -> std::enable_if_t<std::is_arithmetic_v<S>, size_t>
   {
-    if (out) { *reinterpret_cast<T*>(out) = obj; }
+    if (out) { memcpy(out, &obj, sizeof(S)); }
     return sizeof(S);
   }
 
@@ -101,7 +101,7 @@ struct serial {
   static auto from_bytes(S* p, const uint8_t* in)
     -> std::enable_if_t<std::is_arithmetic_v<S>, size_t>
   {
-    *p = *reinterpret_cast<const S*>(in);
+    memcpy(p, in, sizeof(S));
     return sizeof(S);
   }
 

--- a/cpp/include/raft/detail/serialization.hpp
+++ b/cpp/include/raft/detail/serialization.hpp
@@ -25,6 +25,31 @@
 
 namespace raft::detail {
 
+/**
+ * The structure that holds implementation of serialization for a particular type.
+ * To add serialization to a given type, specialize this structure:
+ *
+ * @code{.cpp}
+ *
+ * template <>
+ * struct serial<YourStructure> {
+ *  static auto to_bytes(uint8_t* out, const YourStructure& obj, ...) -> size_t { ... }
+ *  static auto from_bytes(YourStructure* p, const uint8_t* in, ...) -> size_t { ... }
+ * };
+ * @endcode
+ *
+ * `serial::to_bytes` saves the state of the object to memory if `out` is not null;
+ *  returns the size of the output in any case.
+ *
+ * `serial::from_bytes` constructs a new object by a given _uninitialized_ pointer (a.k.a. placement
+ * new), reads the state from memory (`in`), and returns the number of bytes read.
+ *
+ * _See below this file for examples_.
+ *
+ * All of the `call_serialize` and `call_deserialize` are the convenience wrappers providing various
+ * ways to serialize/deserialize on top of `serial`. See `core/serialization.hpp` for their public
+ * documentation.
+ */
 template <typename T>
 struct serial;
 

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(test_raft
     test/interruptible.cu
     test/nvtx.cpp
     test/pow2_utils.cu
+    test/serialization.cpp
     test/label/label.cu
     test/label/merge_labels.cu
     test/lap/lap.cu

--- a/cpp/test/serialization.cpp
+++ b/cpp/test/serialization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/test/serialization.cpp
+++ b/cpp/test/serialization.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/core/handle.hpp>
+#include <raft/core/mdarray.hpp>
+#include <raft/core/serialization.hpp>
+
+#include <gtest/gtest.h>
+
+namespace raft {
+
+template <typename T, typename... Args>
+void test_serialization(Args... args)
+{
+  handle_t handle;
+  T x{args...};
+  auto s = serialize(handle, x);
+  auto y = deserialize<T>(handle, s);
+  ASSERT_EQ(x, y);
+}
+
+#define ARGS_HEAD(a, ...) a
+#define ARGS_TAIL(a, ...) __VA_ARGS__
+#define TEST_SIMPLE(...)                                                \
+  TEST(serialize, ARGS_HEAD(__VA_ARGS__))                               \
+  {                                                                     \
+    test_serialization<ARGS_HEAD(__VA_ARGS__)>(ARGS_TAIL(__VA_ARGS__)); \
+  }  // NOLINT
+
+TEST_SIMPLE(int, 42);
+TEST_SIMPLE(uint64_t, 1u);
+TEST_SIMPLE(float, 3.0f);
+
+struct not_initializable {
+  const uint32_t content;
+  static inline int count = 0;  // NOLINT
+
+  explicit not_initializable(uint32_t c) : content(c) { count++; }
+  not_initializable()                         = delete;
+  not_initializable(const not_initializable&) = delete;
+  not_initializable(not_initializable&& other) : content(other.content) { count++; }
+  auto operator=(const not_initializable&) -> not_initializable& = delete;
+  auto operator=(not_initializable&&) -> not_initializable& = delete;
+  ~not_initializable() { count--; }
+};
+
+namespace detail {
+
+template <>
+struct serialize<not_initializable> {
+  static auto run(const handle_t& handle, const not_initializable& obj, uint8_t* out) -> size_t
+  {
+    if (out) { *reinterpret_cast<uint32_t*>(out) = obj.content; }
+    return sizeof(not_initializable);
+  }
+};
+
+template <>
+struct deserialize<not_initializable> {
+  static void run(const handle_t& handle, not_initializable* obj, const uint8_t* in)
+  {
+    new (obj) not_initializable{*reinterpret_cast<const uint32_t*>(in)};
+  }
+};
+
+}  // namespace detail
+
+// Here, with the help of `not_initializable` we test two things:
+//  1. No extra unwanted constructors are called within `deserialize`.
+//  2. `deserialize` returns by value without extra copy constructors (copy elision)
+TEST(serialize, not_initializable)
+{
+  handle_t handle;
+  ASSERT_EQ(not_initializable::count, 0);
+  {
+    not_initializable x{17};
+    ASSERT_EQ(not_initializable::count, 1);
+    auto s = serialize(handle, x);
+    ASSERT_EQ(not_initializable::count, 1);
+    auto y = deserialize<not_initializable>(handle, s);
+    ASSERT_EQ(not_initializable::count, 2);
+    ASSERT_EQ(x.content, y.content);
+  }
+  ASSERT_EQ(not_initializable::count, 0);
+}
+
+TEST(serialize, mdarray)
+{
+  handle_t handle;
+  auto exts = make_extents<int>(2, 3, 4);
+  auto x    = make_device_mdarray<double>(handle, exts);
+  auto s    = serialize(handle, x);
+  auto y    = deserialize<decltype(x)>(handle, s);
+  ASSERT_EQ(x.extents(), y.extents());
+  for (int i = 0; i < exts.extent(2); i++) {
+    ASSERT_EQ(x(0, 2, i), y(0, 2, i));
+  }
+}
+
+}  // namespace raft


### PR DESCRIPTION
This draft pull request adds a simple serialization to commonly used types in raft.

__Serialized layout__
_Simple_ here refers to the way the data is stored: at the moment, no safety/type/versioning information is preserved; only a bare minimum of information is stored to a byte array and read back.

__Target type__
In the most basic form, the target of serialization is a raw pointer. Currently, I also provide overloads to store data to `vector<uint8_t>`.

__ContextArgs... args__
Plain structures and arithmetic types do not require any context to serialize/deserialize (zero args). The data on gpu devices needs, at least, a cuda stream (one arg). mdarrays / rmm vectors may need a memory resource to tell where to keep the deserialized live object (two args). To allow all of these in a single template, I chose to use a parameter pack in this iteration.

Closes: https://github.com/rapidsai/raft/issues/752