### PR TITLE
[REVIEW] Include knn.cuh in knn.cu benchmark source for finding brute_force_knn

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -218,7 +218,9 @@ fi
 
 if hasArg bench || (( ${NUMARGS} == 0 )); then
     BUILD_BENCH=ON
+    COMPILE_DIST_LIBRARY=ON
     ENABLE_NN_DEPENDENCIES=ON
+    COMPILE_NN_LIBRARY=ON
     CMAKE_TARGET="${CMAKE_TARGET};bench_raft"
 fi
 

--- a/cpp/bench/spatial/knn.cuh
+++ b/cpp/bench/spatial/knn.cuh
@@ -23,6 +23,11 @@
 #include <raft/spatial/knn/ivf_flat.cuh>
 #include <raft/spatial/knn/ivf_pq.cuh>
 #include <raft/spatial/knn/knn.cuh>
+
+#if defined RAFT_DISTANCE_COMPILED
+#include <raft/distance/specializations.cuh>
+#endif
+
 #if defined RAFT_NN_COMPILED
 #include <raft/spatial/knn/specializations.cuh>
 #endif


### PR DESCRIPTION
Current issue is that if you try to build only the benchmark code by doing `./build.sh bench`, the file `cpp/bench/spatial/knn.cu` fails to compile with the following error:
```
...
./cpp/bench/spatial/knn.cu(177): error: namespace "raft::spatial::knn" has no member "brute_force_knn"
          detected during:
            instantiation of "void raft::bench::spatial::knn<ValT, IdxT, ImplT>::run_benchmark(benchmark::State &) [with ValT=float, IdxT=int64_t, ImplT=raft::bench::spa$ial::brute_force_knn<float, int64_t>]"
...
```

The issue is that this file doesn't include `knn.cuh` (Courtesy: @achirkin). This PR fixes the error.