### PR TITLE
Use rapids-cmake 22.10 best practice for RAPIDS.cmake location

### DIFF
--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -11,7 +11,9 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
-file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
-     ${CMAKE_BINARY_DIR}/RAPIDS.cmake
-)
-include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RAFT_RAPIDS.cmake)
+  file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.10/RAPIDS.cmake
+       ${CMAKE_CURRENT_BINARY_DIR}/RAFT_RAPIDS.cmake
+  )
+endif()
+include(${CMAKE_CURRENT_BINARY_DIR}/RAFT_RAPIDS.cmake)


### PR DESCRIPTION
Removes possibility of another projects `RAPIDS.cmake` being used, and removes need to always download a version.