### PR TITLE
[REVIEW] mdspan-ify rmat_rectangular_gen

### DIFF
--- a/cpp/include/raft/random/detail/rmat_rectangular_generator.cuh
+++ b/cpp/include/raft/random/detail/rmat_rectangular_generator.cuh
@@ -16,10 +16,15 @@
 
 #pragma once
 
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/handle.hpp>
 #include <raft/random/rng_device.cuh>
 #include <raft/random/rng_state.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
+
+#include <optional>
+#include <variant>
 
 namespace raft {
 namespace random {
@@ -180,6 +185,315 @@ void rmat_rectangular_gen_caller(IdxT* out,
     out, out_src, out_dst, a, b, c, r_scale, c_scale, n_edges, max_scale, r);
   RAFT_CUDA_TRY(cudaGetLastError());
   r.advance(n_edges, max_scale);
+}
+
+/**
+ * @brief Implementation detail for checking output vector parameter(s)
+ *   of `raft::random::rmat_rectangular_gen`.
+ *
+ * @tparam IdxT Type of each node index; must be integral.
+ *
+ * Users can provide either `out` by itself, (`out_src` and `out_dst`)
+ * together, or all three (`out`, `out_src`, and `out_dst`).
+ * This class prevents users from doing anything other than that.
+ * It also checks compatibility of dimensions at run time.
+ *
+ * The following examples show how to create an output parameter.
+ *
+ * @code
+ * rmat_rectangular_gen_output<size_t> output1(out);
+ * rmat_rectangular_gen_output<size_t> output2(out_src, out_dst);
+ * rmat_rectangular_gen_output<size_t> output3(out, out_src, out_dst);
+ * @endcode
+ *
+ */
+template <typename IdxT>
+class rmat_rectangular_gen_output {
+ public:
+  using out_view_type =
+    raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major>;
+  using out_src_view_type = raft::device_vector_view<IdxT, IdxT>;
+  using out_dst_view_type = raft::device_vector_view<IdxT, IdxT>;
+
+ private:
+  class output_pair {
+   public:
+    output_pair(const out_src_view_type& src, const out_dst_view_type& dst) : src_(src), dst_(dst)
+    {
+      RAFT_EXPECTS(src.extent(0) == dst.extent(0),
+                   "rmat_rectangular_gen: "
+                   "out_src.extent(0) = %zu != out_dst.extent(0) = %zu",
+                   static_cast<std::size_t>(src.extent(0)),
+                   static_cast<std::size_t>(dst.extent(0)));
+    }
+
+    out_src_view_type out_src_view() const { return src_; }
+
+    out_dst_view_type out_dst_view() const { return dst_; }
+
+    IdxT number_of_edges() const { return src_.extent(0); }
+
+   private:
+    out_src_view_type src_;
+    out_dst_view_type dst_;
+  };
+
+  class output_triple {
+   public:
+    output_triple(const out_view_type& out,
+                  const out_src_view_type& src,
+                  const out_dst_view_type& dst)
+      : out_(out), pair_(src, dst)
+    {
+      RAFT_EXPECTS(out.extent(0) == IdxT(2) * dst.extent(0),
+                   "rmat_rectangular_gen: "
+                   "out.extent(0) = %zu != 2 * out_dst.extent(0) = %zu",
+                   static_cast<std::size_t>(out.extent(0)),
+                   static_cast<std::size_t>(IdxT(2) * dst.extent(0)));
+    }
+
+    out_view_type out_view() const { return out_; }
+
+    out_src_view_type out_src_view() const { return pair_.out_src_view(); }
+
+    out_dst_view_type out_dst_view() const { return pair_.out_dst_view(); }
+
+    IdxT number_of_edges() const { return pair_.number_of_edges(); }
+
+   private:
+    out_view_type out_;
+    output_pair pair_;
+  };
+
+ public:
+  /**
+   * @brief Constructor taking no vectors,
+   *   that effectively makes all the vectors length zero.
+   */
+  rmat_rectangular_gen_output() = default;
+
+  /**
+   * @brief Constructor taking a single vector, that packs the source
+   *   node ids and destination node ids in array-of-structs fashion.
+   *
+   * @param[out] out Generated edgelist [on device].  In each row, the
+   *   first element is the source node id, and the second element is
+   *   the destination node id.
+   */
+  rmat_rectangular_gen_output(const out_view_type& out) : data_(out) {}
+
+  /**
+   * @brief Constructor taking two vectors, that store the source node
+   *   ids and the destination node ids separately, in
+   *   struct-of-arrays fashion.
+   *
+   * @param[out] out_src Source node id's [on device] [len = n_edges].
+   *
+   * @param[out] out_dst Destination node id's [on device] [len = n_edges].
+   */
+  rmat_rectangular_gen_output(const out_src_view_type& src, const out_dst_view_type& dst)
+    : data_(output_pair(src, dst))
+  {
+  }
+
+  /**
+   * @brief Constructor taking all three vectors.
+   *
+   * @param[out] out Generated edgelist [on device].  In each row, the
+   *   first element is the source node id, and the second element is
+   *   the destination node id.
+   *
+   * @param[out] out_src Source node id's [on device] [len = n_edges].
+   *
+   * @param[out] out_dst Destination node id's [on device] [len = n_edges].
+   */
+  rmat_rectangular_gen_output(const out_view_type& out,
+                              const out_src_view_type& src,
+                              const out_dst_view_type& dst)
+    : data_(output_triple(out, src, dst))
+  {
+  }
+
+  /**
+   * @brief Whether this object was created with a constructor
+   *   taking more than zero arguments.
+   */
+  bool has_value() const { return not std::holds_alternative<std::nullopt_t>(data_); }
+
+  /**
+   * @brief Vector for the output single edgelist; the argument given
+   *   to the one-argument constructor, or the first argument of the
+   *   three-argument constructor; `std::nullopt` if not provided.
+   */
+  std::optional<out_view_type> out_view() const
+  {
+    if (std::holds_alternative<out_view_type>(data_)) {
+      return std::get<out_view_type>(data_);
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).out_view();
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief Vector for the output source edgelist; the first argument
+   *   given to the two-argument constructor, or the second argument
+   *   of the three-argument constructor; `std::nullopt` if not provided.
+   */
+  std::optional<out_src_view_type> out_src_view() const
+  {
+    if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).out_src_view();
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).out_src_view();
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief Vector for the output destination edgelist; the second
+   *   argument given to the two-argument constructor, or the third
+   *   argument of the three-argument constructor;
+   *   `std::nullopt` if not provided.
+   */
+  std::optional<out_dst_view_type> out_dst_view() const
+  {
+    if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).out_dst_view();
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).out_dst_view();
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief Number of edges in the graph; zero if no output vector
+   *   was provided to the constructor.
+   */
+  IdxT number_of_edges() const
+  {
+    if (std::holds_alternative<out_view_type>(data_)) {
+      return std::get<out_view_type>(data_).extent(0);
+    } else if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).number_of_edges();
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).number_of_edges();
+    } else {
+      return IdxT(0);
+    }
+  }
+
+ private:
+  // Defaults to std::nullopt.
+  std::variant<std::nullopt_t, out_view_type, output_pair, output_triple> data_;
+};
+
+/**
+ * @brief Implementation of `raft::random::rmat_rectangular_gen_impl`.
+ *
+ * @tparam IdxT  type of each node index
+ * @tparam ProbT data type used for probability distributions (either fp32 or fp64)
+ * @param[in]  handle  RAFT handle, containing the CUDA stream on which to schedule work
+ * @param[in]  r       underlying state of the random generator. Especially useful when
+ *                     one wants to call this API for multiple times in order to generate
+ *                     a larger graph. For that case, just create this object with the
+ *                     initial seed once and after every call continue to pass the same
+ *                     object for the successive calls.
+ * @param[out] output  Encapsulation of one, two, or three output vectors.
+ * @param[in]  theta   distribution of each quadrant at each level of resolution.
+ *                     Since these are probabilities, each of the 2x2 matrices for
+ *                     each level of the RMAT must sum to one. [on device]
+ *                     [dim = max(r_scale, c_scale) x 2 x 2]. Of course, it is assumed
+ *                     that each of the group of 2 x 2 numbers all sum up to 1.
+ * @param[in]  r_scale 2^r_scale represents the number of source nodes
+ * @param[in]  c_scale 2^c_scale represents the number of destination nodes
+ */
+template <typename IdxT, typename ProbT>
+void rmat_rectangular_gen_impl(const raft::handle_t& handle,
+                               raft::random::RngState& r,
+                               raft::device_vector_view<const ProbT, IdxT> theta,
+                               raft::random::detail::rmat_rectangular_gen_output<IdxT> output,
+                               IdxT r_scale,
+                               IdxT c_scale)
+{
+  static_assert(std::is_integral_v<IdxT>,
+                "rmat_rectangular_gen: "
+                "Template parameter IdxT must be an integral type");
+  if (not output.has_value()) {
+    return;  // nothing to do; not an error
+  }
+
+  const IdxT expected_theta_len = IdxT(4) * (r_scale >= c_scale ? r_scale : c_scale);
+  RAFT_EXPECTS(theta.extent(0) == expected_theta_len,
+               "rmat_rectangular_gen: "
+               "theta.extent(0) = %zu != 2 * 2 * max(r_scale = %zu, c_scale = %zu) = %zu",
+               static_cast<std::size_t>(theta.extent(0)),
+               static_cast<std::size_t>(r_scale),
+               static_cast<std::size_t>(c_scale),
+               static_cast<std::size_t>(expected_theta_len));
+
+  auto out                     = output.out_view();
+  auto out_src                 = output.out_src_view();
+  auto out_dst                 = output.out_dst_view();
+  const bool out_has_value     = out.has_value();
+  const bool out_src_has_value = out_src.has_value();
+  const bool out_dst_has_value = out_dst.has_value();
+  IdxT* out_ptr                = out_has_value ? (*out).data_handle() : nullptr;
+  IdxT* out_src_ptr            = out_src_has_value ? (*out_src).data_handle() : nullptr;
+  IdxT* out_dst_ptr            = out_dst_has_value ? (*out_dst).data_handle() : nullptr;
+  const IdxT n_edges           = output.number_of_edges();
+
+  rmat_rectangular_gen_caller(out_ptr,
+                              out_src_ptr,
+                              out_dst_ptr,
+                              theta.data_handle(),
+                              r_scale,
+                              c_scale,
+                              n_edges,
+                              handle.get_stream(),
+                              r);
+}
+
+/**
+ * @brief Overload of `rmat_rectangular_gen` that assumes the same
+ *   a, b, c, d probability distributions across all the scales.
+ *
+ * `a`, `b, and `c` effectively replace the above overload's
+ * `theta` parameter.
+ */
+template <typename IdxT, typename ProbT>
+void rmat_rectangular_gen_impl(const raft::handle_t& handle,
+                               raft::random::RngState& r,
+                               raft::random::detail::rmat_rectangular_gen_output<IdxT> output,
+                               ProbT a,
+                               ProbT b,
+                               ProbT c,
+                               IdxT r_scale,
+                               IdxT c_scale)
+{
+  static_assert(std::is_integral_v<IdxT>,
+                "rmat_rectangular_gen: "
+                "Template parameter IdxT must be an integral type");
+  if (not output.has_value()) {
+    return;  // nowhere to write output, so nothing to do
+  }
+
+  auto out                     = output.out_view();
+  auto out_src                 = output.out_src_view();
+  auto out_dst                 = output.out_dst_view();
+  const bool out_has_value     = out.has_value();
+  const bool out_src_has_value = out_src.has_value();
+  const bool out_dst_has_value = out_dst.has_value();
+  IdxT* out_ptr                = out_has_value ? (*out).data_handle() : nullptr;
+  IdxT* out_src_ptr            = out_src_has_value ? (*out_src).data_handle() : nullptr;
+  IdxT* out_dst_ptr            = out_dst_has_value ? (*out_dst).data_handle() : nullptr;
+  const IdxT n_edges           = output.number_of_edges();
+
+  detail::rmat_rectangular_gen_caller(
+    out_ptr, out_src_ptr, out_dst_ptr, a, b, c, r_scale, c_scale, n_edges, handle.get_stream(), r);
 }
 
 }  // end namespace detail

