### PR TITLE
[FEA] Statically link all CUDA toolkit libraries

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -53,7 +53,7 @@ option(BUILD_TESTS "Build raft unit-tests" ON)
 option(BUILD_BENCH "Build raft C++ benchmark tests" OFF)
 option(CUDA_ENABLE_KERNELINFO "Enable kernel resource usage info" OFF)
 option(CUDA_ENABLE_LINEINFO "Enable the -lineinfo option for nvcc (useful for cuda-memcheck / profiler)" OFF)
-option(CUDA_STATIC_RUNTIME "Statically link the CUDA runtime" OFF)
+option(CUDA_STATIC_RUNTIME "Statically link the CUDA toolkit runtime and libraries" OFF)
 option(DETECT_CONDA_ENV "Enable detection of conda environment for dependencies" ON)
 option(DISABLE_DEPRECATION_WARNINGS "Disable deprecaction warnings " ON)
 option(DISABLE_OPENMP "Disable OpenMP" OFF)
@@ -85,7 +85,7 @@ message(VERBOSE "RAFT: Disable OpenMP: ${DISABLE_OPENMP}")
 message(VERBOSE "RAFT: Enable kernel resource usage info: ${CUDA_ENABLE_KERNELINFO}")
 message(VERBOSE "RAFT: Enable lineinfo in nvcc: ${CUDA_ENABLE_LINEINFO}")
 message(VERBOSE "RAFT: Enable nvtx markers: ${RAFT_NVTX}")
-message(VERBOSE "RAFT: Statically link the CUDA runtime: ${CUDA_STATIC_RUNTIME}")
+message(VERBOSE "RAFT: Statically link the CUDA toolkit runtime and libraries: ${CUDA_STATIC_RUNTIME}")
 
 # Set RMM logging level
 set(RMM_LOGGING_LEVEL "INFO" CACHE STRING "Choose the logging level.")
@@ -105,6 +105,21 @@ endif()
 
 ##############################################################################
 # - compiler options ---------------------------------------------------------
+
+set(_ctk_static_suffix "")
+if(CUDA_STATIC_RUNTIME)
+  # If we're statically linking CTK cuBLAS,
+  # we also want to statically link BLAS
+  set(BLA_STATIC ON)
+  set(_ctk_static_suffix "_static")
+  # Control legacy FindCUDA.cmake behavior too
+  # Remove this after we push it into rapids-cmake:
+  # https://github.com/rapidsai/rapids-cmake/pull/259
+  set(CUDA_USE_STATIC_CUDA_RUNTIME ON)
+endif()
+
+# CUDA runtime
+rapids_cuda_init_runtime(USE_STATIC ${CUDA_STATIC_RUNTIME})
 
 if (NOT DISABLE_OPENMP)
   find_package(OpenMP)
@@ -168,12 +183,11 @@ target_include_directories(raft INTERFACE
 # Only CUDA libs and rmm should
 # be used in global target.
 target_link_libraries(raft INTERFACE
-        CUDA::cublas
-        CUDA::curand
-        CUDA::cusolver
-        CUDA::cudart
-        CUDA::cusparse
         rmm::rmm
+        CUDA::cublas${_ctk_static_suffix}
+        CUDA::curand${_ctk_static_suffix}
+        CUDA::cusolver${_ctk_static_suffix}
+        CUDA::cusparse${_ctk_static_suffix}
         $<$<BOOL:${RAFT_ENABLE_thrust_DEPENDENCY}>:raft::Thrust>
 )
 

--- a/cpp/cmake/thirdparty/get_faiss.cmake
+++ b/cpp/cmake/thirdparty/get_faiss.cmake
@@ -15,7 +15,7 @@
 #=============================================================================
 
 function(find_and_configure_faiss)
-    set(oneValueArgs VERSION PINNED_TAG BUILD_STATIC_LIBS EXCLUDE_FROM_ALL)
+    set(oneValueArgs VERSION REPOSITORY PINNED_TAG BUILD_STATIC_LIBS EXCLUDE_FROM_ALL)
     cmake_parse_arguments(PKG "${options}" "${oneValueArgs}"
                           "${multiValueArgs}" ${ARGN} )
 
@@ -33,7 +33,7 @@ function(find_and_configure_faiss)
       rapids_cpm_find(faiss ${PKG_VERSION}
           GLOBAL_TARGETS     faiss::faiss
           CPM_ARGS
-            GIT_REPOSITORY   https://github.com/facebookresearch/faiss.git
+            GIT_REPOSITORY   ${PKG_REPOSITORY}
             GIT_TAG          ${PKG_PINNED_TAG}
             EXCLUDE_FROM_ALL ${PKG_EXCLUDE_FROM_ALL}
             OPTIONS
@@ -42,6 +42,7 @@ function(find_and_configure_faiss)
               "FAISS_ENABLE_GPU ON"
               "BUILD_TESTING OFF"
               "CMAKE_MESSAGE_LOG_LEVEL VERBOSE"
+              "FAISS_USE_CUDA_TOOLKIT_STATIC ${CUDA_STATIC_RUNTIME}"
       )
 
       if(TARGET faiss AND NOT TARGET faiss::faiss)
@@ -66,7 +67,22 @@ function(find_and_configure_faiss)
     rapids_export_find_package_root(BUILD faiss [=[${CMAKE_CURRENT_LIST_DIR}]=] raft-nn-lib-exports)
 endfunction()
 
+if(NOT RAFT_FAISS_GIT_TAG)
+  # TODO: Remove this once faiss supports FAISS_USE_CUDA_TOOLKIT_STATIC
+  # (https://github.com/facebookresearch/faiss/pull/2446)
+  set(RAFT_FAISS_GIT_TAG fea/statically-link-ctk-v1.7.0)
+  # set(RAFT_FAISS_GIT_TAG bde7c0027191f29c9dadafe4f6e68ca0ee31fb30)
+endif()
+
+if(NOT RAFT_FAISS_GIT_REPOSITORY)
+  # TODO: Remove this once faiss supports FAISS_USE_CUDA_TOOLKIT_STATIC
+  # (https://github.com/facebookresearch/faiss/pull/2446)
+  set(RAFT_FAISS_GIT_REPOSITORY https://github.com/trxcllnt/faiss.git)
+  # set(RAFT_FAISS_GIT_REPOSITORY https://github.com/facebookresearch/faiss.git)
+endif()
+
 find_and_configure_faiss(VERSION    1.7.0
-                         PINNED_TAG  bde7c0027191f29c9dadafe4f6e68ca0ee31fb30
+                         REPOSITORY  ${RAFT_FAISS_GIT_REPOSITORY}
+                         PINNED_TAG  ${RAFT_FAISS_GIT_TAG}
                          BUILD_STATIC_LIBS ${RAFT_USE_FAISS_STATIC}
                          EXCLUDE_FROM_ALL ${RAFT_EXCLUDE_FAISS_FROM_ALL})


### PR DESCRIPTION
This PR ensures RAFT statically links all the CUDA toolkit libraries (not just `cudart`) if a user enables `CUDA_STATIC_RUNTIME`.