### PR TITLE
[REVIEW] Do not use strcpy to copy 2 char

### DIFF
--- a/cpp/include/raft/linalg/detail/svd.cuh
+++ b/cpp/include/raft/linalg/detail/svd.cuh
@@ -66,15 +66,9 @@ void svdQR(const raft::handle_t& handle,
   char jobu  = 'S';
   char jobvt = 'A';
 
-  if (!gen_left_vec) {
-    char new_u = 'N';
-    strcpy(&jobu, &new_u);
-  }
+  if (!gen_left_vec) { jobu = 'N'; }
 
-  if (!gen_right_vec) {
-    char new_vt = 'N';
-    strcpy(&jobvt, &new_vt);
-  }
+  if (!gen_right_vec) { jobvt = 'N'; }
 
   RAFT_CUSOLVER_TRY(cusolverDngesvd(cusolverH,
                                     jobu,


### PR DESCRIPTION
Given `char src` and `char dst`, one should copy them like `dst = src`, not like `strcpy(&dst, &src)`.

Using `strcpy` in this way invokes undefined behavior, and may cause stack corruption.

Fixes #847.