### PR TITLE
Using std::vector instead of arrays in gtests

### DIFF
--- a/cpp/test/device_atomics.cu
+++ b/cpp/test/device_atomics.cu
@@ -15,7 +15,7 @@
  */
 
 #include <algorithm>
-#include <array>
+#include <vector>
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <iostream>
@@ -46,7 +46,7 @@ TEST(Raft, AtomicIncWarp)
 
   rmm::device_scalar<int> counter{0, s};
   rmm::device_uvector<int> out_device{num_elts, s};
-  std::array<int, num_elts> out_host{0};
+  std::vector<int> out_host(num_elts, 0);
 
   // Write all 1M thread indices to a unique location in `out_device`
   test_atomic_inc_warp_kernel<<<num_blocks, threads_per_block, 0, s>>>(counter.data(),

--- a/cpp/test/device_atomics.cu
+++ b/cpp/test/device_atomics.cu
@@ -15,7 +15,6 @@
  */
 
 #include <algorithm>
-#include <vector>
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <iostream>
@@ -26,6 +25,7 @@
 #include <rmm/cuda_stream_pool.hpp>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+#include <vector>
 
 namespace raft {
 

--- a/cpp/test/device_atomics.cu
+++ b/cpp/test/device_atomics.cu
@@ -46,7 +46,8 @@ TEST(Raft, AtomicIncWarp)
 
   rmm::device_scalar<int> counter{0, s};
   rmm::device_uvector<int> out_device{num_elts, s};
-  std::vector<int> out_host(num_elts, 0);
+  std::vector<int> out_host(num_elts);
+  memset(out_host.data(), 0, num_elts * sizeof(int));
 
   // Write all 1M thread indices to a unique location in `out_device`
   test_atomic_inc_warp_kernel<<<num_blocks, threads_per_block, 0, s>>>(counter.data(),

--- a/cpp/test/stats/sum.cu
+++ b/cpp/test/stats/sum.cu
@@ -23,8 +23,8 @@
 
 #include <rmm/device_uvector.hpp>
 
-#include <vector>
 #include <gtest/gtest.h>
+#include <vector>
 
 namespace raft {
 namespace stats {

--- a/cpp/test/stats/sum.cu
+++ b/cpp/test/stats/sum.cu
@@ -23,6 +23,7 @@
 
 #include <rmm/device_uvector.hpp>
 
+#include <vector>
 #include <gtest/gtest.h>
 
 namespace raft {
@@ -59,12 +60,12 @@ class SumTest : public ::testing::TestWithParam<SumInputs<T>> {
   {
     int len = rows * cols;
 
-    T data_h[len];
+    std::vector<T> data_h(len);
     for (int i = 0; i < len; i++) {
       data_h[i] = T(1);
     }
 
-    raft::update_device(data.data(), data_h, len, stream);
+    raft::update_device(data.data(), data_h.data(), len, stream);
     sum(sum_act.data(), data.data(), cols, rows, false, stream);
     handle.sync_stream(stream);
   }


### PR DESCRIPTION
This fixes some strange behavior we're encountering in the `stats/SumTest` and `AtomicWarpInc` test. For some reason, when using a fixed-sized array we get a segfault. We're not sure yet if it's a `g++ 9.4.0` specific problem or related to something else in the system configuration but we aren't able to reproduce this in `g++ 9.3.0`. 