--- a/cpp/include/raft/random/detail/rmat_rectangular_generator_types.cuh
+++ b/cpp/include/raft/random/detail/rmat_rectangular_generator_types.cuh
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/core/device_mdspan.hpp>
+#include <raft/random/rng_device.cuh>
+#include <raft/random/rng_state.hpp>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+
+#include <optional>
+#include <variant>
+
+namespace raft {
+namespace random {
+namespace detail {
+
+/**
+ * @brief Implementation detail for checking output vector parameter(s)
+ *   of `raft::random::rmat_rectangular_gen`.
+ *
+ * `raft::random::rmat_rectangular_gen` lets users specify
+ * output vector(s) in three different ways.
+ *
+ * 1. One vector: `out`, an "array-of-structs" representation
+ *    of the edge list.
+ *
+ * 2. Two vectors: `out_src` and `out_dst`, together forming
+ *    a "struct of arrays" representation of the edge list.
+ *
+ * 3. Three vectors: `out`, `out_src`, and `out_dst`.
+ *    `out` is as in (1),
+ *    and `out_src` and `out_dst` are as in (2).
+ *
+ * This class prevents users from doing anything other than that,
+ * and makes it easier for the three cases to share a common implementation.
+ * It also prevents duplication of run-time vector length checking
+ * (`out` must have twice the number of elements as `out_src` and `out_dst`,
+ * and `out_src` and `out_dst` must have the same length).
+ *
+ * @tparam IdxT Type of each node index; must be integral.
+ *
+ * The following examples show how to create an output parameter.
+ *
+ * @code
+ * rmat_rectangular_gen_output<IdxT> output1(out);
+ * rmat_rectangular_gen_output<IdxT> output2(out_src, out_dst);
+ * rmat_rectangular_gen_output<IdxT> output3(out, out_src, out_dst);
+ * @endcode
+ */
+template <typename IdxT>
+class rmat_rectangular_gen_output {
+ public:
+  using out_view_type =
+    raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major>;
+  using out_src_view_type = raft::device_vector_view<IdxT, IdxT>;
+  using out_dst_view_type = raft::device_vector_view<IdxT, IdxT>;
+
+ private:
+  class output_pair {
+   public:
+    output_pair(const out_src_view_type& src, const out_dst_view_type& dst) : src_(src), dst_(dst)
+    {
+      RAFT_EXPECTS(src.extent(0) == dst.extent(0),
+                   "rmat_rectangular_gen: "
+                   "out_src.extent(0) = %zu != out_dst.extent(0) = %zu",
+                   static_cast<std::size_t>(src.extent(0)),
+                   static_cast<std::size_t>(dst.extent(0)));
+    }
+
+    out_src_view_type out_src_view() const { return src_; }
+
+    out_dst_view_type out_dst_view() const { return dst_; }
+
+    IdxT number_of_edges() const { return src_.extent(0); }
+
+    bool empty() const { return src_.extent(0) == 0 && dst_.extent(0) == 0; }
+
+   private:
+    out_src_view_type src_;
+    out_dst_view_type dst_;
+  };
+
+  class output_triple {
+   public:
+    output_triple(const out_view_type& out,
+                  const out_src_view_type& src,
+                  const out_dst_view_type& dst)
+      : out_(out), pair_(src, dst)
+    {
+      RAFT_EXPECTS(out.extent(0) == IdxT(2) * dst.extent(0),
+                   "rmat_rectangular_gen: "
+                   "out.extent(0) = %zu != 2 * out_dst.extent(0) = %zu",
+                   static_cast<std::size_t>(out.extent(0)),
+                   static_cast<std::size_t>(IdxT(2) * dst.extent(0)));
+    }
+
+    out_view_type out_view() const { return out_; }
+
+    out_src_view_type out_src_view() const { return pair_.out_src_view(); }
+
+    out_dst_view_type out_dst_view() const { return pair_.out_dst_view(); }
+
+    IdxT number_of_edges() const { return pair_.number_of_edges(); }
+
+    bool empty() const { return out_.extent(0) == 0 && pair_.empty(); }
+
+   private:
+    out_view_type out_;
+    output_pair pair_;
+  };
+
+ public:
+  /**
+   * @brief You're not allowed to construct this with no vectors.
+   */
+  rmat_rectangular_gen_output() = delete;
+
+  /**
+   * @brief Constructor taking a single vector, that packs the source
+   *   node ids and destination node ids in array-of-structs fashion.
+   *
+   * @param[out] out Generated edgelist [on device].  In each row, the
+   *   first element is the source node id, and the second element is
+   *   the destination node id.
+   */
+  rmat_rectangular_gen_output(const out_view_type& out) : data_(out) {}
+
+  /**
+   * @brief Constructor taking two vectors, that store the source node
+   *   ids and the destination node ids separately, in
+   *   struct-of-arrays fashion.
+   *
+   * @param[out] out_src Source node id's [on device] [len = n_edges].
+   *
+   * @param[out] out_dst Destination node id's [on device] [len = n_edges].
+   */
+  rmat_rectangular_gen_output(const out_src_view_type& src, const out_dst_view_type& dst)
+    : data_(output_pair(src, dst))
+  {
+  }
+
+  /**
+   * @brief Constructor taking all three vectors.
+   *
+   * @param[out] out Generated edgelist [on device].  In each row, the
+   *   first element is the source node id, and the second element is
+   *   the destination node id.
+   *
+   * @param[out] out_src Source node id's [on device] [len = n_edges].
+   *
+   * @param[out] out_dst Destination node id's [on device] [len = n_edges].
+   */
+  rmat_rectangular_gen_output(const out_view_type& out,
+                              const out_src_view_type& src,
+                              const out_dst_view_type& dst)
+    : data_(output_triple(out, src, dst))
+  {
+  }
+
+  /**
+   * @brief Whether the vector(s) are all length zero.
+   */
+  bool empty() const
+  {
+    if (std::holds_alternative<out_view_type>(data_)) {
+      return std::get<out_view_type>(data_).extent(0) == 0;
+    } else if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).empty();
+    } else {  // std::holds_alternative<output_triple>(data_)
+      return std::get<output_triple>(data_).empty();
+    }
+  }
+
+  /**
+   * @brief Vector for the output single edgelist; the argument given
+   *   to the one-argument constructor, or the first argument of the
+   *   three-argument constructor; `std::nullopt` if not provided.
+   */
+  std::optional<out_view_type> out_view() const
+  {
+    if (std::holds_alternative<out_view_type>(data_)) {
+      return std::get<out_view_type>(data_);
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).out_view();
+    } else {  // if (std::holds_alternative<>(output_pair))
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief Vector for the output source edgelist; the first argument
+   *   given to the two-argument constructor, or the second argument
+   *   of the three-argument constructor; `std::nullopt` if not provided.
+   */
+  std::optional<out_src_view_type> out_src_view() const
+  {
+    if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).out_src_view();
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).out_src_view();
+    } else {  // if (std::holds_alternative<out_view_type>(data_))
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief Vector for the output destination edgelist; the second
+   *   argument given to the two-argument constructor, or the third
+   *   argument of the three-argument constructor;
+   *   `std::nullopt` if not provided.
+   */
+  std::optional<out_dst_view_type> out_dst_view() const
+  {
+    if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).out_dst_view();
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).out_dst_view();
+    } else {  // if (std::holds_alternative<out_view_type>(data_))
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief Number of edges in the graph; zero if no output vector
+   *   was provided to the constructor.
+   */
+  IdxT number_of_edges() const
+  {
+    if (std::holds_alternative<out_view_type>(data_)) {
+      return std::get<out_view_type>(data_).extent(0);
+    } else if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).number_of_edges();
+    } else {  // if (std::holds_alternative<output_triple>(data_))
+      return std::get<output_triple>(data_).number_of_edges();
+    }
+  }
+
+ private:
+  std::variant<out_view_type, output_pair, output_triple> data_;
+};
+
+}  // end namespace detail
+}  // end namespace random
+}  // end namespace raft

