### PR TITLE
Prepare parts of the balanced kmeans for ivf-pq

### DIFF
--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -419,12 +419,12 @@ template <typename T>
 void build_clusters(const handle_t& handle,
                     uint32_t n_iters,
                     uint32_t dim,
-                    const T* dataset,  // managed; [n_rows, dim]
+                    const T* dataset,  // device; [n_rows, dim]
                     size_t n_rows,
                     uint32_t n_clusters,
-                    float* cluster_centers,    // managed; [n_clusters, dim]
-                    uint32_t* cluster_labels,  // managed; [n_rows]
-                    uint32_t* cluster_sizes,   // managed; [n_clusters]
+                    float* cluster_centers,    // device; [n_clusters, dim]
+                    uint32_t* cluster_labels,  // device; [n_rows]
+                    uint32_t* cluster_sizes,   // device; [n_clusters]
                     raft::distance::DistanceType metric,
                     rmm::mr::device_memory_resource* device_memory,
                     rmm::cuda_stream_view stream)

--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -439,7 +439,7 @@ auto adjust_centers(float* centers,
  * @param n_cluster the requested number of clusters
  * @param[inout] cluster_centers a pointer to a managed row-major array [n_clusters, dim]
  * @param[out] cluster_labels a pointer to a managed row-major array [n_rows]
- * @param[out] cluster_labels a pointer to a managed row-major array [n_clusters]
+ * @param[out] cluster_sizes a pointer to a managed row-major array [n_clusters]
  * @param metric the distance type (there is a tweak in place for the similarity-based metrics)
  * @param balancing_pullback
  *   if the cluster centers are rebalanced on this number of iterations,

--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -492,7 +492,9 @@ void balancing_em_iters(const handle_t& handle,
                            true,
                            stream);
     // Balancing step - move the centers around to equalize cluster sizes
-    if (iter + 1 < balancing_pullback * n_iters) {
+    if (iter + balancing_pullback < balancing_pullback * n_iters + 1) {
+      // The condition above ensures that `adjust_centers` never comes last in the process;
+      // if at least one center is adjusted, `predict` runs afterwards.
       if (kmeans::adjust_centers(cluster_centers,
                                  n_clusters,
                                  dim,

--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -56,16 +56,16 @@ constexpr static inline const float kAdjustCentersWeight = 7.0f;
  * @param stream
  * @param mr (optional) memory resource to use for temporary allocations
  */
-void predict_float_core(const handle_t& handle,
-                        const float* centers,
-                        uint32_t n_clusters,
-                        uint32_t dim,
-                        const float* dataset,
-                        size_t n_rows,
-                        uint32_t* labels,
-                        raft::distance::DistanceType metric,
-                        rmm::cuda_stream_view stream,
-                        rmm::mr::device_memory_resource* mr)
+inline void predict_float_core(const handle_t& handle,
+                               const float* centers,
+                               uint32_t n_clusters,
+                               uint32_t dim,
+                               const float* dataset,
+                               size_t n_rows,
+                               uint32_t* labels,
+                               raft::distance::DistanceType metric,
+                               rmm::cuda_stream_view stream,
+                               rmm::mr::device_memory_resource* mr)
 {
   rmm::device_uvector<float> distances(n_rows * n_clusters, stream, mr);
 
@@ -118,7 +118,7 @@ void predict_float_core(const handle_t& handle,
  * @param n_rows dataset size
  * @return a suggested minibatch size
  */
-constexpr auto calc_minibatch_size(uint32_t n_clusters, size_t n_rows) -> uint32_t
+constexpr inline auto calc_minibatch_size(uint32_t n_clusters, size_t n_rows) -> uint32_t
 {
   n_clusters              = std::max<uint32_t>(1, n_clusters);
   uint32_t minibatch_size = (1 << 20);
@@ -487,10 +487,10 @@ void build_clusters(const handle_t& handle,
 }
 
 /** Calculate how many fine clusters should belong to each mesocluster. */
-auto arrange_fine_clusters(uint32_t n_clusters,
-                           uint32_t n_mesoclusters,
-                           size_t n_rows,
-                           const uint32_t* mesocluster_sizes)
+inline auto arrange_fine_clusters(uint32_t n_clusters,
+                                  uint32_t n_mesoclusters,
+                                  size_t n_rows,
+                                  const uint32_t* mesocluster_sizes)
 {
   std::vector<uint32_t> fine_clusters_nums(n_mesoclusters);
   std::vector<uint32_t> fine_clusters_csum(n_mesoclusters + 1);

--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -656,7 +656,7 @@ auto build_fine_clusters(const handle_t& handle,
                          rmm::mr::device_memory_resource* device_memory,
                          rmm::cuda_stream_view stream) -> uint32_t
 {
-  rmm::device_uvector<uint32_t> mc_trainset_ids_buf(mesocluster_size_max, stream, managed_memory);
+  rmm::device_uvector<size_t> mc_trainset_ids_buf(mesocluster_size_max, stream, managed_memory);
   rmm::device_uvector<float> mc_trainset_buf(mesocluster_size_max * dim, stream, device_memory);
   auto mc_trainset_ids = mc_trainset_ids_buf.data();
   auto mc_trainset     = mc_trainset_buf.data();

--- a/cpp/include/raft/spatial/knn/detail/ann_utils.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_utils.cuh
@@ -493,20 +493,20 @@ void outer_add(
   outer_add_kernel<<<blocks, threads, 0, stream>>>(a, len_a, b, len_b, c);
 }
 
-template <typename T, typename S>
-__global__ void copy_selected_kernel(uint32_t n_rows,
-                                     uint32_t n_cols,
+template <typename T, typename S, typename IdxT>
+__global__ void copy_selected_kernel(uint64_t n_rows,
+                                     uint64_t n_cols,
                                      const S* src,
-                                     const uint32_t* row_ids,
-                                     uint32_t ld_src,
+                                     const IdxT* row_ids,
+                                     uint64_t ld_src,
                                      T* dst,
-                                     uint32_t ld_dst)
+                                     uint64_t ld_dst)
 {
-  uint64_t gid   = threadIdx.x + blockDim.x * blockIdx.x;
+  uint64_t gid   = threadIdx.x + uint64_t{blockDim.x} * uint64_t{blockIdx.x};
   uint64_t j     = gid % n_cols;
   uint64_t i_dst = gid / n_cols;
   if (i_dst >= n_rows) return;
-  uint64_t i_src          = row_ids[i_dst];
+  auto i_src              = static_cast<uint64_t>(row_ids[i_dst]);
   dst[ld_dst * i_dst + j] = mapping<T>{}(src[ld_src * i_src + j]);
 }
 
@@ -526,28 +526,28 @@ __global__ void copy_selected_kernel(uint32_t n_rows,
  * @param ld_dst number of cols in the output (ld_dst >= n_cols)
  * @param stream
  */
-template <typename T, typename S>
-void copy_selected(uint32_t n_rows,
-                   uint32_t n_cols,
+template <typename T, typename S, typename IdxT>
+void copy_selected(uint64_t n_rows,
+                   uint64_t n_cols,
                    const S* src,
-                   const uint32_t* row_ids,
-                   uint32_t ld_src,
+                   const IdxT* row_ids,
+                   uint64_t ld_src,
                    T* dst,
-                   uint32_t ld_dst,
+                   uint64_t ld_dst,
                    rmm::cuda_stream_view stream)
 {
-  switch (check_pointer_residency(src, dst)) {
+  switch (check_pointer_residency(src, dst, row_ids)) {
     case pointer_residency::host_and_device:
     case pointer_residency::device_only: {
-      uint32_t block_dim = 128;
-      uint32_t grid_dim  = ceildiv(n_rows * n_cols, block_dim);
+      uint64_t block_dim = 128;
+      uint64_t grid_dim  = ceildiv(n_rows * n_cols, block_dim);
       copy_selected_kernel<T, S>
         <<<grid_dim, block_dim, 0, stream>>>(n_rows, n_cols, src, row_ids, ld_src, dst, ld_dst);
     } break;
     case pointer_residency::host_only: {
       stream.synchronize();
       for (uint64_t i_dst = 0; i_dst < n_rows; i_dst++) {
-        uint64_t i_src = row_ids[i_dst];
+        auto i_src = static_cast<uint64_t>(row_ids[i_dst]);
         for (uint64_t j = 0; j < n_cols; j++) {
           dst[ld_dst * i_dst + j] = mapping<T>{}(src[ld_src * i_src + j]);
         }


### PR DESCRIPTION
Backport a piece of implementation from cuann/ivf-pq. This include:
  1. Move part of the internal kmeans code to GPU, thus reducing the number of necessary managed memory allocations;
  2. Split some of the functions into smaller reusable pieces;
  3. Move dataset-trainset sampling to the caller side.