### PR TITLE
ivf-pq post integration hotfixes

### DIFF
--- a/cpp/include/raft/spatial/knn/detail/ivf_pq_build.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ivf_pq_build.cuh
@@ -31,6 +31,7 @@
 #include <raft/random/rng.cuh>
 #include <raft/stats/histogram.cuh>
 #include <raft/util/cuda_utils.cuh>
+#include <raft/util/device_atomics.cuh>
 #include <raft/util/pow2_utils.cuh>
 
 #include <rmm/cuda_stream_view.hpp>

--- a/cpp/test/spatial/ann_ivf_pq.cuh
+++ b/cpp/test/spatial/ann_ivf_pq.cuh
@@ -439,6 +439,34 @@ inline auto var_k() -> test_cases_t
     });
 }
 
+/**
+ * Cases brought up from downstream projects.
+ */
+inline auto special_cases() -> test_cases_t
+{
+  test_cases_t xs;
+
+#define ADD_CASE(f)                               \
+  do {                                            \
+    xs.push_back({});                             \
+    ([](ivf_pq_inputs & x) f)(xs[xs.size() - 1]); \
+  } while (0);
+
+  ADD_CASE({
+    x.num_db_vecs                = 1183514;
+    x.dim                        = 100;
+    x.num_queries                = 10000;
+    x.k                          = 10;
+    x.index_params.codebook_kind = ivf_pq::codebook_gen::PER_SUBSPACE;
+    x.index_params.pq_dim        = 10;
+    x.index_params.pq_bits       = 8;
+    x.index_params.n_lists       = 1024;
+    x.search_params.n_probes     = 50;
+  });
+
+  return xs;
+}
+
 /* Test instantiations */
 
 #define TEST_BUILD_SEARCH(type)                         \

--- a/cpp/test/spatial/ann_ivf_pq/test_float_uint32_t.cu
+++ b/cpp/test/spatial/ann_ivf_pq/test_float_uint32_t.cu
@@ -21,6 +21,6 @@ namespace raft::spatial::knn {
 using f32_f32_u32 = ivf_pq_test<float, float, uint32_t>;
 
 TEST_BUILD_SEARCH(f32_f32_u32)
-INSTANTIATE(f32_f32_u32, defaults() + var_n_probes() + var_k());
+INSTANTIATE(f32_f32_u32, defaults() + var_n_probes() + var_k() + special_cases());
 
 }  // namespace raft::spatial::knn

--- a/cpp/test/spatial/ann_utils.cuh
+++ b/cpp/test/spatial/ann_utils.cuh
@@ -21,7 +21,9 @@
 #include <raft/spatial/knn/detail/topk.cuh>
 #include <raft/util/cuda_utils.cuh>
 
+#include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
+#include <rmm/mr/device/device_memory_resource.hpp>
 
 namespace raft::spatial::knn {
 

--- a/cpp/test/spatial/ann_utils.cuh
+++ b/cpp/test/spatial/ann_utils.cuh
@@ -99,13 +99,13 @@ inline auto operator<<(std::ostream& os, const print_metric& p) -> std::ostream&
 }
 
 template <typename EvalT, typename DataT, typename IdxT>
-__global__ void naiveDistanceKernel(EvalT* dist,
-                                    const DataT* x,
-                                    const DataT* y,
-                                    IdxT m,
-                                    IdxT n,
-                                    IdxT k,
-                                    raft::distance::DistanceType type)
+__global__ void naive_distance_kernel(EvalT* dist,
+                                      const DataT* x,
+                                      const DataT* y,
+                                      IdxT m,
+                                      IdxT n,
+                                      IdxT k,
+                                      raft::distance::DistanceType type)
 {
   detail::utils::mapping<EvalT> f{};
   IdxT midx = threadIdx.x + blockIdx.x * blockDim.x;
@@ -146,23 +146,26 @@ void naiveBfKnn(EvalT* dist_topk,
                 size_t dim,
                 uint32_t k,
                 raft::distance::DistanceType type,
-                cudaStream_t stream = 0)
+                rmm::cuda_stream_view stream)
 {
+  rmm::mr::device_memory_resource* mr = nullptr;
+  auto pool_guard                     = raft::get_pool_memory_resource(mr, 1024 * 1024);
+
   dim3 block_dim(16, 32, 1);
   // maximum reasonable grid size in `y` direction
-  uint16_t grid_y =
+  auto grid_y =
     static_cast<uint16_t>(std::min<size_t>(raft::ceildiv<size_t>(input_len, block_dim.y), 32768));
 
   // bound the memory used by this function
   size_t max_batch_size =
     std::min<size_t>(n_inputs, raft::ceildiv<size_t>(size_t(1) << size_t(27), input_len));
-  rmm::device_uvector<EvalT> dist(max_batch_size * input_len, stream);
+  rmm::device_uvector<EvalT> dist(max_batch_size * input_len, stream, mr);
 
   for (size_t offset = 0; offset < n_inputs; offset += max_batch_size) {
     size_t batch_size = std::min(max_batch_size, n_inputs - offset);
     dim3 grid_dim(raft::ceildiv<size_t>(batch_size, block_dim.x), grid_y, 1);
 
-    naiveDistanceKernel<EvalT, DataT, IdxT><<<grid_dim, block_dim, 0, stream>>>(
+    naive_distance_kernel<EvalT, DataT, IdxT><<<grid_dim, block_dim, 0, stream>>>(
       dist.data(), x + offset * dim, y, batch_size, input_len, dim, type);
 
     detail::select_topk<EvalT, IdxT>(dist.data(),
@@ -173,7 +176,8 @@ void naiveBfKnn(EvalT* dist_topk,
                                      dist_topk + offset * k,
                                      indices_topk + offset * k,
                                      type != raft::distance::DistanceType::InnerProduct,
-                                     stream);
+                                     stream,
+                                     mr);
   }
   RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
 }
@@ -183,7 +187,7 @@ struct idx_dist_pair {
   IdxT idx;
   DistT dist;
   CompareDist eq_compare;
-  bool operator==(const idx_dist_pair<IdxT, DistT, CompareDist>& a) const
+  auto operator==(const idx_dist_pair<IdxT, DistT, CompareDist>& a) const -> bool
   {
     if (idx == a.idx) return true;
     if (eq_compare(dist, a.dist)) return true;


### PR DESCRIPTION
Fixes to ivf_pq::search:

  1. Fixed a typo in argument name of `select_cluster` (n_queries -> queries_batch) which led to illegal memory access for large batches.
  2. Removed unnecessary argument `max_batch_size` from the worker function.
  3. Replaced `<<<bracket-calling>>>` of dynamically selected kernels with `cudaLaunchKernel` invocations.
     The former led to the kernels silently being not called at all in some cases for no apparent reason (not reproducible in tests).

Fixes to ivf_pq::build:
  1. A missing include `raft/util/device_atomics.cuh` passed unnoticed due to transient dependencies.