--- a/cpp/include/raft/random/rmat_rectangular_generator.cuh
+++ b/cpp/include/raft/random/rmat_rectangular_generator.cuh
@@ -18,10 +18,217 @@
 
 #include "detail/rmat_rectangular_generator.cuh"
 
+#include <optional>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/handle.hpp>
+#include <variant>
 
 namespace raft::random {
+
+/**
+ * @brief Type of the output vector(s) parameter for `rmat_rectangular_gen`
+ *   (see below).
+ *
+ * @tparam IdxT Type of each node index; must be integral.
+ *
+ * Users can provide either `out` by itself, (`out_src` and `out_dst`)
+ * together, or all three (`out`, `out_src`, and `out_dst`).
+ * This class prevents users from doing anything other than that.
+ * It also checks compatibility of dimensions at run time.
+ *
+ * The following examples show how to create an output parameter.
+ *
+ * @code
+ * rmat_rectangular_gen_output<size_t> output1(out);
+ * rmat_rectangular_gen_output<size_t> output2(out_src, out_dst);
+ * rmat_rectangular_gen_output<size_t> output3(out, out_src, out_dst);
+ * @endcode
+ *
+ * @{
+ */
+template <typename IdxT>
+class rmat_rectangular_gen_output {
+ public:
+  using out_view_type =
+    raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major>;
+  using out_src_view_type = raft::device_vector_view<IdxT, IdxT>;
+  using out_dst_view_type = raft::device_vector_view<IdxT, IdxT>;
+
+ private:
+  class output_pair {
+   public:
+    output_pair(const out_src_view_type& src, const out_dst_view_type& dst) : src_(src), dst_(dst)
+    {
+      RAFT_EXPECTS(src.extent(0) == dst.extent(0),
+                   "rmat_rectangular_gen: "
+                   "out_src.extent(0) = %d != out_dst.extent(0) = %d",
+                   static_cast<int>(src.extent(0)),
+                   static_cast<int>(dst.extent(0)));
+    }
+
+    out_src_view_type out_src_view() const { return src_; }
+
+    out_dst_view_type out_dst_view() const { return dst_; }
+
+    IdxT number_of_edges() const { return src_.extent(0); }
+
+   private:
+    out_src_view_type src_;
+    out_dst_view_type dst_;
+  };
+
+  class output_triple {
+   public:
+    output_triple(const out_view_type& out,
+                  const out_src_view_type& src,
+                  const out_dst_view_type& dst)
+      : out_(out), pair_(src, dst)
+    {
+      RAFT_EXPECTS(out.extent(0) == IdxT(2) * dst.extent(0),
+                   "rmat_rectangular_gen: "
+                   "out.extent(0) = %d != 2 * out_dst.extent(0) = %d",
+                   static_cast<int>(out.extent(0)),
+                   static_cast<int>(IdxT(2) * dst.extent(0)));
+    }
+
+    out_view_type out_view() const { return out_; }
+
+    out_src_view_type out_src_view() const { return pair_.out_src_view(); }
+
+    out_dst_view_type out_dst_view() const { return pair_.out_dst_view(); }
+
+    IdxT number_of_edges() const { return pair_.number_of_edges(); }
+
+   private:
+    out_view_type out_;
+    output_pair pair_;
+  };
+
+ public:
+  /**
+   * @brief Constructor taking no vectors,
+   *   that effectively makes all the vectors length zero.
+   */
+  rmat_rectangular_gen_output() = default;
+
+  /**
+   * @brief Constructor taking a single vector, that packs the source
+   *   node ids and destination node ids in array-of-structs fashion.
+   *
+   * @param[out] out Generated edgelist [on device].  In each row, the
+   *   first element is the source node id, and the second element is
+   *   the destination node id.
+   */
+  rmat_rectangular_gen_output(const out_view_type& out) : data_(out) {}
+
+  /**
+   * @brief Constructor taking two vectors, that store the source node
+   *   ids and the destination node ids separately, in
+   *   struct-of-arrays fashion.
+   *
+   * @param[out] out_src Source node id's [on device] [len = n_edges].
+   *
+   * @param[out] out_dst Destination node id's [on device] [len = n_edges].
+   */
+  rmat_rectangular_gen_output(const out_src_view_type& src, const out_dst_view_type& dst)
+    : data_(output_pair(src, dst))
+  {
+  }
+
+  /**
+   * @brief Constructor taking all three vectors.
+   *
+   * @param[out] out Generated edgelist [on device].  In each row, the
+   *   first element is the source node id, and the second element is
+   *   the destination node id.
+   *
+   * @param[out] out_src Source node id's [on device] [len = n_edges].
+   *
+   * @param[out] out_dst Destination node id's [on device] [len = n_edges].
+   */
+  rmat_rectangular_gen_output(const out_view_type& out,
+                              const out_src_view_type& src,
+                              const out_dst_view_type& dst)
+    : data_(output_triple(out, src, dst))
+  {
+  }
+
+  /**
+   * @brief Whether this object was created with a constructor
+   *   taking more than zero arguments.
+   */
+  bool has_value() const { return not std::holds_alternative<std::nullopt_t>(data_); }
+
+  /**
+   * @brief Vector for the output single edgelist; the argument given
+   *   to the one-argument constructor, or the first argument of the
+   *   three-argument constructor; `std::nullopt` if not provided.
+   */
+  std::optional<out_view_type> out_view() const
+  {
+    if (std::holds_alternative<out_view_type>(data_)) {
+      return std::get<out_view_type>(data_);
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).out_view();
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief Vector for the output source edgelist; the first argument
+   *   given to the two-argument constructor, or the second argument
+   *   of the three-argument constructor; `std::nullopt` if not provided.
+   */
+  std::optional<out_src_view_type> out_src_view() const
+  {
+    if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).out_src_view();
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).out_src_view();
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief Vector for the output destination edgelist; the second
+   *   argument given to the two-argument constructor, or the third
+   *   argument of the three-argument constructor;
+   *   `std::nullopt` if not provided.
+   */
+  std::optional<out_dst_view_type> out_dst_view() const
+  {
+    if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).out_dst_view();
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).out_dst_view();
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief Number of edges in the graph; zero if no output vector
+   *   was provided to the constructor.
+   */
+  IdxT number_of_edges() const
+  {
+    if (std::holds_alternative<out_view_type>(data_)) {
+      return std::get<out_view_type>(data_).extent(0);
+    } else if (std::holds_alternative<output_pair>(data_)) {
+      return std::get<output_pair>(data_).number_of_edges();
+    } else if (std::holds_alternative<output_triple>(data_)) {
+      return std::get<output_triple>(data_).number_of_edges();
+    } else {
+      return IdxT(0);
+    }
+  }
+
+ private:
+  // Defaults to std::nullopt.
+  std::variant<std::nullopt_t, out_view_type, output_pair, output_triple> data_;
+};
 
 /**
  * @brief Generate RMAT for a rectangular adjacency matrix (useful when
@@ -36,22 +243,14 @@ namespace raft::random {
  *                     a larger graph. For that case, just create this object with the
  *                     initial seed once and after every call continue to pass the same
  *                     object for the successive calls.
- * @param[out] out     generated edgelist [on device] [dim = n_edges x 2]. In each row
- *                     the first element is the source node id, and the second element
- *                     is the destination node id. If you don't need this output
- *                     then pass a `nullptr` in its place.
- * @param[out] out_src list of source node id's [on device] [len = n_edges]. If you
- *                     don't need this output then pass a `nullptr` in its place.
- * @param[out] out_dst list of destination node id's [on device] [len = n_edges]. If
- *                     you don't need this output then pass a `nullptr` in its place.
  * @param[in]  theta   distribution of each quadrant at each level of resolution.
  *                     Since these are probabilities, each of the 2x2 matrices for
  *                     each level of the RMAT must sum to one. [on device]
  *                     [dim = max(r_scale, c_scale) x 2 x 2]. Of course, it is assumed
  *                     that each of the group of 2 x 2 numbers all sum up to 1.
+ * @param[out] output  generated edgelist [on device]
  * @param[in]  r_scale 2^r_scale represents the number of source nodes
  * @param[in]  c_scale 2^c_scale represents the number of destination nodes
- * @param[in]  n_edges number of edges to generate
  *
  * We call the `r_scale != c_scale` case the "rectangular adjacency matrix" case (IOW generating
  * bipartite graphs). In this case, at `depth >= r_scale`, the distribution is assumed to be:
@@ -64,29 +263,90 @@ namespace raft::random {
 
  * @note This also only generates directed graphs. If undirected graphs are needed, then a
  *       separate post-processing step is expected to be done by the caller.
- *
- * @{
  */
 template <typename IdxT, typename ProbT>
 void rmat_rectangular_gen(const raft::handle_t& handle,
                           raft::random::RngState& r,
                           raft::device_vector_view<const ProbT, IdxT> theta,
-                          raft::device_vector_view<IdxT, IdxT> out,
-                          raft::device_vector_view<IdxT, IdxT> out_src,
-                          raft::device_vector_view<IdxT, IdxT> out_dst,
+                          rmat_rectangular_gen_output<IdxT> output,
                           IdxT r_scale,
-                          IdxT c_scale,
-                          IdxT n_edges)
+                          IdxT c_scale)
 {
-  detail::rmat_rectangular_gen_caller(out.data_handle(),
-                                      out_src.data_handle(),
-                                      out_dst.data_handle(),
+  static_assert(std::is_integral_v<IdxT>,
+                "rmat_rectangular_gen: "
+                "Template parameter IdxT must be an integral type");
+  if (not output.has_value()) {
+    return;  // nowhere to write output, so nothing to do
+  }
+
+  const IdxT expected_theta_len = IdxT(4) * (r_scale >= c_scale ? r_scale : c_scale);
+  RAFT_EXPECTS(theta.extent(0) == expected_theta_len,
+               "rmat_rectangular_gen: "
+               "theta.extent(0) = %d != 2 * 2 * max(r_scale = %d, c_scale = %d) = %d",
+               static_cast<int>(theta.extent(0)),
+               static_cast<int>(r_scale),
+               static_cast<int>(c_scale),
+               static_cast<int>(expected_theta_len));
+
+  auto out                     = output.out_view();
+  auto out_src                 = output.out_src_view();
+  auto out_dst                 = output.out_dst_view();
+  const bool out_has_value     = out.has_value();
+  const bool out_src_has_value = out_src.has_value();
+  const bool out_dst_has_value = out_dst.has_value();
+  IdxT* out_ptr                = out_has_value ? (*out).data_handle() : nullptr;
+  IdxT* out_src_ptr            = out_src_has_value ? (*out_src).data_handle() : nullptr;
+  IdxT* out_dst_ptr            = out_dst_has_value ? (*out_dst).data_handle() : nullptr;
+  const IdxT n_edges           = output.number_of_edges();
+
+  detail::rmat_rectangular_gen_caller(out_ptr,
+                                      out_src_ptr,
+                                      out_dst_ptr,
                                       theta.data_handle(),
                                       r_scale,
                                       c_scale,
                                       n_edges,
                                       handle.get_stream(),
                                       r);
+}
+
+/**
+ * @brief Overload of `rmat_rectangular_gen` that assumes the same
+ *   a, b, c, d probability distributions across all the scales.
+ *
+ * `a`, `b, and `c` effectively replace the above overload's
+ * `theta` parameter.
+ */
+template <typename IdxT, typename ProbT>
+void rmat_rectangular_gen(const raft::handle_t& handle,
+                          raft::random::RngState& r,
+                          rmat_rectangular_gen_output<IdxT> output,
+                          ProbT a,
+                          ProbT b,
+                          ProbT c,
+                          IdxT r_scale,
+                          IdxT c_scale)
+{
+  static_assert(std::is_integral_v<IdxT>,
+                "rmat_rectangular_gen: "
+                "Template parameter IdxT must be an integral type");
+  if (not output.has_value()) {
+    return;  // nowhere to write output, so nothing to do
+  }
+
+  auto out                     = output.out_view();
+  auto out_src                 = output.out_src_view();
+  auto out_dst                 = output.out_dst_view();
+  const bool out_has_value     = out.has_value();
+  const bool out_src_has_value = out_src.has_value();
+  const bool out_dst_has_value = out_dst.has_value();
+  IdxT* out_ptr                = out_has_value ? (*out).data_handle() : nullptr;
+  IdxT* out_src_ptr            = out_src_has_value ? (*out_src).data_handle() : nullptr;
+  IdxT* out_dst_ptr            = out_dst_has_value ? (*out_dst).data_handle() : nullptr;
+  const IdxT n_edges           = output.number_of_edges();
+
+  detail::rmat_rectangular_gen_caller(
+    out_ptr, out_src_ptr, out_dst_ptr, a, b, c, r_scale, c_scale, n_edges, handle.get_stream(), r);
 }
 
 /**
@@ -132,36 +392,6 @@ void rmat_rectangular_gen(IdxT* out,
 {
   detail::rmat_rectangular_gen_caller(
     out, out_src, out_dst, theta, r_scale, c_scale, n_edges, stream, r);
-}
-
-/**
- * This is the same as the previous method but assumes the same a, b, c, d probability
- * distributions across all the scales
- */
-template <typename IdxT, typename ProbT>
-void rmat_rectangular_gen(const raft::handle_t& handle,
-                          raft::random::RngState& r,
-                          raft::device_vector_view<IdxT, IdxT> out,
-                          raft::device_vector_view<IdxT, IdxT> out_src,
-                          raft::device_vector_view<IdxT, IdxT> out_dst,
-                          ProbT a,
-                          ProbT b,
-                          ProbT c,
-                          IdxT r_scale,
-                          IdxT c_scale,
-                          IdxT n_edges)
-{
-  detail::rmat_rectangular_gen_caller(out.data_handle(),
-                                      out_src.data_handle(),
-                                      out_dst.data_handle(),
-                                      a,
-                                      b,
-                                      c,
-                                      r_scale,
-                                      c_scale,
-                                      n_edges,
-                                      handle.get_stream(),
-                                      r);
 }
 
 /**

--- a/cpp/include/raft/random/rmat_rectangular_generator.cuh
+++ b/cpp/include/raft/random/rmat_rectangular_generator.cuh
@@ -18,42 +18,44 @@
 
 #include "detail/rmat_rectangular_generator.cuh"
 
+#include <raft/mdarray.hpp>
+
 namespace raft::random {
 
 /**
- * @brief Generate RMAT for a rectangular shaped adjacency matrices (useful when
+ * @brief Generate RMAT for a rectangular adjacency matrix (useful when
  *        graphs to be generated are bipartite)
  *
- * @tparam IdxT  node indices type
+ * @tparam IdxT  type of each node index
  * @tparam ProbT data type used for probability distributions (either fp32 or fp64)
  *
- * @param[out] out     generated edgelist [on device] [dim = n_edges x 2]. On each row
- *                     the first element corresponds to the source node id while the
- *                     second, the destination node id. If you don't need this output
+ * @param[in]  handle  RAFT handle, containing the CUDA stream on which to schedule work
+ * @param[in]  r       underlying state of the random generator. Especially useful when
+ *                     one wants to call this API for multiple times in order to generate
+ *                     a larger graph. For that case, just create this object with the
+ *                     initial seed once and after every call continue to pass the same
+ *                     object for the successive calls.
+ * @param[out] out     generated edgelist [on device] [dim = n_edges x 2]. In each row
+ *                     the first element is the source node id, and the second element
+ *                     is the destination node id. If you don't need this output
  *                     then pass a `nullptr` in its place.
  * @param[out] out_src list of source node id's [on device] [len = n_edges]. If you
  *                     don't need this output then pass a `nullptr` in its place.
  * @param[out] out_dst list of destination node id's [on device] [len = n_edges]. If
  *                     you don't need this output then pass a `nullptr` in its place.
  * @param[in]  theta   distribution of each quadrant at each level of resolution.
- *                     Since these are probabilities, each of the 2x2 matrix for
+ *                     Since these are probabilities, each of the 2x2 matrices for
  *                     each level of the RMAT must sum to one. [on device]
  *                     [dim = max(r_scale, c_scale) x 2 x 2]. Of course, it is assumed
  *                     that each of the group of 2 x 2 numbers all sum up to 1.
  * @param[in]  r_scale 2^r_scale represents the number of source nodes
  * @param[in]  c_scale 2^c_scale represents the number of destination nodes
  * @param[in]  n_edges number of edges to generate
- * @param[in]  stream  cuda stream to schedule the work on
- * @param[in]  r       underlying state of the random generator. Especially useful when
- *                     one wants to call this API for multiple times in order to generate
- *                     a larger graph. For that case, just create this object with the
- *                     initial seed once and after every call continue to pass the same
- *                     object for the successive calls.
  *
- * When `r_scale != c_scale` it is referred to as rectangular adjacency matrix case (IOW generating
+ * We call the `r_scale != c_scale` case the "rectangular adjacency matrix" case (IOW generating
  * bipartite graphs). In this case, at `depth >= r_scale`, the distribution is assumed to be:
  * `[theta[4 * depth] + theta[4 * depth + 2], theta[4 * depth + 1] + theta[4 * depth + 3]; 0, 0]`.
- * Then for the `depth >= c_scale`, the distribution is assumed to be:
+ * Then for `depth >= c_scale`, the distribution is assumed to be:
  * `[theta[4 * depth] + theta[4 * depth + 1], 0; theta[4 * depth + 2] + theta[4 * depth + 3], 0]`.
  *
  * @note This can generate duplicate edges and self-loops. It is the responsibility of the
@@ -63,6 +65,70 @@ namespace raft::random {
  *       separate post-processing step is expected to be done by the caller.
  *
  * @{
+ */
+template <typename IdxT, typename ProbT>
+void rmat_rectangular_gen(const raft::handle_t& handle,
+                          raft::random::RngState& r,
+                          raft::device_vector_view<IdxT, IdxT> out,
+                          raft::device_vector_view<IdxT, IdxT> out_src,
+                          raft::device_vector_view<IdxT, IdxT> out_dst,
+                          raft::device_vector_view<const ProbT, IdxT> theta,
+                          IdxT r_scale,
+                          IdxT c_scale,
+                          IdxT n_edges)
+{
+  detail::rmat_rectangular_gen_caller(out.data_handle(),
+                                      out_src.data_handle(),
+                                      out_dst.data_handle(),
+                                      theta.data_handle(),
+                                      r_scale,
+                                      c_scale,
+                                      n_edges,
+                                      handle.get_stream(),
+                                      r);
+}
+
+/**
+ * @brief Generate RMAT for a rectangular adjacency matrix (useful when
+ *        graphs to be generated are bipartite)
+ *
+ * @tparam IdxT  type of each node index
+ * @tparam ProbT data type used for probability distributions (either fp32 or fp64)
+ *
+ * @param[out] out     generated edgelist [on device] [dim = n_edges x 2]. In each row
+ *                     the first element is the source node id, and the second element
+ *                     is the destination node id. If you don't need this output
+ *                     then pass a `nullptr` in its place.
+ * @param[out] out_src list of source node id's [on device] [len = n_edges]. If you
+ *                     don't need this output then pass a `nullptr` in its place.
+ * @param[out] out_dst list of destination node id's [on device] [len = n_edges]. If
+ *                     you don't need this output then pass a `nullptr` in its place.
+ * @param[in]  theta   distribution of each quadrant at each level of resolution.
+ *                     Since these are probabilities, each of the 2x2 matrices for
+ *                     each level of the RMAT must sum to one. [on device]
+ *                     [dim = max(r_scale, c_scale) x 2 x 2]. Of course, it is assumed
+ *                     that each of the group of 2 x 2 numbers all sum up to 1.
+ * @param[in]  r_scale 2^r_scale represents the number of source nodes
+ * @param[in]  c_scale 2^c_scale represents the number of destination nodes
+ * @param[in]  n_edges number of edges to generate
+ * @param[in]  stream  cuda stream on which to schedule the work
+ * @param[in]  r       underlying state of the random generator. Especially useful when
+ *                     one wants to call this API for multiple times in order to generate
+ *                     a larger graph. For that case, just create this object with the
+ *                     initial seed once and after every call continue to pass the same
+ *                     object for the successive calls.
+ *
+ * We call the `r_scale != c_scale` case the "rectangular adjacency matrix" case (IOW generating
+ * bipartite graphs). In this case, at `depth >= r_scale`, the distribution is assumed to be:
+ * `[theta[4 * depth] + theta[4 * depth + 2], theta[4 * depth + 1] + theta[4 * depth + 3]; 0, 0]`.
+ * Then for `depth >= c_scale`, the distribution is assumed to be:
+ * `[theta[4 * depth] + theta[4 * depth + 1], 0; theta[4 * depth + 2] + theta[4 * depth + 3], 0]`.
+ *
+ * @note This can generate duplicate edges and self-loops. It is the responsibility of the
+ *       caller to clean them up accordingly.
+
+ * @note This also only generates directed graphs. If undirected graphs are needed, then a
+ *       separate post-processing step is expected to be done by the caller.
  */
 template <typename IdxT, typename ProbT>
 void rmat_rectangular_gen(IdxT* out,
@@ -98,6 +164,36 @@ void rmat_rectangular_gen(IdxT* out,
 {
   detail::rmat_rectangular_gen_caller(
     out, out_src, out_dst, a, b, c, r_scale, c_scale, n_edges, stream, r);
+}
+
+/**
+ * This is the same as the previous method but assumes the same a, b, c, d probability
+ * distributions across all the scales
+ */
+template <typename IdxT, typename ProbT>
+void rmat_rectangular_gen(const raft::handle_t& handle,
+                          raft::random::RngState& r,
+                          raft::device_vector_view<IdxT, IdxT> out,
+                          raft::device_vector_view<IdxT, IdxT> out_src,
+                          raft::device_vector_view<IdxT, IdxT> out_dst,
+                          ProbT a,
+                          ProbT b,
+                          ProbT c,
+                          IdxT r_scale,
+                          IdxT c_scale,
+                          IdxT n_edges)
+{
+  detail::rmat_rectangular_gen_caller(out.data_handle(),
+                                      out_src.data_handle(),
+                                      out_dst.data_handle(),
+                                      a,
+                                      b,
+                                      c,
+                                      r_scale,
+                                      c_scale,
+                                      n_edges,
+                                      handle.get_stream(),
+                                      r);
 }
 /** @} */
 

--- a/cpp/include/raft/random/rmat_rectangular_generator.cuh
+++ b/cpp/include/raft/random/rmat_rectangular_generator.cuh
@@ -18,7 +18,8 @@
 
 #include "detail/rmat_rectangular_generator.cuh"
 
-#include <raft/mdarray.hpp>
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/handle.hpp>
 
 namespace raft::random {
 

--- a/cpp/include/raft/random/rmat_rectangular_generator.cuh
+++ b/cpp/include/raft/random/rmat_rectangular_generator.cuh
@@ -18,224 +18,16 @@
 
 #include "detail/rmat_rectangular_generator.cuh"
 
-#include <optional>
-#include <raft/core/device_mdspan.hpp>
-#include <raft/core/handle.hpp>
-#include <variant>
-
 namespace raft::random {
 
 /**
- * @brief Type of the output vector(s) parameter for `rmat_rectangular_gen`
- *   (see below).
+ * @brief Generate a bipartite RMAT graph for a rectangular adjacency matrix.
  *
- * @tparam IdxT Type of each node index; must be integral.
+ * This is the most general of several overloads of `rmat_rectangular_gen`
+ * in this file, and thus has the most detailed documentation.
  *
- * Users can provide either `out` by itself, (`out_src` and `out_dst`)
- * together, or all three (`out`, `out_src`, and `out_dst`).
- * This class prevents users from doing anything other than that.
- * It also checks compatibility of dimensions at run time.
- *
- * The following examples show how to create an output parameter.
- *
- * @code
- * rmat_rectangular_gen_output<size_t> output1(out);
- * rmat_rectangular_gen_output<size_t> output2(out_src, out_dst);
- * rmat_rectangular_gen_output<size_t> output3(out, out_src, out_dst);
- * @endcode
- *
- * @{
- */
-template <typename IdxT>
-class rmat_rectangular_gen_output {
- public:
-  using out_view_type =
-    raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major>;
-  using out_src_view_type = raft::device_vector_view<IdxT, IdxT>;
-  using out_dst_view_type = raft::device_vector_view<IdxT, IdxT>;
-
- private:
-  class output_pair {
-   public:
-    output_pair(const out_src_view_type& src, const out_dst_view_type& dst) : src_(src), dst_(dst)
-    {
-      RAFT_EXPECTS(src.extent(0) == dst.extent(0),
-                   "rmat_rectangular_gen: "
-                   "out_src.extent(0) = %d != out_dst.extent(0) = %d",
-                   static_cast<int>(src.extent(0)),
-                   static_cast<int>(dst.extent(0)));
-    }
-
-    out_src_view_type out_src_view() const { return src_; }
-
-    out_dst_view_type out_dst_view() const { return dst_; }
-
-    IdxT number_of_edges() const { return src_.extent(0); }
-
-   private:
-    out_src_view_type src_;
-    out_dst_view_type dst_;
-  };
-
-  class output_triple {
-   public:
-    output_triple(const out_view_type& out,
-                  const out_src_view_type& src,
-                  const out_dst_view_type& dst)
-      : out_(out), pair_(src, dst)
-    {
-      RAFT_EXPECTS(out.extent(0) == IdxT(2) * dst.extent(0),
-                   "rmat_rectangular_gen: "
-                   "out.extent(0) = %d != 2 * out_dst.extent(0) = %d",
-                   static_cast<int>(out.extent(0)),
-                   static_cast<int>(IdxT(2) * dst.extent(0)));
-    }
-
-    out_view_type out_view() const { return out_; }
-
-    out_src_view_type out_src_view() const { return pair_.out_src_view(); }
-
-    out_dst_view_type out_dst_view() const { return pair_.out_dst_view(); }
-
-    IdxT number_of_edges() const { return pair_.number_of_edges(); }
-
-   private:
-    out_view_type out_;
-    output_pair pair_;
-  };
-
- public:
-  /**
-   * @brief Constructor taking no vectors,
-   *   that effectively makes all the vectors length zero.
-   */
-  rmat_rectangular_gen_output() = default;
-
-  /**
-   * @brief Constructor taking a single vector, that packs the source
-   *   node ids and destination node ids in array-of-structs fashion.
-   *
-   * @param[out] out Generated edgelist [on device].  In each row, the
-   *   first element is the source node id, and the second element is
-   *   the destination node id.
-   */
-  rmat_rectangular_gen_output(const out_view_type& out) : data_(out) {}
-
-  /**
-   * @brief Constructor taking two vectors, that store the source node
-   *   ids and the destination node ids separately, in
-   *   struct-of-arrays fashion.
-   *
-   * @param[out] out_src Source node id's [on device] [len = n_edges].
-   *
-   * @param[out] out_dst Destination node id's [on device] [len = n_edges].
-   */
-  rmat_rectangular_gen_output(const out_src_view_type& src, const out_dst_view_type& dst)
-    : data_(output_pair(src, dst))
-  {
-  }
-
-  /**
-   * @brief Constructor taking all three vectors.
-   *
-   * @param[out] out Generated edgelist [on device].  In each row, the
-   *   first element is the source node id, and the second element is
-   *   the destination node id.
-   *
-   * @param[out] out_src Source node id's [on device] [len = n_edges].
-   *
-   * @param[out] out_dst Destination node id's [on device] [len = n_edges].
-   */
-  rmat_rectangular_gen_output(const out_view_type& out,
-                              const out_src_view_type& src,
-                              const out_dst_view_type& dst)
-    : data_(output_triple(out, src, dst))
-  {
-  }
-
-  /**
-   * @brief Whether this object was created with a constructor
-   *   taking more than zero arguments.
-   */
-  bool has_value() const { return not std::holds_alternative<std::nullopt_t>(data_); }
-
-  /**
-   * @brief Vector for the output single edgelist; the argument given
-   *   to the one-argument constructor, or the first argument of the
-   *   three-argument constructor; `std::nullopt` if not provided.
-   */
-  std::optional<out_view_type> out_view() const
-  {
-    if (std::holds_alternative<out_view_type>(data_)) {
-      return std::get<out_view_type>(data_);
-    } else if (std::holds_alternative<output_triple>(data_)) {
-      return std::get<output_triple>(data_).out_view();
-    } else {
-      return std::nullopt;
-    }
-  }
-
-  /**
-   * @brief Vector for the output source edgelist; the first argument
-   *   given to the two-argument constructor, or the second argument
-   *   of the three-argument constructor; `std::nullopt` if not provided.
-   */
-  std::optional<out_src_view_type> out_src_view() const
-  {
-    if (std::holds_alternative<output_pair>(data_)) {
-      return std::get<output_pair>(data_).out_src_view();
-    } else if (std::holds_alternative<output_triple>(data_)) {
-      return std::get<output_triple>(data_).out_src_view();
-    } else {
-      return std::nullopt;
-    }
-  }
-
-  /**
-   * @brief Vector for the output destination edgelist; the second
-   *   argument given to the two-argument constructor, or the third
-   *   argument of the three-argument constructor;
-   *   `std::nullopt` if not provided.
-   */
-  std::optional<out_dst_view_type> out_dst_view() const
-  {
-    if (std::holds_alternative<output_pair>(data_)) {
-      return std::get<output_pair>(data_).out_dst_view();
-    } else if (std::holds_alternative<output_triple>(data_)) {
-      return std::get<output_triple>(data_).out_dst_view();
-    } else {
-      return std::nullopt;
-    }
-  }
-
-  /**
-   * @brief Number of edges in the graph; zero if no output vector
-   *   was provided to the constructor.
-   */
-  IdxT number_of_edges() const
-  {
-    if (std::holds_alternative<out_view_type>(data_)) {
-      return std::get<out_view_type>(data_).extent(0);
-    } else if (std::holds_alternative<output_pair>(data_)) {
-      return std::get<output_pair>(data_).number_of_edges();
-    } else if (std::holds_alternative<output_triple>(data_)) {
-      return std::get<output_triple>(data_).number_of_edges();
-    } else {
-      return IdxT(0);
-    }
-  }
-
- private:
-  // Defaults to std::nullopt.
-  std::variant<std::nullopt_t, out_view_type, output_pair, output_triple> data_;
-};
-
-/**
- * @brief Generate RMAT for a rectangular adjacency matrix (useful when
- *        graphs to be generated are bipartite)
- *
- * @tparam IdxT  type of each node index
- * @tparam ProbT data type used for probability distributions (either fp32 or fp64)
+ * @tparam IdxT  Type of each node index
+ * @tparam ProbT Data type used for probability distributions (either fp32 or fp64)
  *
  * @param[in]  handle  RAFT handle, containing the CUDA stream on which to schedule work
  * @param[in]  r       underlying state of the random generator. Especially useful when
@@ -243,110 +35,181 @@ class rmat_rectangular_gen_output {
  *                     a larger graph. For that case, just create this object with the
  *                     initial seed once and after every call continue to pass the same
  *                     object for the successive calls.
+ * @param[out] out     Generated edgelist [on device], packed in array-of-structs fashion.
+ *                     In each row, the first element is the source node id,
+ *                     and the second element is the destination node id.
+ * @param[out] out_src Source node id's [on device].
+ * @param[out] out_dst Destination node id's [on device].  `out_src` and `out_dst`
+ *                     together form the struct-of-arrays representation of the same
+ *                     output data as `out`.
  * @param[in]  theta   distribution of each quadrant at each level of resolution.
  *                     Since these are probabilities, each of the 2x2 matrices for
  *                     each level of the RMAT must sum to one. [on device]
  *                     [dim = max(r_scale, c_scale) x 2 x 2]. Of course, it is assumed
  *                     that each of the group of 2 x 2 numbers all sum up to 1.
- * @param[out] output  generated edgelist [on device]
  * @param[in]  r_scale 2^r_scale represents the number of source nodes
  * @param[in]  c_scale 2^c_scale represents the number of destination nodes
  *
- * We call the `r_scale != c_scale` case the "rectangular adjacency matrix" case (IOW generating
- * bipartite graphs). In this case, at `depth >= r_scale`, the distribution is assumed to be:
+ * @pre `out.extent(0) == 2 * `out_src.extent(0)` is `true`
+ * @pre `out_src.extent(0) == out_dst.extent(0)` is `true`
+ *
+ * We call the `r_scale != c_scale` case the "rectangular adjacency matrix" case
+ * (in other words, generating bipartite graphs). In this case, at `depth >= r_scale`,
+ * the distribution is assumed to be:
+ *
  * `[theta[4 * depth] + theta[4 * depth + 2], theta[4 * depth + 1] + theta[4 * depth + 3]; 0, 0]`.
+ *
  * Then for `depth >= c_scale`, the distribution is assumed to be:
+ *
  * `[theta[4 * depth] + theta[4 * depth + 1], 0; theta[4 * depth + 2] + theta[4 * depth + 3], 0]`.
  *
  * @note This can generate duplicate edges and self-loops. It is the responsibility of the
  *       caller to clean them up accordingly.
-
+ *
  * @note This also only generates directed graphs. If undirected graphs are needed, then a
  *       separate post-processing step is expected to be done by the caller.
+ *
+ * @{
+ */
+template <typename IdxT, typename ProbT>
+void rmat_rectangular_gen(
+  const raft::handle_t& handle,
+  raft::random::RngState& r,
+  raft::device_vector_view<const ProbT, IdxT> theta,
+  raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major> out,
+  raft::device_vector_view<IdxT, IdxT> out_src,
+  raft::device_vector_view<IdxT, IdxT> out_dst,
+  IdxT r_scale,
+  IdxT c_scale)
+{
+  detail::rmat_rectangular_gen_output<IdxT> output(out, out_src, out_dst);
+  detail::rmat_rectangular_gen_impl(handle, r, theta, output, r_scale, c_scale);
+}
+
+/**
+ * @brief Overload of `rmat_rectangular_gen` that only generates
+ *   the struct-of-arrays (two vectors) output representation.
+ *
+ * This overload only generates the struct-of-arrays (two vectors)
+ * output representation: output vector `out_src` of source node id's,
+ * and output vector `out_dst` of destination node id's.
+ *
+ * @pre `out_src.extent(0) == out_dst.extent(0)` is `true`
  */
 template <typename IdxT, typename ProbT>
 void rmat_rectangular_gen(const raft::handle_t& handle,
                           raft::random::RngState& r,
                           raft::device_vector_view<const ProbT, IdxT> theta,
-                          rmat_rectangular_gen_output<IdxT> output,
+                          raft::device_vector_view<IdxT, IdxT> out_src,
+                          raft::device_vector_view<IdxT, IdxT> out_dst,
                           IdxT r_scale,
                           IdxT c_scale)
 {
-  static_assert(std::is_integral_v<IdxT>,
-                "rmat_rectangular_gen: "
-                "Template parameter IdxT must be an integral type");
-  if (not output.has_value()) {
-    return;  // nowhere to write output, so nothing to do
-  }
+  detail::rmat_rectangular_gen_output<IdxT> output(out_src, out_dst);
+  detail::rmat_rectangular_gen_impl(handle, r, theta, output, r_scale, c_scale);
+}
 
-  const IdxT expected_theta_len = IdxT(4) * (r_scale >= c_scale ? r_scale : c_scale);
-  RAFT_EXPECTS(theta.extent(0) == expected_theta_len,
-               "rmat_rectangular_gen: "
-               "theta.extent(0) = %d != 2 * 2 * max(r_scale = %d, c_scale = %d) = %d",
-               static_cast<int>(theta.extent(0)),
-               static_cast<int>(r_scale),
-               static_cast<int>(c_scale),
-               static_cast<int>(expected_theta_len));
-
-  auto out                     = output.out_view();
-  auto out_src                 = output.out_src_view();
-  auto out_dst                 = output.out_dst_view();
-  const bool out_has_value     = out.has_value();
-  const bool out_src_has_value = out_src.has_value();
-  const bool out_dst_has_value = out_dst.has_value();
-  IdxT* out_ptr                = out_has_value ? (*out).data_handle() : nullptr;
-  IdxT* out_src_ptr            = out_src_has_value ? (*out_src).data_handle() : nullptr;
-  IdxT* out_dst_ptr            = out_dst_has_value ? (*out_dst).data_handle() : nullptr;
-  const IdxT n_edges           = output.number_of_edges();
-
-  detail::rmat_rectangular_gen_caller(out_ptr,
-                                      out_src_ptr,
-                                      out_dst_ptr,
-                                      theta.data_handle(),
-                                      r_scale,
-                                      c_scale,
-                                      n_edges,
-                                      handle.get_stream(),
-                                      r);
+/**
+ * @brief Overload of `rmat_rectangular_gen` that only generates
+ *   the array-of-structs (one vector) output representation.
+ *
+ * This overload only generates the array-of-structs (one vector)
+ * output representation: a single output vector `out`,
+ * where in each row, the first element is the source node id,
+ * and the second element is the destination node id.
+ */
+template <typename IdxT, typename ProbT>
+void rmat_rectangular_gen(
+  const raft::handle_t& handle,
+  raft::random::RngState& r,
+  raft::device_vector_view<const ProbT, IdxT> theta,
+  raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major> out,
+  IdxT r_scale,
+  IdxT c_scale)
+{
+  detail::rmat_rectangular_gen_output<IdxT> output(out);
+  detail::rmat_rectangular_gen_impl(handle, r, theta, output, r_scale, c_scale);
 }
 
 /**
  * @brief Overload of `rmat_rectangular_gen` that assumes the same
- *   a, b, c, d probability distributions across all the scales.
+ *   a, b, c, d probability distributions across all the scales,
+ *   and takes all three output vectors
+ *   (`out` with the array-of-structs output representation,
+ *   and `out_src` and `out_dst` with the struct-of-arrays
+ *   output representation).
  *
- * `a`, `b, and `c` effectively replace the above overload's
+ * `a`, `b, and `c` effectively replace the above overloads'
  * `theta` parameter.
+ *
+ * @pre `out.extent(0) == 2 * `out_src.extent(0)` is `true`
+ * @pre `out_src.extent(0) == out_dst.extent(0)` is `true`
+ */
+template <typename IdxT, typename ProbT>
+void rmat_rectangular_gen(
+  const raft::handle_t& handle,
+  raft::random::RngState& r,
+  raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major> out,
+  raft::device_vector_view<IdxT, IdxT> out_src,
+  raft::device_vector_view<IdxT, IdxT> out_dst,
+  ProbT a,
+  ProbT b,
+  ProbT c,
+  IdxT r_scale,
+  IdxT c_scale)
+{
+  detail::rmat_rectangular_gen_output<IdxT> output(out, out_src, out_dst);
+  detail::rmat_rectangular_gen_impl(handle, r, output, a, b, c, r_scale, c_scale);
+}
+
+/**
+ * @brief Overload of `rmat_rectangular_gen` that assumes the same
+ *   a, b, c, d probability distributions across all the scales,
+ *   and takes only two output vectors
+ *   (the struct-of-arrays output representation).
+ *
+ * `a`, `b, and `c` effectively replace the above overloads'
+ * `theta` parameter.
+ *
+ * @pre `out_src.extent(0) == out_dst.extent(0)` is `true`
  */
 template <typename IdxT, typename ProbT>
 void rmat_rectangular_gen(const raft::handle_t& handle,
                           raft::random::RngState& r,
-                          rmat_rectangular_gen_output<IdxT> output,
+                          raft::device_vector_view<IdxT, IdxT> out_src,
+                          raft::device_vector_view<IdxT, IdxT> out_dst,
                           ProbT a,
                           ProbT b,
                           ProbT c,
                           IdxT r_scale,
                           IdxT c_scale)
 {
-  static_assert(std::is_integral_v<IdxT>,
-                "rmat_rectangular_gen: "
-                "Template parameter IdxT must be an integral type");
-  if (not output.has_value()) {
-    return;  // nowhere to write output, so nothing to do
-  }
+  detail::rmat_rectangular_gen_output<IdxT> output(out_src, out_dst);
+  detail::rmat_rectangular_gen_impl(handle, r, output, a, b, c, r_scale, c_scale);
+}
 
-  auto out                     = output.out_view();
-  auto out_src                 = output.out_src_view();
-  auto out_dst                 = output.out_dst_view();
-  const bool out_has_value     = out.has_value();
-  const bool out_src_has_value = out_src.has_value();
-  const bool out_dst_has_value = out_dst.has_value();
-  IdxT* out_ptr                = out_has_value ? (*out).data_handle() : nullptr;
-  IdxT* out_src_ptr            = out_src_has_value ? (*out_src).data_handle() : nullptr;
-  IdxT* out_dst_ptr            = out_dst_has_value ? (*out_dst).data_handle() : nullptr;
-  const IdxT n_edges           = output.number_of_edges();
-
-  detail::rmat_rectangular_gen_caller(
-    out_ptr, out_src_ptr, out_dst_ptr, a, b, c, r_scale, c_scale, n_edges, handle.get_stream(), r);
+/**
+ * @brief Overload of `rmat_rectangular_gen` that assumes the same
+ *   a, b, c, d probability distributions across all the scales,
+ *   and takes only one output vector
+ *   (the array-of-structs output representation).
+ *
+ * `a`, `b, and `c` effectively replace the above overloads'
+ * `theta` parameter.
+ */
+template <typename IdxT, typename ProbT>
+void rmat_rectangular_gen(
+  const raft::handle_t& handle,
+  raft::random::RngState& r,
+  raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major> out,
+  ProbT a,
+  ProbT b,
+  ProbT c,
+  IdxT r_scale,
+  IdxT c_scale)
+{
+  detail::rmat_rectangular_gen_output<IdxT> output(out);
+  detail::rmat_rectangular_gen_impl(handle, r, output, a, b, c, r_scale, c_scale);
 }
 
 /**

--- a/cpp/include/raft/random/rng_state.hpp
+++ b/cpp/include/raft/random/rng_state.hpp
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 namespace raft {
 namespace random {
 

--- a/cpp/test/nvtx.cpp
+++ b/cpp/test/nvtx.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 #ifdef NVTX_ENABLED
 #include <gtest/gtest.h>
-#include <raft/common/detail/nvtx.hpp>
+#include <raft/core/detail/nvtx.hpp>
 /**
  * tests for the functionality of generating next color based on string
  * entered in the NVTX Range marker wrappers

--- a/cpp/test/random/rmat_rectangular_generator.cu
+++ b/cpp/test/random/rmat_rectangular_generator.cu
@@ -287,33 +287,24 @@ class RmatGenMdspanTest : public ::testing::TestWithParam<RmatInputs> {
   void SetUp() override
   {
     using index_type = size_t;
-    raft::device_vector_view<size_t, index_type> out_view(out.data(), out.size());
-    raft::device_vector_view<size_t, index_type> out_src_view(out_src.data(), out_src.size());
-    raft::device_vector_view<size_t, index_type> out_dst_view(out_dst.data(), out_dst.size());
+
+    using out_view_type = typename rmat_rectangular_gen_output<index_type>::out_view_type;
+    out_view_type out_view(out.data(), out.size());
+
+    using out_src_view_type = typename rmat_rectangular_gen_output<index_type>::out_src_view_type;
+    out_src_view_type out_src_view(out_src.data(), out_src.size());
+
+    using out_dst_view_type = typename rmat_rectangular_gen_output<index_type>::out_dst_view_type;
+    out_dst_view_type out_dst_view(out_dst.data(), out_dst.size());
+
+    rmat_rectangular_gen_output<index_type> output(out_view, out_src_view, out_dst_view);
 
     if (params.theta_array) {
       raft::device_vector_view<const float, index_type> theta_view(theta.data(), theta.size());
-      rmat_rectangular_gen(handle,
-                           state,
-                           theta_view,
-                           out_view,
-                           out_src_view,
-                           out_dst_view,
-                           params.r_scale,
-                           params.c_scale,
-                           params.n_edges);
+      rmat_rectangular_gen(handle, state, theta_view, output, params.r_scale, params.c_scale);
     } else {
-      rmat_rectangular_gen(handle,
-                           state,
-                           out_view,
-                           out_src_view,
-                           out_dst_view,
-                           h_theta[0],
-                           h_theta[1],
-                           h_theta[2],
-                           params.r_scale,
-                           params.c_scale,
-                           params.n_edges);
+      rmat_rectangular_gen(
+        handle, state, output, h_theta[0], h_theta[1], h_theta[2], params.r_scale, params.c_scale);
     }
     RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
   }

--- a/cpp/test/random/rmat_rectangular_generator.cu
+++ b/cpp/test/random/rmat_rectangular_generator.cu
@@ -288,23 +288,38 @@ class RmatGenMdspanTest : public ::testing::TestWithParam<RmatInputs> {
   {
     using index_type = size_t;
 
-    using out_view_type = typename rmat_rectangular_gen_output<index_type>::out_view_type;
+    using out_view_type = raft::device_mdspan<index_type,
+                                              raft::extents<index_type, raft::dynamic_extent, 2>,
+                                              raft::row_major>;
     out_view_type out_view(out.data(), out.size());
 
-    using out_src_view_type = typename rmat_rectangular_gen_output<index_type>::out_src_view_type;
+    using out_src_view_type = raft::device_vector_view<index_type, index_type>;
     out_src_view_type out_src_view(out_src.data(), out_src.size());
 
-    using out_dst_view_type = typename rmat_rectangular_gen_output<index_type>::out_dst_view_type;
+    using out_dst_view_type = raft::device_vector_view<index_type, index_type>;
     out_dst_view_type out_dst_view(out_dst.data(), out_dst.size());
-
-    rmat_rectangular_gen_output<index_type> output(out_view, out_src_view, out_dst_view);
 
     if (params.theta_array) {
       raft::device_vector_view<const float, index_type> theta_view(theta.data(), theta.size());
-      rmat_rectangular_gen(handle, state, theta_view, output, params.r_scale, params.c_scale);
+      rmat_rectangular_gen(handle,
+                           state,
+                           theta_view,
+                           out_view,
+                           out_src_view,
+                           out_dst_view,
+                           params.r_scale,
+                           params.c_scale);
     } else {
-      rmat_rectangular_gen(
-        handle, state, output, h_theta[0], h_theta[1], h_theta[2], params.r_scale, params.c_scale);
+      rmat_rectangular_gen(handle,
+                           state,
+                           out_view,
+                           out_src_view,
+                           out_dst_view,
+                           h_theta[0],
+                           h_theta[1],
+                           h_theta[2],
+                           params.r_scale,
+                           params.c_scale);
     }
     RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
   }

--- a/cpp/test/random/rmat_rectangular_generator.cu
+++ b/cpp/test/random/rmat_rectangular_generator.cu
@@ -295,10 +295,10 @@ class RmatGenMdspanTest : public ::testing::TestWithParam<RmatInputs> {
       raft::device_vector_view<const float, index_type> theta_view(theta.data(), theta.size());
       rmat_rectangular_gen(handle,
                            state,
+                           theta_view,
                            out_view,
                            out_src_view,
                            out_dst_view,
-                           theta_view,
                            params.r_scale,
                            params.c_scale,
                            params.n_edges);


### PR DESCRIPTION
I added two overloads of `rmat_rectangular_gen`, one for each of the existing overloads, that take device mdspan instead of raw arrays. I've added a unit test that imitates the existing unit test for the raw-array overloads; it builds and passes.

I also opportunistically fixed some unrelated existing small build errors that were blocking forward progress.