### PR TITLE
Making sure we are benchmarking both `build()` and `extend()` from IVF-flat

### DIFF
--- a/cpp/bench/spatial/knn.cu
+++ b/cpp/bench/spatial/knn.cu
@@ -140,10 +140,11 @@ struct ivf_flat_knn {
   {
     index_params.n_lists                  = 4096;
     index_params.metric                   = raft::distance::DistanceType::L2Expanded;
-    index_params.kmeans_trainset_fraction = 0.3 index_params.add_data_on_build =
-      false index.emplace(raft::spatial::knn::ivf_flat::build(
-        handle, index_params, data, IdxT(ps.n_samples), uint32_t(ps.n_dims)));
-    index.emplace(raft::spatial::knn::ivf_flat::build<ValT, IdxT>(
+    index_params.kmeans_trainset_fraction = 0.3;
+    index_params.add_data_on_build        = false;
+    index.emplace(raft::spatial::knn::ivf_flat::build(
+      handle, index_params, data, IdxT(ps.n_samples), uint32_t(ps.n_dims)));
+    index.emplace(raft::spatial::knn::ivf_flat::extend<ValT, IdxT>(
       handle, index.value(), data, std::nullptr, IdxT(ps.n_samples)));
   }
 

--- a/cpp/bench/spatial/knn.cu
+++ b/cpp/bench/spatial/knn.cu
@@ -140,7 +140,7 @@ struct ivf_flat_knn {
   {
     index_params.n_lists                  = 4096;
     index_params.metric                   = raft::distance::DistanceType::L2Expanded;
-    index_params.kmeans_trainset_fraction = 0.3;
+    index_params.kmeans_trainset_fraction = 1;
     index_params.add_data_on_build        = false;
     index.emplace(raft::spatial::knn::ivf_flat::build(
       handle, index_params, data, IdxT(ps.n_samples), uint32_t(ps.n_dims)));

--- a/cpp/bench/spatial/knn.cu
+++ b/cpp/bench/spatial/knn.cu
@@ -19,6 +19,7 @@
 #include <raft/random/rng.cuh>
 
 #include <raft/spatial/knn/ivf_flat.cuh>
+#include <raft/spatial/knn/knn.cuh>
 #if defined RAFT_NN_COMPILED
 #include <raft/spatial/knn/specializations.cuh>
 #endif
@@ -145,7 +146,7 @@ struct ivf_flat_knn {
     index.emplace(raft::spatial::knn::ivf_flat::build(
       handle, index_params, data, IdxT(ps.n_samples), uint32_t(ps.n_dims)));
     index.emplace(raft::spatial::knn::ivf_flat::extend<ValT, IdxT>(
-      handle, index.value(), data, std::nullptr, IdxT(ps.n_samples)));
+      handle, index.value(), data, nullptr, IdxT(ps.n_samples)));
   }
 
   void search(const raft::handle_t& handle,

--- a/cpp/bench/spatial/knn.cu
+++ b/cpp/bench/spatial/knn.cu
@@ -138,15 +138,13 @@ struct ivf_flat_knn {
 
   ivf_flat_knn(const raft::handle_t& handle, const params& ps, const ValT* data) : ps(ps)
   {
-    index_params.n_lists = 4096;
-    index_params.metric  = raft::distance::DistanceType::L2Expanded;
-    index_params.kmeans_trainset_fraction = 0.3
-    index_params.add_data_on_build = false
-    index.emplace(raft::spatial::knn::ivf_flat::build(
-      handle, index_params, data, IdxT(ps.n_samples), uint32_t(ps.n_dims)));
+    index_params.n_lists                  = 4096;
+    index_params.metric                   = raft::distance::DistanceType::L2Expanded;
+    index_params.kmeans_trainset_fraction = 0.3 index_params.add_data_on_build =
+      false index.emplace(raft::spatial::knn::ivf_flat::build(
+        handle, index_params, data, IdxT(ps.n_samples), uint32_t(ps.n_dims)));
     index.emplace(raft::spatial::knn::ivf_flat::build<ValT, IdxT>(
       handle, index.value(), data, std::nullptr, IdxT(ps.n_samples)));
-
   }
 
   void search(const raft::handle_t& handle,

--- a/cpp/bench/spatial/knn.cu
+++ b/cpp/bench/spatial/knn.cu
@@ -140,8 +140,13 @@ struct ivf_flat_knn {
   {
     index_params.n_lists = 4096;
     index_params.metric  = raft::distance::DistanceType::L2Expanded;
+    index_params.kmeans_trainset_fraction = 0.3
+    index_params.add_data_on_build = false
     index.emplace(raft::spatial::knn::ivf_flat::build(
       handle, index_params, data, IdxT(ps.n_samples), uint32_t(ps.n_dims)));
+    index.emplace(raft::spatial::knn::ivf_flat::build<ValT, IdxT>(
+      handle, index.value(), data, std::nullptr, IdxT(ps.n_samples)));
+
   }
 
   void search(const raft::handle_t& handle,


### PR DESCRIPTION
For the FAISS integration, we have to invoke both `build()` and `extend()` in IVF-flat (corresponding to `train()` and `add()` in FAISS parlance). Even though the impact should be small, this makes sure we're always considering the effect of `extend()` when tuning performance.