### PR TITLE
[REVIEW] mdspan-ify uniformInt and normalTable

### DIFF
--- a/cpp/include/raft/random/rng.cuh
+++ b/cpp/include/raft/random/rng.cuh
@@ -75,6 +75,33 @@ void uniform(const raft::handle_t& handle,
 /**
  * @brief Generate uniformly distributed integers in the given range
  *
+ * @tparam OutputValueType Integral type; value type of the output vector
+ * @tparam IndexType Type used to represent length of the output vector
+ *
+ * @param[in] handle raft handle for resource management
+ * @param[in] rng_state random number generator state
+ * @param[out] out the output vector of random numbers
+ * @param[in] start start of the range
+ * @param[in] end end of the range
+ */
+template <typename OutputValueType, typename IndexType>
+void uniformInt(const raft::handle_t& handle,
+                RngState& rng_state,
+                raft::device_vector_view<OutputValueType, IndexType> out,
+                OutputValueType start,
+                OutputValueType end)
+{
+  static_assert(std::is_same<OutputValueType, typename std::remove_cv<OutputValueType>::type>::value,
+                "uniformInt: The output vector must be a view of nonconst, "
+                "so that we can write to it.");
+  static_assert(std::is_integral<OutputValueType>::value,
+                "uniformInt: The elements of the output vector must have integral type.");
+  detail::uniformInt(rng_state, out.data_handle(), out.extent(0), start, end, handle.get_stream());
+}
+
+/**
+ * @brief Legacy raw pointer overload of `uniformInt`
+ *
  * @tparam OutType data type of output random number
  * @tparam LenType data type used to represent length of the arrays
  * @param[in] handle raft handle for resource management

--- a/cpp/include/raft/random/rng.cuh
+++ b/cpp/include/raft/random/rng.cuh
@@ -21,10 +21,10 @@
 #include "rng_state.hpp"
 #include <cassert>
 #include <optional>
-#include <variant>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/handle.hpp>
 #include <type_traits>
+#include <variant>
 
 namespace raft::random {
 
@@ -92,9 +92,10 @@ void uniformInt(const raft::handle_t& handle,
                 OutputValueType start,
                 OutputValueType end)
 {
-  static_assert(std::is_same<OutputValueType, typename std::remove_cv<OutputValueType>::type>::value,
-                "uniformInt: The output vector must be a view of nonconst, "
-                "so that we can write to it.");
+  static_assert(
+    std::is_same<OutputValueType, typename std::remove_cv<OutputValueType>::type>::value,
+    "uniformInt: The output vector must be a view of nonconst, "
+    "so that we can write to it.");
   static_assert(std::is_integral<OutputValueType>::value,
                 "uniformInt: The elements of the output vector must have integral type.");
   detail::uniformInt(rng_state, out.data_handle(), out.extent(0), start, end, handle.get_stream());
@@ -213,11 +214,12 @@ void normalInt(const raft::handle_t& handle,
  * @param[out] ptr the output table
  */
 template <typename OutputValueType, typename IndexType>
-void normalTable(const raft::handle_t& handle,
-                 RngState& rng_state,
-                 raft::device_vector_view<const OutputValueType, IndexType> mu_vec,
-                 std::variant<raft::device_vector_view<const OutputValueType, IndexType>, OutputValueType> sigma,
-                 raft::device_matrix_view<OutputValueType, IndexType, raft::row_major> out)
+void normalTable(
+  const raft::handle_t& handle,
+  RngState& rng_state,
+  raft::device_vector_view<const OutputValueType, IndexType> mu_vec,
+  std::variant<raft::device_vector_view<const OutputValueType, IndexType>, OutputValueType> sigma,
+  raft::device_matrix_view<OutputValueType, IndexType, raft::row_major> out)
 {
   const OutputValueType* sigma_vec_ptr = nullptr;
   OutputValueType sigma_value{};
@@ -225,10 +227,12 @@ void normalTable(const raft::handle_t& handle,
   using sigma_vec_type = raft::device_vector_view<const OutputValueType, IndexType>;
   if (std::holds_alternative<sigma_vec_type>(sigma)) {
     auto sigma_vec = std::get<sigma_vec_type>(sigma);
-    RAFT_EXPECTS( sigma_vec.extent(0) == out.extent(1), "normalTable: The sigma vector "
-                  "has length %zu, which does not equal the number of columns "
-                  "in the output table %zu.", static_cast<size_t>(sigma_vec.extent(0)),
-                  static_cast<size_t>(out.extent(1)) );
+    RAFT_EXPECTS(sigma_vec.extent(0) == out.extent(1),
+                 "normalTable: The sigma vector "
+                 "has length %zu, which does not equal the number of columns "
+                 "in the output table %zu.",
+                 static_cast<size_t>(sigma_vec.extent(0)),
+                 static_cast<size_t>(out.extent(1)));
     // The extra length check makes this work even if sigma_vec views a std::vector,
     // where .data() need not return nullptr even if .size() is zero.
     sigma_vec_ptr = sigma_vec.extent(0) == 0 ? nullptr : sigma_vec.data_handle();
@@ -236,14 +240,21 @@ void normalTable(const raft::handle_t& handle,
     sigma_value = std::get<OutputValueType>(sigma);
   }
 
-  RAFT_EXPECTS( mu_vec.extent(0) == out.extent(1), "normalTable: The mu vector "
-                "has length %zu, which does not equal the number of columns "
-                "in the output table %zu.", static_cast<size_t>(mu_vec.extent(0)),
-                static_cast<size_t>(out.extent(1)) );
+  RAFT_EXPECTS(mu_vec.extent(0) == out.extent(1),
+               "normalTable: The mu vector "
+               "has length %zu, which does not equal the number of columns "
+               "in the output table %zu.",
+               static_cast<size_t>(mu_vec.extent(0)),
+               static_cast<size_t>(out.extent(1)));
 
-  detail::normalTable(
-    rng_state, out.data_handle(), out.extent(0), out.extent(1),
-    mu_vec.data_handle(), sigma_vec_ptr, sigma_value, handle.get_stream());
+  detail::normalTable(rng_state,
+                      out.data_handle(),
+                      out.extent(0),
+                      out.extent(1),
+                      mu_vec.data_handle(),
+                      sigma_vec_ptr,
+                      sigma_value,
+                      handle.get_stream());
 }
 
 /**

--- a/cpp/test/random/rng.cu
+++ b/cpp/test/random/rng.cu
@@ -596,7 +596,8 @@ class RngNormalTableMdspanTest : public ::testing::TestWithParam<RngNormalTableI
 
     fill(handle, r, mu_vec.data(), params.cols, params.mu);
 
-    raft::device_matrix_view<T, int, raft::row_major> data_view(data.data(), params.rows, params.cols);
+    raft::device_matrix_view<T, int, raft::row_major> data_view(
+      data.data(), params.rows, params.cols);
     raft::device_vector_view<const T, int> mu_vec_view(mu_vec.data(), params.cols);
     std::variant<raft::device_vector_view<const T, int>, T> sigma_var(params.sigma);
 
@@ -652,7 +653,9 @@ TEST_P(RngNormalTableMdspanTestF, Result)
   ASSERT_TRUE(match(meanvar[0], h_stats[0], CompareApprox<float>(num_sigma * params.tolerance)));
   ASSERT_TRUE(match(meanvar[1], h_stats[1], CompareApprox<float>(num_sigma * params.tolerance)));
 }
-INSTANTIATE_TEST_SUITE_P(RngNormalTableMdspanTests, RngNormalTableMdspanTestF, ::testing::ValuesIn(inputsf_t));
+INSTANTIATE_TEST_SUITE_P(RngNormalTableMdspanTests,
+                         RngNormalTableMdspanTestF,
+                         ::testing::ValuesIn(inputsf_t));
 
 const std::vector<RngNormalTableInputs<double>> inputsd_t = {
   {0.0055, 32, 1024, 1.0, 1.0, GenPhilox, 1234ULL},
@@ -679,7 +682,9 @@ TEST_P(RngNormalTableMdspanTestD, Result)
   ASSERT_TRUE(match(meanvar[0], h_stats[0], CompareApprox<double>(num_sigma * params.tolerance)));
   ASSERT_TRUE(match(meanvar[1], h_stats[1], CompareApprox<double>(num_sigma * params.tolerance)));
 }
-INSTANTIATE_TEST_SUITE_P(RngNormalTableMdspanTests, RngNormalTableMdspanTestD, ::testing::ValuesIn(inputsd_t));
+INSTANTIATE_TEST_SUITE_P(RngNormalTableMdspanTests,
+                         RngNormalTableMdspanTestD,
+                         ::testing::ValuesIn(inputsd_t));
 
 struct RngAffineInputs {
   int n;

--- a/cpp/test/random/rng_int.cu
+++ b/cpp/test/random/rng_int.cu
@@ -121,13 +121,69 @@ class RngTest : public ::testing::TestWithParam<RngInputs<T>> {
   float h_stats[2];  // mean, var
 };
 
-typedef RngTest<uint32_t> RngTestU32;
+template <typename T>
+class RngMdspanTest : public ::testing::TestWithParam<RngInputs<T>> {
+ public:
+  RngMdspanTest()
+    : params(::testing::TestWithParam<RngInputs<T>>::GetParam()),
+      stream(handle.get_stream()),
+      data(0, stream),
+      stats(2, stream)
+  {
+    data.resize(params.len, stream);
+    RAFT_CUDA_TRY(cudaMemsetAsync(stats.data(), 0, 2 * sizeof(float), stream));
+  }
+
+ protected:
+  void SetUp() override
+  {
+    RngState r(params.seed, params.gtype);
+    raft::device_vector_view<T> data_view(data.data(), data.size());
+
+    switch (params.type) {
+      case RNG_Uniform:
+        uniformInt(handle, r, data_view, params.start, params.end);
+        break;
+    };
+    static const int threads = 128;
+    meanKernel<T, threads><<<raft::ceildiv(params.len, threads), threads, 0, stream>>>(
+      stats.data(), data.data(), params.len);
+    update_host<float>(h_stats, stats.data(), 2, stream);
+    handle.sync_stream(stream);
+    h_stats[0] /= params.len;
+    h_stats[1] = (h_stats[1] / params.len) - (h_stats[0] * h_stats[0]);
+    handle.sync_stream(stream);
+  }
+
+  void getExpectedMeanVar(float meanvar[2])
+  {
+    switch (params.type) {
+      case RNG_Uniform:
+        meanvar[0] = (params.start + params.end) * 0.5f;
+        meanvar[1] = params.end - params.start;
+        meanvar[1] = meanvar[1] * meanvar[1] / 12.f;
+        break;
+    };
+  }
+
+ protected:
+  raft::handle_t handle;
+  cudaStream_t stream;
+
+  RngInputs<T> params;
+  rmm::device_uvector<T> data;
+  rmm::device_uvector<float> stats;
+  float h_stats[2];  // mean, var
+};
+
 const std::vector<RngInputs<uint32_t>> inputs_u32 = {
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
 
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPC, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPC, 1234ULL}};
+
+using RngTestU32 = RngTest<uint32_t>;
 TEST_P(RngTestU32, Result)
 {
   float meanvar[2];
@@ -137,13 +193,24 @@ TEST_P(RngTestU32, Result)
 }
 INSTANTIATE_TEST_SUITE_P(RngTests, RngTestU32, ::testing::ValuesIn(inputs_u32));
 
-typedef RngTest<uint64_t> RngTestU64;
+using RngMdspanTestU32 = RngMdspanTest<uint32_t>;
+TEST_P(RngMdspanTestU32, Result)
+{
+  float meanvar[2];
+  getExpectedMeanVar(meanvar);
+  ASSERT_TRUE(match(meanvar[0], h_stats[0], CompareApprox<float>(params.tolerance)));
+  ASSERT_TRUE(match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_SUITE_P(RngMdspanTests, RngMdspanTestU32, ::testing::ValuesIn(inputs_u32));
+
 const std::vector<RngInputs<uint64_t>> inputs_u64 = {
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
 
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPC, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPC, 1234ULL}};
+
+using RngTestU64 = RngTest<uint64_t>;
 TEST_P(RngTestU64, Result)
 {
   float meanvar[2];
@@ -153,13 +220,24 @@ TEST_P(RngTestU64, Result)
 }
 INSTANTIATE_TEST_SUITE_P(RngTests, RngTestU64, ::testing::ValuesIn(inputs_u64));
 
-typedef RngTest<int32_t> RngTestS32;
+using RngMdspanTestU64 = RngMdspanTest<uint64_t>;
+TEST_P(RngMdspanTestU64, Result)
+{
+  float meanvar[2];
+  getExpectedMeanVar(meanvar);
+  ASSERT_TRUE(match(meanvar[0], h_stats[0], CompareApprox<float>(params.tolerance)));
+  ASSERT_TRUE(match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_SUITE_P(RngMdspanTests, RngMdspanTestU64, ::testing::ValuesIn(inputs_u64));
+
 const std::vector<RngInputs<int32_t>> inputs_s32 = {
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
 
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPC, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPC, 1234ULL}};
+
+using RngTestS32 = RngTest<int32_t>;
 TEST_P(RngTestS32, Result)
 {
   float meanvar[2];
@@ -169,13 +247,24 @@ TEST_P(RngTestS32, Result)
 }
 INSTANTIATE_TEST_SUITE_P(RngTests, RngTestS32, ::testing::ValuesIn(inputs_s32));
 
-typedef RngTest<int64_t> RngTestS64;
+using RngMdspanTestS32 = RngMdspanTest<int32_t>;
+TEST_P(RngMdspanTestS32, Result)
+{
+  float meanvar[2];
+  getExpectedMeanVar(meanvar);
+  ASSERT_TRUE(match(meanvar[0], h_stats[0], CompareApprox<float>(params.tolerance)));
+  ASSERT_TRUE(match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_SUITE_P(RngMdspanTests, RngMdspanTestS32, ::testing::ValuesIn(inputs_s32));
+
 const std::vector<RngInputs<int64_t>> inputs_s64 = {
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPhilox, 1234ULL},
 
   {0.1f, 32 * 1024, 0, 20, RNG_Uniform, GenPC, 1234ULL},
   {0.1f, 8 * 1024, 0, 20, RNG_Uniform, GenPC, 1234ULL}};
+
+using RngTestS64 = RngTest<int64_t>;
 TEST_P(RngTestS64, Result)
 {
   float meanvar[2];
@@ -184,6 +273,16 @@ TEST_P(RngTestS64, Result)
   ASSERT_TRUE(match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
 }
 INSTANTIATE_TEST_SUITE_P(RngTests, RngTestS64, ::testing::ValuesIn(inputs_s64));
+
+using RngMdspanTestS64 = RngMdspanTest<int64_t>;
+TEST_P(RngMdspanTestS64, Result)
+{
+  float meanvar[2];
+  getExpectedMeanVar(meanvar);
+  ASSERT_TRUE(match(meanvar[0], h_stats[0], CompareApprox<float>(params.tolerance)));
+  ASSERT_TRUE(match(meanvar[1], h_stats[1], CompareApprox<float>(params.tolerance)));
+}
+INSTANTIATE_TEST_SUITE_P(RngMdspanTests, RngMdspanTestS64, ::testing::ValuesIn(inputs_s64));
 
 }  // namespace random
 }  // namespace raft

--- a/cpp/test/random/rng_int.cu
+++ b/cpp/test/random/rng_int.cu
@@ -141,9 +141,7 @@ class RngMdspanTest : public ::testing::TestWithParam<RngInputs<T>> {
     raft::device_vector_view<T> data_view(data.data(), data.size());
 
     switch (params.type) {
-      case RNG_Uniform:
-        uniformInt(handle, r, data_view, params.start, params.end);
-        break;
+      case RNG_Uniform: uniformInt(handle, r, data_view, params.start, params.end); break;
     };
     static const int threads = 128;
     meanKernel<T, threads><<<raft::ceildiv(params.len, threads), threads, 0, stream>>>(


### PR DESCRIPTION
* Add overloads of `raft::random::uniformInt` and `raft::random::normalTable` that take mdspan.
* Add unit tests for each case.
* Improve documentation of `normalTable` to explain that the output table uses a row-major layout.