### PR TITLE
Add alignment to the TxN_t vectorized type

### DIFF
--- a/cpp/include/raft/vectorized.cuh
+++ b/cpp/include/raft/vectorized.cuh
@@ -269,7 +269,7 @@ struct TxN_t {
   /** defines the number of 'math_t' types stored by this struct */
   static const int Ratio = veclen_;
 
-  struct {
+  struct alignas(io_t) {
     /** the vectorized data that is used for subsequent operations */
     math_t data[Ratio];
   } val;


### PR DESCRIPTION
The recent removal of the union-based type punning in https://github.com/rapidsai/raft/pull/781 caused misaligned access in some cases. This PR returns the alignment to the data type.