### PR TITLE
Fix logger (vsnprintf consumes args)

### DIFF
--- a/cpp/include/raft/core/logger.hpp
+++ b/cpp/include/raft/core/logger.hpp
@@ -78,8 +78,9 @@ namespace detail {
  */
 inline std::string format(const char* fmt, va_list& vl)
 {
-  int length = std::vsnprintf(nullptr, 0, fmt, vl);
-  assert(length >= 0);
+  va_list vl_copy;
+  va_copy(vl_copy, vl);
+  int length = std::vsnprintf(nullptr, 0, fmt, vl_copy);
   std::vector<char> buf(length + 1);
   std::vsnprintf(buf.data(), length + 1, fmt, vl);
   return std::string(buf.data());

--- a/cpp/include/raft/core/logger.hpp
+++ b/cpp/include/raft/core/logger.hpp
@@ -81,6 +81,7 @@ inline std::string format(const char* fmt, va_list& vl)
   va_list vl_copy;
   va_copy(vl_copy, vl);
   int length = std::vsnprintf(nullptr, 0, fmt, vl_copy);
+  assert(length >= 0);
   std::vector<char> buf(length + 1);
   std::vsnprintf(buf.data(), length + 1, fmt, vl);
   return std::string(buf.data());


### PR DESCRIPTION
I noticed debug logs displayed nonsensical values so I had a look at the logger code and found it incorrect. Indeed `vsnprintf` consumes the arg list, so in order to call it twice, one must make a copy of the arg list.