### PR TITLE
Moving low-level iterative solver primitives to `raft::solver` 

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -258,8 +258,9 @@ if(RAFT_COMPILE_DIST_LIBRARY)
     src/distance/specializations/detail/kernels/gram_matrix_base_float.cu
     src/distance/specializations/detail/kernels/polynomial_kernel_double_int.cu
     src/distance/specializations/detail/kernels/polynomial_kernel_float_int.cu
-    src/distance/specializations/detail/kernels/rbf_kernel_double.cu
-    src/distance/specializations/detail/kernels/rbf_kernel_float.cu
+# These are somehow missing a kernel definition which is causing a compile error.
+#    src/distance/specializations/detail/kernels/rbf_kernel_double.cu
+#    src/distance/specializations/detail/kernels/rbf_kernel_float.cu
     src/distance/specializations/detail/kernels/tanh_kernel_double.cu
     src/distance/specializations/detail/kernels/tanh_kernel_float.cu
     src/distance/specializations/detail/kl_divergence_float_float_float_int.cu

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -248,11 +248,20 @@ if(RAFT_COMPILE_DIST_LIBRARY)
     src/distance/specializations/detail/chebyshev.cu
     src/distance/specializations/detail/correlation.cu
     src/distance/specializations/detail/cosine.cu
+    src/distance/specializations/detail/cosine.cu
     src/distance/specializations/detail/hamming_unexpanded.cu
     src/distance/specializations/detail/hellinger_expanded.cu
     src/distance/specializations/detail/jensen_shannon_float_float_float_int.cu
     src/distance/specializations/detail/jensen_shannon_float_float_float_uint32.cu
     src/distance/specializations/detail/jensen_shannon_double_double_double_int.cu
+    src/distance/specializations/detail/kernels/gram_matrix_base_double.cu
+    src/distance/specializations/detail/kernels/gram_matrix_base_float.cu
+    src/distance/specializations/detail/kernels/polynomial_kernel_double_int.cu
+    src/distance/specializations/detail/kernels/polynomial_kernel_float_int.cu
+    src/distance/specializations/detail/kernels/rbf_kernel_double.cu
+    src/distance/specializations/detail/kernels/rbf_kernel_float.cu
+    src/distance/specializations/detail/kernels/tanh_kernel_double.cu
+    src/distance/specializations/detail/kernels/tanh_kernel_float.cu
     src/distance/specializations/detail/kl_divergence_float_float_float_int.cu
     src/distance/specializations/detail/kl_divergence_float_float_float_uint32.cu
     src/distance/specializations/detail/kl_divergence_double_double_double_int.cu

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -85,6 +85,7 @@ if(BUILD_BENCH)
             bench/distance/distance_exp_l2.cu
             bench/distance/distance_l1.cu
             bench/distance/distance_unexp_l2.cu
+            bench/distance/kernels.cu
             bench/main.cpp
             OPTIONAL DIST
             )

--- a/cpp/bench/distance/distance_common.cuh
+++ b/cpp/bench/distance/distance_common.cuh
@@ -16,7 +16,7 @@
 
 #include <common/benchmark.hpp>
 #include <raft/distance/distance.cuh>
-#include <raft/util/cudart_utils.h>
+#include <raft/util/cudart_utils.hpp>
 #if defined RAFT_DISTANCE_COMPILED
 #include <raft/distance/specializations.cuh>
 #endif

--- a/cpp/bench/distance/distance_common.cuh
+++ b/cpp/bench/distance/distance_common.cuh
@@ -15,8 +15,8 @@
  */
 
 #include <common/benchmark.hpp>
-#include <raft/cudart_utils.h>
 #include <raft/distance/distance.cuh>
+#include <raft/util/cudart_utils.h>
 #if defined RAFT_DISTANCE_COMPILED
 #include <raft/distance/specializations.cuh>
 #endif

--- a/cpp/bench/distance/kernels.cu
+++ b/cpp/bench/distance/kernels.cu
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if defined RAFT_DISTANCE_COMPILED
+#include <raft/distance/specializations.cuh>
+#endif
+
+#include <common/benchmark.hpp>
+#include <memory>
+#include <raft/core/handle.hpp>
+#include <raft/distance/distance_types.hpp>
+#include <raft/distance/kernels.cuh>
+#include <raft/random/rng.cuh>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace raft::distance::kernels::bench {
+
+struct GramTestParams {
+  int m;  // m parameter of the GEMM
+  int k;  // k parameter of the GEMM
+  int n;  // n parameter of the GEMM
+  KernelParams kernel_params;
+  bool is_row_major;
+};  // struct GramTestParams
+
+template <typename T>
+struct GramMatrix : public Fixture {
+  GramMatrix(const std::string& name, const GramTestParams& p)
+    : Fixture(name), params(p), A(0, stream), B(0, stream), C(0, stream)
+  {
+    std::vector<std::string> kernel_names{"linear", "poly", "rbf", "tanh"};
+    std::ostringstream oss;
+    oss << name << "/" << kernel_names[p.kernel_params.kernel] << "/" << p.m << "x" << p.k << "x"
+        << p.n << "/" << (p.is_row_major ? "row_major" : "col_major");
+    this->SetName(oss.str().c_str());
+
+    kernel = std::unique_ptr<GramMatrixBase<T>>(
+      KernelFactory<T>::create(p.kernel_params, handle.get_cublas_handle()));
+  }
+
+  ~GramMatrix() {}
+
+ protected:
+  void allocateBuffers(const ::benchmark::State& state) override
+  {
+    A.resize(params.m * params.k, stream);
+    B.resize(params.k * params.n, stream);
+    C.resize(params.m * params.n, stream);
+    raft::random::Rng r(123456ULL);
+    r.uniform(A.data(), params.m * params.k, T(-1.0), T(1.0), stream);
+    r.uniform(B.data(), params.k * params.n, T(-1.0), T(1.0), stream);
+  }
+  void deallocateBuffers(const ::benchmark::State& state) override
+  {
+    A.release();
+    B.release();
+    C.release();
+  }
+  void runBenchmark(::benchmark::State& state) override
+  {
+    if (!this->kernel) { state.SkipWithError("Kernel matrix is not initialized"); }
+    loopOnState(state, [this]() {
+      (*this->kernel)(A.data(),
+                      this->params.m,
+                      this->params.k,
+                      B.data(),
+                      this->params.n,
+                      C.data(),
+                      this->params.is_row_major,
+                      this->stream);
+    });
+  }
+
+ private:
+  raft::handle_t& handle;
+  std::unique_ptr<GramMatrixBase<T>> kernel;
+  GramTestParams params;
+
+  rmm::device_uvector<T> A;  // input matrix A, size [m * k]
+  rmm::device_uvector<T> B;  // input matrix B, size [n * k]
+  rmm::device_uvector<T> C;  // output matrix C, size [m*n]
+};
+
+static std::vector<GramTestParams> getInputs()
+{
+  std::vector<GramTestParams> param_vec;
+  std::vector<KernelParams> kernel_params{KernelParams{LINEAR, 3, 1, 0},
+                                          KernelParams{POLYNOMIAL, 2, 1.3, 1},
+                                          KernelParams{TANH, 2, 0.5, 2.4},
+                                          KernelParams{RBF, 2, 0.5, 0}};
+  struct TestSize {
+    int m;
+    int k;
+    int n;
+  };
+  std::vector<TestSize> data_size{{4096, 10, 1024},
+                                  {4096, 100, 1024},
+                                  {4096, 1000, 1024},
+                                  {4096, 10000, 1024},
+                                  {100000, 10, 1024},
+                                  {100000, 100, 1024},
+                                  {100000, 1000, 1024}};
+
+  param_vec.reserve(kernel_params.size() * data_size.size());
+  for (TestSize s : data_size) {
+    for (auto kernel : kernel_params) {
+      for (bool row_major : {false, true}) {
+        param_vec.push_back(GramTestParams{s.m, s.k, s.n, kernel, row_major});
+      }
+    }
+  }
+  return param_vec;
+}
+
+ML_BENCH_REGISTER(GramTestParams, GramMatrix<float>, "", getInputs());
+ML_BENCH_REGISTER(GramTestParams, GramMatrix<double>, "", getInputs());
+
+}  // namespace raft::distance::kernels::bench

--- a/cpp/include/raft/distance/detail/kernels/gram_matrix.cuh
+++ b/cpp/include/raft/distance/detail/kernels/gram_matrix.cuh
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/distance/distance.cuh>
+
+#include <raft/linalg/detail/cublas_wrappers.hpp>
+#include <raft/linalg/gemm.cuh>
+
+namespace raft::distance::kernels::detail {
+
+/**
+ * Base class for general Gram matrices
+ * A Gram matrix is the Hermitian matrix of inner probucts G_ik = <x_i, x_k>
+ * Here, the  inner product is evaluated for all elements from vectors sets X1,
+ * and X2.
+ *
+ * To be more precise, on exit the output buffer will store:
+ * - if is_row_major == true: out[j+k*n1] = <x1_j, x2_k>,
+ * - if is_row_major == false: out[j*n2 + k] = <x1_j, x2_k>,
+ * where x1_j is the j-th vector from the x1 set and x2_k is the k-th vector
+ * from the x2 set.
+ */
+template <typename math_t>
+class GramMatrixBase {
+  cublasHandle_t cublas_handle;
+
+ public:
+  GramMatrixBase(cublasHandle_t cublas_handle) : cublas_handle(cublas_handle){};
+
+  virtual ~GramMatrixBase(){};
+
+  /** Convenience function to evaluate the Gram matrix for two vector sets.
+   *
+   * @param [in] x1 device array of vectors, size [n1*n_cols]
+   * @param [in] n1 number vectors in x1
+   * @param [in] n_cols number of columns (features) in x1 and x2
+   * @param [in] x2 device array of vectors, size [n2*n_cols]
+   * @param [in] n2 number vectors in x2
+   * @param [out] out device buffer to store the Gram matrix, size [n1*n2]
+   * @param [in] is_row_major whether the input and output matrices are in row
+   *        major format
+   * @param [in] stream cuda stream
+   * @param ld1 leading dimension of x1
+   * @param ld2 leading dimension of x2
+   * @param ld_out leading dimension of out
+   */
+  virtual void operator()(const math_t* x1,
+                          int n1,
+                          int n_cols,
+                          const math_t* x2,
+                          int n2,
+                          math_t* out,
+                          bool is_row_major,
+                          cudaStream_t stream,
+                          int ld1    = 0,
+                          int ld2    = 0,
+                          int ld_out = 0)
+  {
+    if (ld1 <= 0) { ld1 = is_row_major ? n_cols : n1; }
+    if (ld2 <= 0) { ld2 = is_row_major ? n_cols : n2; }
+    if (ld_out <= 0) { ld_out = is_row_major ? n2 : n1; }
+    evaluate(x1, n1, n_cols, x2, n2, out, is_row_major, stream, ld1, ld2, ld_out);
+  }
+
+  /** Evaluate the Gram matrix for two vector sets using simple dot product.
+   *
+   * @param [in] x1 device array of vectors, size [n1*n_cols]
+   * @param [in] n1 number vectors in x1
+   * @param [in] n_cols number of columns (features) in x1 and x2
+   * @param [in] x2 device array of vectors, size [n2*n_cols]
+   * @param [in] n2 number vectors in x2
+   * @param [out] out device buffer to store the Gram matrix, size [n1*n2]
+   * @param [in] is_row_major whether the input and output matrices are in row
+   *        major format
+   * @param [in] stream cuda stream
+   * @param ld1 leading dimension of x1 (usually it is n1)
+   * @param ld2 leading dimension of x2 (usually it is n2)
+   * @param ld_out leading dimension of out (usually it is n1)
+   */
+  virtual void evaluate(const math_t* x1,
+                        int n1,
+                        int n_cols,
+                        const math_t* x2,
+                        int n2,
+                        math_t* out,
+                        bool is_row_major,
+                        cudaStream_t stream,
+                        int ld1,
+                        int ld2,
+                        int ld_out)
+  {
+    linear(x1, n1, n_cols, x2, n2, out, is_row_major, stream, ld1, ld2, ld_out);
+  }
+
+  // private:
+  // The following methods should be private, they are kept public to avoid:
+  // "error: The enclosing parent function ("distance") for an extended
+  // __device__ lambda cannot have private or protected access within its class"
+
+  /** Calculates the Gram matrix using simple dot product between vector sets.
+   *
+   * out = x1 * x2
+   *
+   * Can be used as a building block for more complex kernel functions.
+   *
+   * @param [in] x1 device array of vectors, size [n1*n_cols]
+   * @param [in] n1 number vectors in x1
+   * @param [in] n_cols number of colums (features) in x1 and x2
+   * @param [in] x2 device array of vectors, size [n2*n_cols]
+   * @param [in] n2 number vectors in x2
+   * @param [out] out device buffer to store the Gram matrix, size [n1*n2]
+   * @param [in] is_row_major whether the input and output matrices are in row
+   *        major format
+   * @param [in] stream cuda stream
+   * @param ld1 leading dimension of x1
+   * @param ld2 leading dimension of x2
+   * @param ld_out leading dimension of out
+   */
+  void linear(const math_t* x1,
+              int n1,
+              int n_cols,
+              const math_t* x2,
+              int n2,
+              math_t* out,
+              bool is_row_major,
+              cudaStream_t stream,
+              int ld1,
+              int ld2,
+              int ld_out)
+  {
+    math_t alpha = 1.0;
+    math_t beta  = 0.0;
+    if (is_row_major) {
+      // #TODO: Call from public API when ready
+      RAFT_CUBLAS_TRY(raft::linalg::detail::cublasgemm(cublas_handle,
+                                                       CUBLAS_OP_T,
+                                                       CUBLAS_OP_N,
+                                                       n2,
+                                                       n1,
+                                                       n_cols,
+                                                       &alpha,
+                                                       x2,
+                                                       ld2,
+                                                       x1,
+                                                       ld1,
+                                                       &beta,
+                                                       out,
+                                                       ld_out,
+                                                       stream));
+    } else {
+      // #TODO: Call from public API when ready
+      RAFT_CUBLAS_TRY(raft::linalg::detail::cublasgemm(cublas_handle,
+                                                       CUBLAS_OP_N,
+                                                       CUBLAS_OP_T,
+                                                       n1,
+                                                       n2,
+                                                       n_cols,
+                                                       &alpha,
+                                                       x1,
+                                                       ld1,
+                                                       x2,
+                                                       ld2,
+                                                       &beta,
+                                                       out,
+                                                       ld_out,
+                                                       stream));
+    }
+  }
+
+  /** Calculates the Gram matrix using Euclidean distance.
+   *
+   * Can be used as a building block for more complex kernel functions.
+   *
+   * @param [in] x1 device array of vectors, size [n1*n_cols]
+   * @param [in] n1 number vectors in x1
+   * @param [in] n_cols number of columns (features) in x1 and x2
+   * @param [in] x2 device array of vectors, size [n2*n_cols]
+   * @param [in] n2 number vectors in x2
+   * @param [out] out device buffer to store the Gram matrix, size [n1*n2]
+   * @param [in] is_row_major whether the input and output matrices are in row
+   *        major format
+   * @param [in] stream cuda stream
+   * @param ld1 leading dimension of x1
+   * @param ld2 leading dimension of x2
+   * @param ld_out leading dimension of out
+   */
+  virtual void distance(const math_t* x1,
+                        int n1,
+                        int n_cols,
+                        const math_t* x2,
+                        int n2,
+                        math_t* out,
+                        bool is_row_major,
+                        cudaStream_t stream,
+                        int ld1,
+                        int ld2,
+                        int ld_out)
+  {
+    raft::distance::distance<raft::distance::DistanceType::L2Unexpanded, math_t, math_t, math_t>(
+      x1, x2, out, n1, n2, n_cols, stream, is_row_major);
+  }
+};
+};  // end namespace raft::distance::kernels::detail

--- a/cpp/include/raft/distance/detail/kernels/kernel_factory.cuh
+++ b/cpp/include/raft/distance/detail/kernels/kernel_factory.cuh
@@ -18,7 +18,7 @@
 
 #include "gram_matrix.cuh"
 #include "kernel_matrices.cuh"
-#include <cuml/matrix/kernelparams.h>
+#include <raft/distance/distance_types.hpp>
 #include <raft/util/cudart_utils.hpp>
 
 namespace raft::distance::kernels::detail {

--- a/cpp/include/raft/distance/detail/kernels/kernel_factory.cuh
+++ b/cpp/include/raft/distance/detail/kernels/kernel_factory.cuh
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "gram_matrix.cuh"
+#include "kernel_matrices.cuh"
+#include <cuml/matrix/kernelparams.h>
+#include <raft/util/cudart_utils.hpp>
+
+namespace raft::distance::kernels::detail {
+
+template <typename math_t>
+class KernelFactory {
+ public:
+  static GramMatrixBase<math_t>* create(KernelParams params, cublasHandle_t cublas_handle)
+  {
+    GramMatrixBase<math_t>* res;
+    // KernelParams is not templated, we convert the parameters to math_t here:
+    math_t coef0 = params.coef0;
+    math_t gamma = params.gamma;
+    switch (params.kernel) {
+      case LINEAR: res = new GramMatrixBase<math_t>(cublas_handle); break;
+      case POLYNOMIAL:
+        res = new PolynomialKernel<math_t, int>(params.degree, gamma, coef0, cublas_handle);
+        break;
+      case TANH: res = new TanhKernel<math_t>(gamma, coef0, cublas_handle); break;
+      case RBF: res = new RBFKernel<math_t>(gamma); break;
+      default: throw raft::exception("Kernel not implemented");
+    }
+    return res;
+  }
+};
+
+};  // end namespace raft::distance::kernels::detail

--- a/cpp/include/raft/distance/detail/kernels/kernel_matrices.cuh
+++ b/cpp/include/raft/distance/detail/kernels/kernel_matrices.cuh
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "gram_matrix.cuh"
+#include <raft/util/cuda_utils.cuh>
+
+#include <raft/distance/distance.cuh>
+#include <raft/linalg/gemm.cuh>
+
+namespace raft::distance::kernels::detail {
+
+/** Epiloge function for polynomial kernel without padding.
+ * Calculates output = (gain*in + offset)^exponent
+ * @param inout device vector in column major format, size [len]
+ * @param len array length
+ * @param exponent
+ * @param gain
+ * @param offset
+ */
+template <typename math_t, typename exp_t>
+__global__ void polynomial_kernel_nopad(
+  math_t* inout, size_t len, exp_t exponent, math_t gain, math_t offset)
+{
+  for (size_t tid = threadIdx.x + blockIdx.x * blockDim.x; tid < len;
+       tid += blockDim.x * gridDim.x) {
+    inout[tid] = pow(gain * inout[tid] + offset, exponent);
+  }
+}
+
+/** Epiloge function for polynomial kernel with padding.
+ * Calculates output = (gain*input + offset)^exponent
+ * @param inout device vector in column major format, size [ld * cols]
+ * @param ld leading dimension of the inout buffer
+ * @param rows number of rows (rows <= ld)
+ * @param cols number of colums
+ * @param exponent
+ * @param gain
+ * @param offset
+ */
+template <typename math_t, typename exp_t>
+__global__ void polynomial_kernel(
+  math_t* inout, int ld, int rows, int cols, exp_t exponent, math_t gain, math_t offset)
+{
+  for (size_t tidy = threadIdx.y + blockIdx.y * blockDim.y; tidy < cols;
+       tidy += blockDim.y * gridDim.y)
+    for (size_t tidx = threadIdx.x + blockIdx.x * blockDim.x; tidx < rows;
+         tidx += blockDim.x * gridDim.x) {
+      inout[tidx + tidy * ld] = pow(gain * inout[tidx + tidy * ld] + offset, exponent);
+    }
+}
+
+/** Epiloge function for tanh kernel without padding.
+ * Calculates output = tanh(gain*input + offset)
+ * @param inout device vector, size [len]
+ * @param len length of the input vector
+ * @param gain
+ * @param offset
+ */
+template <typename math_t>
+__global__ void tanh_kernel_nopad(math_t* inout, size_t len, math_t gain, math_t offset)
+{
+  for (size_t tid = threadIdx.x + blockIdx.x * blockDim.x; tid < len;
+       tid += blockDim.x * gridDim.x) {
+    inout[tid] = tanh(gain * inout[tid] + offset);
+  }
+}
+
+/** Epiloge function for tanh kernel without padding.
+ * Calculates output = tanh(gain*input + offset)
+ * @param inout device vector in column major format, size [ld * cols]
+ * @param ld leading dimension of the inout buffer
+ * @param rows number of rows (rows <= ld)
+ * @param cols number of colums
+ * @param gain
+ * @param offset
+ */
+template <typename math_t>
+__global__ void tanh_kernel(math_t* inout, int ld, int rows, int cols, math_t gain, math_t offset)
+{
+  for (size_t tidy = threadIdx.y + blockIdx.y * blockDim.y; tidy < cols;
+       tidy += blockDim.y * gridDim.y)
+    for (size_t tidx = threadIdx.x + blockIdx.x * blockDim.x; tidx < rows;
+         tidx += blockDim.x * gridDim.x) {
+      inout[tidx + tidy * ld] = tanh(gain * inout[tidx + tidy * ld] + offset);
+    }
+}
+
+/**
+ * Create a kernel matrix using polynomial kernel function.
+ */
+template <typename math_t, typename exp_t>
+class PolynomialKernel : public GramMatrixBase<math_t> {
+  exp_t exponent;
+  math_t gain;
+  math_t offset;
+
+  void applyKernel(
+    math_t* inout, int ld, int rows, int cols, bool is_row_major, cudaStream_t stream)
+  {
+    const int n_minor = is_row_major ? cols : rows;
+    if (ld == n_minor) {
+      polynomial_kernel_nopad<<<raft::ceildiv<size_t>((size_t)rows * cols, 128), 128, 0, stream>>>(
+        inout, rows * cols, exponent, gain, offset);
+    } else {
+      int n1 = is_row_major ? cols : rows;
+      int n2 = is_row_major ? rows : cols;
+      polynomial_kernel<<<dim3(raft::ceildiv(n1, 32), raft::ceildiv(n2, 4), 1),
+                          dim3(32, 4, 1),
+                          0,
+                          stream>>>(inout, ld, n1, n2, exponent, gain, offset);
+    }
+    RAFT_CUDA_TRY(cudaPeekAtLastError());
+  }
+
+ public:
+  /**
+   * Constructs a polynomial kernel object.
+   * It evaluates the kernel matrix using the following formula:
+   * K_ij = (gain*<x1_i, x2_k> + offset)^exponent
+   *
+   * @tparam math_t floating point type
+   * @tparam exp_t type of exponent
+   * @param exponent
+   * @param gain
+   * @param offset
+   * @param cublas_handle
+   */
+  PolynomialKernel(exp_t exponent, math_t gain, math_t offset, cublasHandle_t cublas_handle)
+    : GramMatrixBase<math_t>(cublas_handle), exponent(exponent), gain(gain), offset(offset)
+  {
+  }
+
+  /** Evaluate kernel matrix using polynomial kernel.
+   *
+   * output[i,k] = (gain*<x1_i, x2_k> + offset)^exponent,
+   * where x1_i is the i-th vector from the x1 set, and x2_k is k-th vector
+   * in the x2 set, and < , > denotes dot product.
+   *
+   * @param [in] x1 device array of vectors, size [n1*n_cols]
+   * @param [in] n1 number vectors in x1
+   * @param [in] n_cols number of features in x1 and x2
+   * @param [in] x2 device array of vectors, size [n2*cols]
+   * @param [in] n2 number vectors in x2
+   * @param [out] out device buffer to store the Gram matrix, size [n1*n2]
+   * @param [in] is_row_major whether the input and output matrices are in row
+   *        major format
+   * @param [in] stream cuda stream
+   * @param ld1 leading dimension of x1
+   * @param ld2 leading dimension of x2
+   * @param ld_out leading dimension of out
+   */
+  void evaluate(const math_t* x1,
+                int n1,
+                int n_cols,
+                const math_t* x2,
+                int n2,
+                math_t* out,
+                bool is_row_major,
+                cudaStream_t stream,
+                int ld1,
+                int ld2,
+                int ld_out)
+  {
+    GramMatrixBase<math_t>::linear(
+      x1, n1, n_cols, x2, n2, out, is_row_major, stream, ld1, ld2, ld_out);
+    applyKernel(out, ld_out, n1, n2, is_row_major, stream);
+  }
+};
+
+/**
+ * Create a kernel matrix using tanh kernel function.
+ */
+template <typename math_t>
+class TanhKernel : public GramMatrixBase<math_t> {
+  math_t gain, offset;
+
+  void applyKernel(
+    math_t* inout, int ld, int rows, int cols, bool is_row_major, cudaStream_t stream)
+  {
+    const int n_minor = is_row_major ? cols : rows;
+    if (ld == n_minor) {
+      tanh_kernel_nopad<<<raft::ceildiv<size_t>((size_t)rows * cols, 128), 128, 0, stream>>>(
+        inout, rows * cols, gain, offset);
+    } else {
+      int n1 = is_row_major ? cols : rows;
+      int n2 = is_row_major ? rows : cols;
+      tanh_kernel<<<dim3(raft::ceildiv(n1, 32), raft::ceildiv(n2, 4), 1),
+                    dim3(32, 4, 1),
+                    0,
+                    stream>>>(inout, ld, n1, n2, gain, offset);
+    }
+    RAFT_CUDA_TRY(cudaPeekAtLastError());
+  }
+
+ public:
+  /**
+   * Constructs a tanh kernel object.
+   * It evaluates the kernel matrix using the following formula:
+   * K_ij = tanh(gain*<x1_i, x2_k> + offset)
+   *
+   * @tparam math_t floating point type
+   * @param gain
+   * @param offset
+   * @param cublas_handle
+   */
+  TanhKernel(math_t gain, math_t offset, cublasHandle_t cublas_handle)
+    : GramMatrixBase<math_t>(cublas_handle), gain(gain), offset(offset)
+  {
+  }
+
+  /** Evaluate kernel matrix using tanh kernel.
+   *
+   * output_[i + k*n1] = (gain*<x1_i, x2_k> + offset)^exponent,
+   * where x1_i is the i-th vector from the x1 set, and x2_k is k-th vector
+   * in the x2 set, and < , > denotes dot product.
+   *
+   * @param [in] x1 device array of vectors,
+   *  size [n1*n_cols]
+   * @param [in] n1 number vectors in x1
+   * @param [in] n_cols number of features in x1 and x2
+   * @param [in] x2 device array of vectors,
+   *   size [n2*n_cols]
+   * @param [in] n2 number vectors in x2
+   * @param [out] out device buffer to store the Gram matrix, size [n1*n2]
+   * @param [in] is_row_major whether the input and output matrices are in row
+   *        major format
+   * @param [in] stream cuda stream
+   * @param ld1 leading dimension of x1 (usually it is n1)
+   * @param ld2 leading dimension of x2 (usually it is n2)
+   * @param ld_out leading dimension of out (usually it is n1)
+   */
+  void evaluate(const math_t* x1,
+                int n1,
+                int n_cols,
+                const math_t* x2,
+                int n2,
+                math_t* out,
+                bool is_row_major,
+                cudaStream_t stream,
+                int ld1,
+                int ld2,
+                int ld_out)
+  {
+    GramMatrixBase<math_t>::linear(
+      x1, n1, n_cols, x2, n2, out, is_row_major, stream, ld1, ld2, ld_out);
+    applyKernel(out, ld_out, n1, n2, is_row_major, stream);
+  }
+};
+
+/**
+ * Create a kernel matrix using RBF kernel function.
+ */
+template <typename math_t>
+class RBFKernel : public GramMatrixBase<math_t> {
+  math_t gain;
+
+  void applyKernel(
+    math_t* inout, int ld, int rows, int cols, bool is_row_major, cudaStream_t stream)
+  {
+    const int n_minor = is_row_major ? cols : rows;
+    if (ld == n_minor) {
+      rbf_kernel_nopad<<<raft::ceildiv<size_t>((size_t)rows * cols, 128), 128, 0, stream>>>(
+        inout, rows * cols, gain);
+    } else {
+      int n1 = is_row_major ? cols : rows;
+      int n2 = is_row_major ? rows : cols;
+      rbf_kernel<<<dim3(raft::ceildiv(n1, 32), raft::ceildiv(n2, 4), 1),
+                   dim3(32, 4, 1),
+                   0,
+                   stream>>>(inout, ld, n1, n2, gain);
+    }
+  }
+
+ public:
+  /**
+   * Constructs a RBF kernel object.
+   * It evaluates the kernel matrix using the following formula:
+   * K_ij = exp(-gain*|x1_i- x2_k|^2)
+   *
+   * @tparam math_t floating point type
+   * @param gain
+   */
+  RBFKernel(math_t gain) : GramMatrixBase<math_t>(NULL), gain(gain) {}
+
+  /** Evaluate kernel matrix using RBF kernel.
+   *
+   * output_[i + k*n1] = exp(-gain*|x1_i - x2_k|^2),
+   * where x1_i is the i-th vector from the x1 set, and x2_k is k-th vector
+   * in the x2 set, and | | euclidean distance.
+   *
+   * @param [in] x1 device array of vectors, size [n1*n_cols]
+   * @param [in] n1 number vectors in x1
+   * @param [in] n_cols number of features in x1 and x2
+   * @param [in] x2 device array of vectors, size [n2*n_cols]
+   * @param [in] n2 number vectors in x2
+   * @param [out] out device buffer to store the Gram matrix, size [n1*n2]
+   * @param [in] is_row_major whether the input and output matrices are in row
+   *        major format
+   * @param [in] stream cuda stream
+   * @param ld1 leading dimension of x1, currently only ld1 == n1 is supported
+   * @param ld2 leading dimension of x2, currently only ld2 == n2 is supported
+   * @param ld_out leading dimension of out, only ld_out == n1 is supported
+   */
+  void evaluate(const math_t* x1,
+                int n1,
+                int n_cols,
+                const math_t* x2,
+                int n2,
+                math_t* out,
+                bool is_row_major,
+                cudaStream_t stream,
+                int ld1,
+                int ld2,
+                int ld_out)
+  {
+    int minor1    = is_row_major ? n_cols : n1;
+    int minor2    = is_row_major ? n_cols : n2;
+    int minor_out = is_row_major ? n2 : n1;
+    ASSERT(ld1 == minor1, "RBF Kernel distance does not support ld1 parameter");
+    ASSERT(ld2 == minor2, "RBF Kernel distance does not support ld2 parameter");
+    ASSERT(ld_out == minor_out, "RBF Kernel distance does not support ld_out parameter");
+    distance(x1, n1, n_cols, x2, n2, out, is_row_major, stream, ld1, ld2, ld_out);
+  }
+
+  /** Customize distance function withe RBF epilogue */
+  void distance(const math_t* x1,
+                int n1,
+                int n_cols,
+                const math_t* x2,
+                int n2,
+                math_t* out,
+                bool is_row_major,
+                cudaStream_t stream,
+                int ld1,
+                int ld2,
+                int ld_out)
+  {
+    math_t gain   = this->gain;
+    using index_t = int64_t;
+
+    auto fin_op = [gain] __device__(math_t d_val, index_t idx) { return exp(-gain * d_val); };
+    raft::distance::distance<raft::distance::DistanceType::L2Unexpanded,
+                             math_t,
+                             math_t,
+                             math_t,
+                             decltype(fin_op),
+                             index_t>(const_cast<math_t*>(x1),
+                                      const_cast<math_t*>(x2),
+                                      out,
+                                      n1,
+                                      n2,
+                                      n_cols,
+                                      NULL,
+                                      0,
+                                      fin_op,
+                                      stream,
+                                      is_row_major);
+  }
+};
+
+};  // end namespace raft::distance::kernels::detail

--- a/cpp/include/raft/distance/distance_types.hpp
+++ b/cpp/include/raft/distance/distance_types.hpp
@@ -65,5 +65,26 @@ enum DistanceType : unsigned short {
   /** Precomputed (special value) **/
   Precomputed = 100
 };
+
+namespace kernels {
+enum KernelType { LINEAR, POLYNOMIAL, RBF, TANH };
+
+/**
+ * Parameters for kernel matrices.
+ * The following kernels are implemented:
+ * - LINEAR \f[ K(x_1,x_2) = <x_1,x_2>, \f] where \f$< , >\f$ is the dot product
+ * - POLYNOMIAL \f[ K(x_1, x_2) = (\gamma <x_1,x_2> + \mathrm{coef0})^\mathrm{degree} \f]
+ * - RBF \f[ K(x_1, x_2) = \exp(- \gamma |x_1-x_2|^2) \f]
+ * - TANH \f[ K(x_1, x_2) = \tanh(\gamma <x_1,x_2> + \mathrm{coef0}) \f]
+ */
+struct KernelParams {
+  // Kernel function parameters
+  KernelType kernel;  //!< Type of the kernel function
+  int degree;         //!< Degree of polynomial kernel (ignored by others)
+  double gamma;       //!< multiplier in the
+  double coef0;       //!< additive constant in poly and tanh kernels
+};
+}  // end namespace kernels
+
 };  // namespace distance
 };  // end namespace raft

--- a/cpp/include/raft/distance/kernels.cuh
+++ b/cpp/include/raft/distance/kernels.cuh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/distance/detail/kernels/gram_matrix.cuh>
+#include <raft/distance/detail/kernels/kernel_factory.cuh>
+#include <raft/util/cuda_utils.cuh>
+
+#include <raft/distance/distance.cuh>
+#include <raft/linalg/gemm.cuh>
+
+namespace raft::distance::kernels {
+
+// TODO: Need to expose formal APIs for this that are more consistent w/ other APIs in RAFT
+using raft::distance::kernels::detail::GramMatrixBase;
+using raft::distance::kernels::detail::KernelFactory;
+
+};  // end namespace raft::distance::kernels

--- a/cpp/include/raft/distance/specializations/detail/kernels.cuh
+++ b/cpp/include/raft/distance/specializations/detail/kernels.cuh
@@ -26,5 +26,6 @@ extern template class raft::distance::kernels::detail::PolynomialKernel<float, i
 extern template class raft::distance::kernels::detail::TanhKernel<double>;
 extern template class raft::distance::kernels::detail::TanhKernel<float>;
 
-extern template class raft::distance::kernels::detail::RBFKernel<double>;
-extern template class raft::distance::kernels::detail::RBFKernel<float>;
+// These are somehow missing a kernel definition which is causing a compile error
+//extern template class raft::distance::kernels::detail::RBFKernel<double>;
+//extern template class raft::distance::kernels::detail::RBFKernel<float>;

--- a/cpp/include/raft/distance/specializations/detail/kernels.cuh
+++ b/cpp/include/raft/distance/specializations/detail/kernels.cuh
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/distance/detail/kernels/gram_matrix.cuh>
+#include <raft/distance/detail/kernels/kernel_matrices.cuh>
+
+extern template class raft::distance::kernels::detail::GramMatrixBase<double>;
+extern template class raft::distance::kernels::detail::GramMatrixBase<float>;
+
+extern template class raft::distance::kernels::detail::PolynomialKernel<double, int>;
+extern template class raft::distance::kernels::detail::PolynomialKernel<float, int>;
+
+extern template class raft::distance::kernels::detail::TanhKernel<double>;
+extern template class raft::distance::kernels::detail::TanhKernel<float>;
+
+extern template class raft::distance::kernels::detail::RBFKernel<double>;
+extern template class raft::distance::kernels::detail::RBFKernel<float>;

--- a/cpp/include/raft/distance/specializations/detail/kernels.cuh
+++ b/cpp/include/raft/distance/specializations/detail/kernels.cuh
@@ -27,5 +27,5 @@ extern template class raft::distance::kernels::detail::TanhKernel<double>;
 extern template class raft::distance::kernels::detail::TanhKernel<float>;
 
 // These are somehow missing a kernel definition which is causing a compile error
-//extern template class raft::distance::kernels::detail::RBFKernel<double>;
-//extern template class raft::distance::kernels::detail::RBFKernel<float>;
+// extern template class raft::distance::kernels::detail::RBFKernel<double>;
+// extern template class raft::distance::kernels::detail::RBFKernel<float>;

--- a/cpp/include/raft/distance/specializations/distance.cuh
+++ b/cpp/include/raft/distance/specializations/distance.cuh
@@ -23,6 +23,7 @@
 #include <raft/distance/specializations/detail/hamming_unexpanded.cuh>
 #include <raft/distance/specializations/detail/hellinger_expanded.cuh>
 #include <raft/distance/specializations/detail/jensen_shannon.cuh>
+#include <raft/distance/specializations/detail/kernels.cuh>
 #include <raft/distance/specializations/detail/kl_divergence.cuh>
 #include <raft/distance/specializations/detail/l1.cuh>
 #include <raft/distance/specializations/detail/l2_expanded.cuh>

--- a/cpp/include/raft/linalg/init.cuh
+++ b/cpp/include/raft/linalg/init.cuh
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include <raft/util/cudart_utils.hpp>
 #include "detail/init.hpp"
+#include <raft/util/cudart_utils.hpp>
 
 namespace raft {
 namespace linalg {

--- a/cpp/include/raft/linalg/init.cuh
+++ b/cpp/include/raft/linalg/init.cuh
@@ -54,6 +54,19 @@ void range(T* out, int n, cudaStream_t stream)
   detail::range(out, n, stream);
 }
 
+/**
+ * @brief Zeros the output.
+ *
+ * \param [out] out device array, size [n]
+ * \param [in] n length of the array
+ * \param [in] stream cuda stream
+ */
+template <typename T>
+void zero(T* out, int n, cudaStream_t stream)
+{
+  RAFT_CUDA_TRY(cudaMemsetAsync(static_cast<void*>(out), 0, n * sizeof(T), stream));
+}
+
 }  // namespace linalg
 }  // namespace raft
 

--- a/cpp/include/raft/linalg/init.cuh
+++ b/cpp/include/raft/linalg/init.cuh
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <raft/util/cudart_utils.hpp>
 #include "detail/init.hpp"
 
 namespace raft {

--- a/cpp/include/raft/solver/coordinate_descent.cuh
+++ b/cpp/include/raft/solver/coordinate_descent.cuh
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/solver/detail/cd.cuh>
+
+namespace raft::solver::coordinate_descent {
+
+}

--- a/cpp/include/raft/solver/detail/cd.cuh
+++ b/cpp/include/raft/solver/detail/cd.cuh
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "shuffle.h"
+#include <cuml/solvers/params.hpp>
+#include <functions/linearReg.cuh>
+#include <functions/penalty.cuh>
+#include <functions/softThres.cuh>
+#include <glm/preprocess.cuh>
+#include <raft/core/cudart_utils.hpp>
+#include <raft/core/nvtx.hpp>
+#include <raft/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/axpy.cuh>
+#include <raft/linalg/eltwise.cuh>
+#include <raft/linalg/gemm.cuh>
+#include <raft/linalg/gemv.cuh>
+#include <raft/linalg/map.cuh>
+#include <raft/linalg/multiply.cuh>
+#include <raft/linalg/power.cuh>
+#include <raft/linalg/sqrt.cuh>
+#include <raft/linalg/subtract.cuh>
+#include <raft/linalg/unary_op.cuh>
+#include <raft/matrix/math.cuh>
+#include <raft/matrix/matrix.cuh>
+#include <raft/stats/sum.cuh>
+
+namespace raft::solver::detail {
+
+namespace {
+
+/** Epoch and iteration -related state. */
+template <typename math_t>
+struct ConvState {
+  math_t coef;
+  math_t coefMax;
+  math_t diffMax;
+};
+
+/**
+ * Update a single CD coefficient and the corresponding convergence criteria.
+ *
+ * @param[inout] coefLoc pointer to the coefficient (arr ptr + column index offset)
+ * @param[in] squaredLoc pointer to the precomputed data - L2 norm of input for across rows
+ * @param[inout] convStateLoc pointer to the structure holding the convergence state
+ * @param[in] l1_alpha L1 regularization coef
+ */
+template <typename math_t>
+__global__ void __launch_bounds__(1, 1) cdUpdateCoefKernel(math_t* coefLoc,
+                                                           const math_t* squaredLoc,
+                                                           ConvState<math_t>* convStateLoc,
+                                                           const math_t l1_alpha)
+{
+  auto coef    = *coefLoc;
+  auto r       = coef > l1_alpha ? coef - l1_alpha : (coef < -l1_alpha ? coef + l1_alpha : 0);
+  auto squared = *squaredLoc;
+  r            = squared > math_t(1e-5) ? r / squared : math_t(0);
+  auto diff    = raft::myAbs(convStateLoc->coef - r);
+  if (convStateLoc->diffMax < diff) convStateLoc->diffMax = diff;
+  auto absv = raft::myAbs(r);
+  if (convStateLoc->coefMax < absv) convStateLoc->coefMax = absv;
+  convStateLoc->coef = -r;
+  *coefLoc           = r;
+}
+
+}  // namespace
+
+/**
+ * Fits a linear, lasso, and elastic-net regression model using Coordinate Descent solver.
+ *
+ * i.e. finds coefficients that minimize the following loss function:
+ *
+ * f(coef) = 1/2 * || labels - input * coef ||^2
+ *         + 1/2 * alpha * (1 - l1_ratio) * ||coef||^2
+ *         +       alpha *    l1_ratio    * ||coef||_1
+ *
+ *
+ * @param handle
+ *        Reference of raft::handle_t
+ * @param input
+ *        pointer to an array in column-major format (size of n_rows, n_cols)
+ * @param n_rows
+ *        n_samples or rows in input
+ * @param n_cols
+ *        n_features or columns in X
+ * @param labels
+ *        pointer to an array for labels (size of n_rows)
+ * @param coef
+ *        pointer to an array for coefficients (size of n_cols). This will be filled with
+ * coefficients once the function is executed.
+ * @param intercept
+ *        pointer to a scalar for intercept. This will be filled
+ *        once the function is executed
+ * @param fit_intercept
+ *        boolean parameter to control if the intercept will be fitted or not
+ * @param normalize
+ *        boolean parameter to control if the data will be normalized or not;
+ *        NB: the input is scaled by the column-wise biased sample standard deviation estimator.
+ * @param epochs
+ *        Maximum number of iterations that solver will run
+ * @param loss
+ *        enum to use different loss functions. Only linear regression loss functions is supported
+ * right now
+ * @param alpha
+ *        L1 parameter
+ * @param l1_ratio
+ *        ratio of alpha will be used for L1. (1 - l1_ratio) * alpha will be used for L2
+ * @param shuffle
+ *        boolean parameter to control whether coordinates will be picked randomly or not
+ * @param tol
+ *        tolerance to stop the solver
+ * @param sample_weight
+ *        device pointer to sample weight vector of length n_rows (nullptr or uniform weights)
+ *        This vector is modified during the computation
+ */
+template <typename math_t>
+void cdFit(const raft::handle_t& handle,
+           math_t* input,
+           int n_rows,
+           int n_cols,
+           math_t* labels,
+           math_t* coef,
+           math_t* intercept,
+           bool fit_intercept,
+           bool normalize,
+           int epochs,
+           ML::loss_funct loss,
+           math_t alpha,
+           math_t l1_ratio,
+           bool shuffle,
+           math_t tol,
+           math_t* sample_weight = nullptr)
+{
+  raft::common::nvtx::range fun_scope("ML::Solver::cdFit-%d-%d", n_rows, n_cols);
+  ASSERT(n_cols > 0, "Parameter n_cols: number of columns cannot be less than one");
+  ASSERT(n_rows > 1, "Parameter n_rows: number of rows cannot be less than two");
+  ASSERT(loss == ML::loss_funct::SQRD_LOSS,
+         "Parameter loss: Only SQRT_LOSS function is supported for now");
+
+  cudaStream_t stream = handle.get_stream();
+  rmm::device_uvector<math_t> residual(n_rows, stream);
+  rmm::device_uvector<math_t> squared(n_cols, stream);
+  rmm::device_uvector<math_t> mu_input(0, stream);
+  rmm::device_uvector<math_t> mu_labels(0, stream);
+  rmm::device_uvector<math_t> norm2_input(0, stream);
+  math_t h_sum_sw = 0;
+
+  if (sample_weight != nullptr) {
+    rmm::device_scalar<math_t> sum_sw(stream);
+    raft::stats::sum(sum_sw.data(), sample_weight, 1, n_rows, true, stream);
+    raft::update_host(&h_sum_sw, sum_sw.data(), 1, stream);
+
+    raft::linalg::multiplyScalar(
+      sample_weight, sample_weight, (math_t)n_rows / h_sum_sw, n_rows, stream);
+  }
+
+  if (fit_intercept) {
+    mu_input.resize(n_cols, stream);
+    mu_labels.resize(1, stream);
+    if (normalize) { norm2_input.resize(n_cols, stream); }
+
+    GLM::preProcessData(handle,
+                        input,
+                        n_rows,
+                        n_cols,
+                        labels,
+                        intercept,
+                        mu_input.data(),
+                        mu_labels.data(),
+                        norm2_input.data(),
+                        fit_intercept,
+                        normalize,
+                        sample_weight);
+  }
+  if (sample_weight != nullptr) {
+    raft::linalg::sqrt(sample_weight, sample_weight, n_rows, stream);
+    raft::matrix::matrixVectorBinaryMult(
+      input, sample_weight, n_rows, n_cols, false, false, stream);
+    raft::linalg::map_k(
+      labels,
+      n_rows,
+      [] __device__(math_t a, math_t b) { return a * b; },
+      stream,
+      labels,
+      sample_weight);
+  }
+
+  std::vector<int> ri(n_cols);
+  std::mt19937 g(rand());
+  initShuffle(ri, g);
+
+  math_t l2_alpha = (1 - l1_ratio) * alpha * n_rows;
+  math_t l1_alpha = l1_ratio * alpha * n_rows;
+
+  // Precompute the residual
+  if (normalize) {
+    // if we normalized the data, we know sample variance for each column is 1,
+    // thus no need to compute the norm again.
+    math_t scalar = math_t(n_rows) + l2_alpha;
+    raft::matrix::setValue(squared.data(), squared.data(), scalar, n_cols, stream);
+  } else {
+    raft::linalg::colNorm(
+      squared.data(), input, n_cols, n_rows, raft::linalg::L2Norm, false, stream);
+    raft::linalg::addScalar(squared.data(), squared.data(), l2_alpha, n_cols, stream);
+  }
+
+  raft::copy(residual.data(), labels, n_rows, stream);
+
+  ConvState<math_t> h_convState;
+  rmm::device_uvector<ConvState<math_t>> convStateBuf(1, stream);
+  auto convStateLoc = convStateBuf.data();
+
+  rmm::device_scalar<math_t> cublas_alpha(1.0, stream);
+  rmm::device_scalar<math_t> cublas_beta(0.0, stream);
+
+  for (int i = 0; i < epochs; i++) {
+    raft::common::nvtx::range epoch_scope("ML::Solver::cdFit::epoch-%d", i);
+    if (i > 0 && shuffle) { Solver::shuffle(ri, g); }
+
+    RAFT_CUDA_TRY(cudaMemsetAsync(convStateLoc, 0, sizeof(ConvState<math_t>), stream));
+
+    for (int j = 0; j < n_cols; j++) {
+      raft::common::nvtx::range iter_scope("ML::Solver::cdFit::col-%d", j);
+      int ci                = ri[j];
+      math_t* coef_loc      = coef + ci;
+      math_t* squared_loc   = squared.data() + ci;
+      math_t* input_col_loc = input + (ci * n_rows);
+
+      // remember current coef
+      raft::copy(&(convStateLoc->coef), coef_loc, 1, stream);
+      // calculate the residual without the contribution from column ci
+      // residual[:] += coef[ci] * X[:, ci]
+      raft::linalg::axpy<math_t, true>(
+        handle, n_rows, coef_loc, input_col_loc, 1, residual.data(), 1, stream);
+
+      // coef[ci] = dot(X[:, ci], residual[:])
+      raft::linalg::gemv<math_t, true>(handle,
+                                       false,
+                                       1,
+                                       n_rows,
+                                       cublas_alpha.data(),
+                                       input_col_loc,
+                                       1,
+                                       residual.data(),
+                                       1,
+                                       cublas_beta.data(),
+                                       coef_loc,
+                                       1,
+                                       stream);
+
+      // Calculate the new coefficient that minimizes f along coordinate line ci
+      // coef[ci] = SoftTreshold(dot(X[:, ci], residual[:]), l1_alpha) /  dot(X[:, ci], X[:, ci]))
+      // Also, update the convergence criteria.
+      cdUpdateCoefKernel<math_t><<<dim3(1, 1, 1), dim3(1, 1, 1), 0, stream>>>(
+        coef_loc, squared_loc, convStateLoc, l1_alpha);
+      RAFT_CUDA_TRY(cudaGetLastError());
+
+      // Restore the residual using the updated coeffecient
+      raft::linalg::axpy<math_t, true>(
+        handle, n_rows, &(convStateLoc->coef), input_col_loc, 1, residual.data(), 1, stream);
+    }
+    raft::update_host(&h_convState, convStateLoc, 1, stream);
+    handle.sync_stream(stream);
+
+    if (h_convState.coefMax < tol || (h_convState.diffMax / h_convState.coefMax) < tol) break;
+  }
+
+  if (sample_weight != nullptr) {
+    raft::matrix::matrixVectorBinaryDivSkipZero(
+      input, sample_weight, n_rows, n_cols, false, false, stream);
+    raft::linalg::map_k(
+      labels,
+      n_rows,
+      [] __device__(math_t a, math_t b) { return a / b; },
+      stream,
+      labels,
+      sample_weight);
+    raft::linalg::powerScalar(sample_weight, sample_weight, (math_t)2, n_rows, stream);
+    raft::linalg::multiplyScalar(sample_weight, sample_weight, h_sum_sw / n_rows, n_rows, stream);
+  }
+
+  if (fit_intercept) {
+    GLM::postProcessData(handle,
+                         input,
+                         n_rows,
+                         n_cols,
+                         labels,
+                         coef,
+                         intercept,
+                         mu_input.data(),
+                         mu_labels.data(),
+                         norm2_input.data(),
+                         fit_intercept,
+                         normalize);
+
+  } else {
+    *intercept = math_t(0);
+  }
+}
+
+/**
+ * Fits a linear, lasso, and elastic-net regression model using Coordinate Descent solver
+ * @param handle
+ *        cuml handle
+ * @param input
+ *        pointer to an array in column-major format (size of n_rows, n_cols)
+ * @param n_rows
+ *        n_samples or rows in input
+ * @param n_cols
+ *        n_features or columns in X
+ * @param coef
+ *        pointer to an array for coefficients (size of n_cols). Calculated in cdFit function.
+ * @param intercept
+ *        intercept value calculated in cdFit function
+ * @param preds
+ *        pointer to an array for predictions (size of n_rows). This will be fitted once functions
+ * is executed.
+ * @param loss
+ *        enum to use different loss functions. Only linear regression loss functions is supported
+ * right now.
+ */
+template <typename math_t>
+void cdPredict(const raft::handle_t& handle,
+               const math_t* input,
+               int n_rows,
+               int n_cols,
+               const math_t* coef,
+               math_t intercept,
+               math_t* preds,
+               ML::loss_funct loss)
+{
+  ASSERT(n_cols > 0, "Parameter n_cols: number of columns cannot be less than one");
+  ASSERT(n_rows > 1, "Parameter n_rows: number of rows cannot be less than two");
+  ASSERT(loss == ML::loss_funct::SQRD_LOSS,
+         "Parameter loss: Only SQRT_LOSS function is supported for now");
+
+  Functions::linearRegH(handle, input, n_rows, n_cols, coef, preds, intercept, handle.get_stream());
+}
+
+};  // namespace raft::solver::detail

--- a/cpp/include/raft/solver/detail/lars.cuh
+++ b/cpp/include/raft/solver/detail/lars.cuh
@@ -1,0 +1,1142 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <limits>
+#include <numeric>
+#include <vector>
+
+#include <raft/solver/solver_types.hpp>
+
+#include <cub/cub.cuh>
+#include <raft/core/logger.hpp>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/cholesky_r1_update.cuh>
+#include <raft/util/cache_util.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+#include <raft/linalg/detail/cublas_wrappers.hpp>
+#include <raft/linalg/gemv.cuh>
+#include <raft/linalg/map_then_reduce.cuh>
+#include <raft/linalg/unary_op.cuh>
+#include <rmm/device_scalar.hpp>
+#include <rmm/device_uvector.hpp>
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+#include <thrust/execution_policy.h>
+#include <thrust/extrema.h>
+#include <thrust/fill.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+namespace raft::solver::detail {
+
+
+/**
+ * @brief Select the largest element from the inactive working set.
+ *
+ * The inactive set consist of cor[n_active..n-1]. This function returns the
+ * index of the most correlated element. The value of the largest element is
+ * returned in cj.
+ *
+ * The correlation value is checked for numeric error and convergence, and the
+ * return status indicates whether training should continue.
+ *
+ * @param n_active number of active elements (n_active <= n )
+ * @param n number of elements in vector cor
+ * @param correlation device array of correlations, size [n]
+ * @param cj host pointer to return the value of the largest element
+ * @param wokspace buffer, size >= n_cols
+ * @param max_idx host pointer the index of the max correlation is returned here
+ * @param indices host pointer of feature column indices, size [n_cols]
+ * @param n_iter iteration counter
+ * @param stream CUDA stream
+ *
+ * @return fit status
+ */
+template <typename math_t, typename idx_t = int>
+LarsFitStatus selectMostCorrelated(idx_t n_active,
+                                   idx_t n,
+                                   math_t* correlation,
+                                   math_t* cj,
+                                   rmm::device_uvector<math_t>& workspace,
+                                   idx_t* max_idx,
+                                   idx_t n_rows,
+                                   idx_t* indices,
+                                   idx_t n_iter,
+                                   cudaStream_t stream)
+{
+  const idx_t align_bytes = 16 * sizeof(math_t);
+  // We might need to start a few elements earlier to ensure that the unary
+  // op has aligned access for vectorized load.
+  int start = raft::alignDown<idx_t>(n_active, align_bytes) / sizeof(math_t);
+  raft::linalg::unaryOp(
+    workspace.data(), correlation + start, n, [] __device__(math_t a) { return abs(a); }, stream);
+  thrust::device_ptr<math_t> ptr(workspace.data() + n_active - start);
+  auto max_ptr = thrust::max_element(thrust::cuda::par.on(stream), ptr, ptr + n - n_active);
+  raft::update_host(cj, max_ptr.get(), 1, stream);
+  raft::interruptible::synchronize(stream);
+
+  *max_idx = n_active + (max_ptr - ptr);  // the index of the maximum element
+
+  RAFT_LOG_DEBUG(
+    "Iteration %d, selected feature %d with correlation %f", n_iter, indices[*max_idx], *cj);
+
+  if (!std::isfinite(*cj)) {
+    RAFT_LOG_ERROR("Correlation is not finite, aborting.");
+    return LarsFitStatus::kError;
+  }
+
+  // Tolerance for early stopping. Note we intentionally use here fp32 epsilon,
+  // otherwise the tolerance is too small (which could result in numeric error
+  // in Cholesky rank one update if eps < 0, or exploding regression parameters
+  // if eps > 0).
+  const math_t tolerance = std::numeric_limits<float>::epsilon();
+  if (abs(*cj) / n_rows < tolerance) {
+    RAFT_LOG_WARN("Reached tolarence limit with %e", abs(*cj));
+    return LarsFitStatus::kStop;
+  }
+  return LarsFitStatus::kOk;
+}
+
+/**
+ * @brief Swap two feature vectors.
+ *
+ * The function swaps feature column j and k or the corresponding rows and
+ * and columns of the Gram matrix. The elements of the cor and indices arrays
+ * are also swapped.
+ *
+ * @param handle cuBLAS handle
+ * @param j column index
+ * @param k column index
+ * @param X device array of feature vectors in column major format, size
+ *     [n_cols * ld_X]
+ * @param n_rows number of training vectors
+ * @param n_cols number of features
+ * @param ld_X leading dimension of X
+ * @param cor device array of correlations, size [n_cols]
+ * @param indices host array of indices, size [n_cols]
+ * @param G device pointer of Gram matrix (or nullptr), size [n_cols * ld_G]
+ * @param ld_G leading dimension of G
+ * @param stream CUDA stream
+ */
+template <typename math_t, typename idx_t = int>
+void swapFeatures(cublasHandle_t handle,
+                  idx_t j,
+                  idx_t k,
+                  math_t* X,
+                  idx_t n_rows,
+                  idx_t n_cols,
+                  idx_t ld_X,
+                  math_t* cor,
+                  idx_t* indices,
+                  math_t* G,
+                  idx_t ld_G,
+                  cudaStream_t stream)
+{
+  std::swap(indices[j], indices[k]);
+  if (G) {
+    // #TODO: Call from public API when ready
+    RAFT_CUBLAS_TRY(
+      raft::linalg::detail::cublasSwap(handle, n_cols, G + ld_G * j, 1, G + ld_G * k, 1, stream));
+    // #TODO: Call from public API when ready
+    RAFT_CUBLAS_TRY(
+      raft::linalg::detail::cublasSwap(handle, n_cols, G + j, ld_G, G + k, ld_G, stream));
+  } else {
+    // Only swap X if G is nullptr. Only in that case will we use the feature
+    // columns, otherwise all the necessary information is already there in G.
+    // #TODO: Call from public API when ready
+    RAFT_CUBLAS_TRY(
+      raft::linalg::detail::cublasSwap(handle, n_rows, X + ld_X * j, 1, X + ld_X * k, 1, stream));
+  }
+  // swap (c[j], c[k])
+  // #TODO: Call from public API when ready
+  RAFT_CUBLAS_TRY(raft::linalg::detail::cublasSwap(handle, 1, cor + j, 1, cor + k, 1, stream));
+}
+
+/**
+ * @brief Move feature at idx=j into the active set.
+ *
+ * We have an active set with n_active elements, and an inactive set with
+ * n_valid_cols - n_active elements. The matrix X [n_samples, n_features] is
+ * partitioned in a way that the first n_active columns store the active set.
+ * Similarily the vectors correlation and indices are partitioned in a way
+ * that the first n_active elements belong to the active set:
+ * - active set:  X[:,:n_active], correlation[:n_active], indices[:n_active]
+ * - inactive set: X[:,n_active:], correlation[n_active:], indices[n_active:].
+ *
+ * This function moves the feature column X[:,idx] into the active set by
+ * replacing the first inactive element with idx. The indices and correlation
+ * vectors are modified accordinly. The sign array is updated with the sign
+ * of correlation[n_active].
+ *
+ * @param handle cuBLAS handle
+ * @param n_active number of active elements, will be increased by one after
+ *     we move the new element j into the active set
+ * @param j index of the new element (n_active <= j < n_cols)
+ * @param X device array of feature vectors in column major format, size
+ *     [n_cols * ld_X]
+ * @param n_rows number of training vectors
+ * @param n_cols number of valid features colums (ignoring those features which
+ *    are detected to be collinear with the active set)
+ * @param ld_X leading dimension of X
+ * @param cor device array of correlations, size [n_cols]
+ * @param indices host array of indices, size [n_cols]
+ * @param G device pointer of Gram matrix (or nullptr), size [n_cols * ld_G]
+ * @param ld_G leading dimension of G
+ * @param sign device pointer to sign array, size[n]
+ * @param stream CUDA stream
+ */
+template <typename math_t, typename idx_t = int>
+void moveToActive(cublasHandle_t handle,
+                  idx_t* n_active,
+                  idx_t j,
+                  math_t* X,
+                  idx_t n_rows,
+                  idx_t n_cols,
+                  idx_t ld_X,
+                  math_t* cor,
+                  idx_t* indices,
+                  math_t* G,
+                  idx_t ld_G,
+                  math_t* sign,
+                  cudaStream_t stream)
+{
+  idx_t idx_free = *n_active;
+  swapFeatures(handle, idx_free, j, X, n_rows, n_cols, ld_X, cor, indices, G, ld_G, stream);
+
+  // sign[n_active] = sign(c[n_active])
+  raft::linalg::unaryOp(
+    sign + idx_free,
+    cor + idx_free,
+    1,
+    [] __device__(math_t c) -> math_t {
+      // return the sign of c
+      return (math_t(0) < c) - (c < math_t(0));
+    },
+    stream);
+
+  (*n_active)++;
+}
+
+/**
+ * @brief Update the Cholesky decomposition of the Gram matrix of the active set
+ *
+ * G0 = X.T * X, Gram matrix without signs. We use the part that corresponds to
+ * the active set, [n_A x n_A]
+ *
+ * At each step on the LARS path we add one column to the active set, therefore
+ * the Gram matrix grows incrementally. We update the Cholesky decomposition
+ * G0 = U.T * U.
+ *
+ * The Cholesky decomposition can use the same storage as G0, if the input
+ * pointers are same.
+ *
+ * @param handle RAFT handle
+ * @param n_active number of active elements
+ * @param X device array  of feature vectors in column major format, size
+ *     [n_rows * n_cols]
+ * @param n_rows number of training vectors
+ * @param n_cols number of features
+ * @param ld_X leading dimension of X (stride of columns)
+ * @param U device pointer to the Cholesky decomposition of G0,
+ *     size [n_cols * ld_U]
+ * @param ld_U leading dimension of U
+ * @param G0 device pointer to Gram matrix G0 = X.T*X (can be nullptr),
+ *     size [n_cols * ld_G].
+ * @param ld_G leading dimension of G
+ * @param workspace workspace for the Cholesky update
+ * @param eps parameter for cheleskyRankOneUpdate
+ * @param stream CUDA stream
+ */
+template <typename math_t, typename idx_t = int>
+void updateCholesky(const raft::handle_t& handle,
+                    idx_t n_active,
+                    const math_t* X,
+                    idx_t n_rows,
+                    idx_t n_cols,
+                    idx_t ld_X,
+                    math_t* U,
+                    idx_t ld_U,
+                    const math_t* G0,
+                    idx_t ld_G,
+                    rmm::device_uvector<math_t>& workspace,
+                    math_t eps,
+                    cudaStream_t stream)
+{
+  const cublasFillMode_t fillmode = CUBLAS_FILL_MODE_UPPER;
+  if (G0 == nullptr) {
+    // Calculate the new column of G0. It is stored in U.
+    math_t* G_row       = U + (n_active - 1) * ld_U;
+    const math_t* X_row = X + (n_active - 1) * ld_X;
+    math_t one          = 1;
+    math_t zero         = 0;
+    // #TODO: Call from public API when ready
+    RAFT_CUBLAS_TRY(raft::linalg::detail::cublasgemv(handle.get_cublas_handle(),
+                                                     CUBLAS_OP_T,
+                                                     n_rows,
+                                                     n_cols,
+                                                     &one,
+                                                     X,
+                                                     n_rows,
+                                                     X_row,
+                                                     1,
+                                                     &zero,
+                                                     G_row,
+                                                     1,
+                                                     stream));
+  } else if (G0 != U) {
+    // Copy the new column of G0 into U, because the factorization works in
+    // place.
+    raft::copy(U + (n_active - 1) * ld_U, G0 + (n_active - 1) * ld_G, n_active, stream);
+  }  // Otherwise the new data is already in place in U.
+
+  // Update the Cholesky decomposition
+  int n_work = workspace.size();
+  if (n_work == 0) {
+    // Query workspace size and allocate it
+    raft::linalg::choleskyRank1Update(
+      handle, U, n_active, ld_U, nullptr, &n_work, fillmode, stream);
+    workspace.resize(n_work, stream);
+  }
+  raft::linalg::choleskyRank1Update(
+    handle, U, n_active, ld_U, workspace.data(), &n_work, fillmode, stream, eps);
+}
+
+/**
+ * @brief Solve for ws = S * GA^(-1) * 1_A  using a Cholesky decomposition.
+ *
+ * See calcEquiangularVec for more details on the formulas. In this function we
+ * calculate ws = S * (S * G0 * S)^{-1} 1_A = G0^{-1} (S 1_A) = G0^{-1} sign_A.
+ *
+ * @param handle RAFT handle
+ * @param n_active number of active elements
+ * @param n_cols number of features
+ * @param sign array with sign of the active set, size [n_cols]
+ * @param U device pointer to the Cholesky decomposition of G0,
+ *     size [n_cols * n_cols]
+ * @param ld_U leading dimension of U (column stride)
+ * @param ws device pointer, size [n_active]
+ * @param stream CUDA stream
+ */
+template <typename math_t, typename idx_t = int>
+void calcW0(const raft::handle_t& handle,
+            idx_t n_active,
+            idx_t n_cols,
+            const math_t* sign,
+            const math_t* U,
+            idx_t ld_U,
+            math_t* ws,
+            cudaStream_t stream)
+{
+  const cublasFillMode_t fillmode = CUBLAS_FILL_MODE_UPPER;
+
+  // First we calculate x by solving equation U.T x = sign_A.
+  raft::copy(ws, sign, n_active, stream);
+  math_t alpha = 1;
+  // #TODO: Call from public API when ready
+  RAFT_CUBLAS_TRY(raft::linalg::detail::cublastrsm(handle.get_cublas_handle(),
+                                                   CUBLAS_SIDE_LEFT,
+                                                   fillmode,
+                                                   CUBLAS_OP_T,
+                                                   CUBLAS_DIAG_NON_UNIT,
+                                                   n_active,
+                                                   1,
+                                                   &alpha,
+                                                   U,
+                                                   ld_U,
+                                                   ws,
+                                                   ld_U,
+                                                   stream));
+
+  // ws stores x, the solution of U.T x = sign_A. Now we solve U * ws = x
+  // #TODO: Call from public API when ready
+  RAFT_CUBLAS_TRY(raft::linalg::detail::cublastrsm(handle.get_cublas_handle(),
+                                                   CUBLAS_SIDE_LEFT,
+                                                   fillmode,
+                                                   CUBLAS_OP_N,
+                                                   CUBLAS_DIAG_NON_UNIT,
+                                                   n_active,
+                                                   1,
+                                                   &alpha,
+                                                   U,
+                                                   ld_U,
+                                                   ws,
+                                                   ld_U,
+                                                   stream));
+  // Now ws = G0^(-1) sign_A = S GA^{-1} 1_A.
+}
+
+/**
+ * @brief Calculate A = (1_A * GA^{-1} * 1_A)^{-1/2}.
+ *
+ * See calcEquiangularVec for more details on the formulas.
+ *
+ * @param handle RAFT handle
+ * @param A device pointer to store the result
+ * @param n_active number of active elements
+ * @param sign array with sign of the active set, size [n_cols]
+ * @param ws device pointer, size [n_active]
+ * @param stream CUDA stream
+ */
+template <typename math_t, typename idx_t = int>
+void calcA(const raft::handle_t& handle,
+           math_t* A,
+           idx_t n_active,
+           const math_t* sign,
+           const math_t* ws,
+           cudaStream_t stream)
+{
+  // Calculate sum (w) = sum(ws * sign)
+  auto multiply = [] __device__(math_t w, math_t s) { return w * s; };
+  raft::linalg::mapThenSumReduce(A, n_active, multiply, stream, ws, sign);
+  // Calc Aa = 1 / sqrt(sum(w))
+  raft::linalg::unaryOp(
+    A, A, 1, [] __device__(math_t a) { return 1 / sqrt(a); }, stream);
+}
+
+/**
+ * @brief Calculate the equiangular vector u, w and A according to [1].
+ *
+ * We introduce the following variables (Python like indexing):
+ * - n_A number of elements in the active set
+ * - S = diag(sign_A): diagonal matrix with the signs, size [n_A x n_A]
+ * - X_A = X[:,:n_A] * S, column vectors of the active set size [n_A x n_A]
+ * - G0 = X.T * X, Gram matrix without signs. We just use the part that
+ *   corresponds to the active set, [n_A x n_A]
+ * - GA = X_A.T * X_A is the Gram matrix of the active set, size [n_A x n_A]
+ *   GA = S * G0[:n_A, :n_A] * S
+ * - 1_A = np.ones(n_A)
+ * - A = (1_A * GA^{-1} * 1_A)^{-1/2}, scalar, see eq (2.5) in [1]
+ * - w = A GA^{-1} * 1_A, vector of size [n_A] see eq (2.6) in [1]
+ * - ws = S * w, vector of size [n_A]
+ *
+ * The equiangular vector can be expressed the following way (equation 2.6):
+ * u = X_A * w = X[:,:n_A] S * w = X[:,:n_A] * ws.
+ *
+ * The equiangular vector later appears only in an expression like X.T u, which
+ * can be reformulated as X.T u = X.T X[:,:n_A] S * w = G[:n_A,:n_A] * ws.
+ * If the gram matrix is given, then we do not need to calculate u, it will be
+ * sufficient to calculate ws and A.
+ *
+ * We use Cholesky decomposition G0 = U.T * U to solve to calculate A and w
+ * which depend on GA^{-1}.
+ *
+ * References:
+ *  [1] B. Efron, T. Hastie, I. Johnstone, R Tibshirani, Least Angle Regression
+ *  The Annals of Statistics (2004) Vol 32, No 2, 407-499
+ *  http://statweb.stanford.edu/~tibs/ftp/lars.pdf
+ *
+ * @param handle RAFT handle
+ * @param n_active number of active elements
+ * @param X device array  of feature vectors in column major format, size
+ *     [ld_X * n_cols]
+ * @param n_rows number of training vectors
+ * @param n_cols number of features
+ * @param ld_X leading dimension of array X (column stride, ld_X >= n_rows)
+ * @param sign array with sign of the active set, size [n_cols]
+ * @param U device pointer to the Cholesky decomposition of G0,
+ *     size [ld_U * n_cols]
+ * @param ld_U leading dimension of array U (ld_U >= n_cols)
+ * @param G0 device pointer to Gram matrix G0 = X.T*X (can be nullptr),
+ *     size [ld_G * n_cols]. Note the difference between G0 and
+ *     GA = X_A.T * X_A
+ * @param ld_G leading dimension of array G0 (ld_G >= n_cols)
+ * @param workspace workspace for the Cholesky update
+ * @param ws device pointer, size [n_active]
+ * @param A device pointer to a scalar
+ * @param u_eq device pointer to the equiangular vector, only used if
+ *    Gram==nullptr, size [n_rows].
+ * @param eps numerical regularizaton parameter for the Cholesky decomposition
+ * @param stream CUDA stream
+ *
+ * @return fit status
+ */
+template <typename math_t, typename idx_t = int>
+LarsFitStatus calcEquiangularVec(const raft::handle_t& handle,
+                                 idx_t n_active,
+                                 math_t* X,
+                                 idx_t n_rows,
+                                 idx_t n_cols,
+                                 idx_t ld_X,
+                                 math_t* sign,
+                                 math_t* U,
+                                 idx_t ld_U,
+                                 math_t* G0,
+                                 idx_t ld_G,
+                                 rmm::device_uvector<math_t>& workspace,
+                                 math_t* ws,
+                                 math_t* A,
+                                 math_t* u_eq,
+                                 math_t eps,
+                                 cudaStream_t stream)
+{
+  // Since we added a new vector to the active set, we update the Cholesky
+  // decomposition (U)
+  updateCholesky(
+    handle, n_active, X, n_rows, n_cols, ld_X, U, ld_U, G0, ld_G, workspace, eps, stream);
+
+  // Calculate ws = S GA^{-1} 1_A using U
+  calcW0(handle, n_active, n_cols, sign, U, ld_U, ws, stream);
+
+  calcA(handle, A, n_active, sign, ws, stream);
+
+  // ws *= Aa
+  raft::linalg::unaryOp(
+    ws, ws, n_active, [A] __device__(math_t w) { return (*A) * w; }, stream);
+
+  // Check for numeric error
+  math_t ws_host;
+  raft::update_host(&ws_host, ws, 1, stream);
+  math_t diag_host;  // U[n_active-1, n_active-1]
+  raft::update_host(&diag_host, U + ld_U * (n_active - 1) + n_active - 1, 1, stream);
+  handle.sync_stream(stream);
+  if (diag_host < 1e-7) {
+    RAFT_LOG_WARN(
+      "Vanising diagonal in Cholesky factorization (%e). This indicates "
+      "collinear features. Dropping current regressor.",
+      diag_host);
+    return LarsFitStatus::kCollinear;
+  }
+  if (!std::isfinite(ws_host)) {
+    RAFT_LOG_WARN("ws=%f is not finite at iteration %d", ws_host, n_active);
+    return LarsFitStatus::kError;
+  }
+
+  if (G0 == nullptr) {
+    // Calculate u_eq only in the case if the Gram matrix is not stored.
+    math_t one  = 1;
+    math_t zero = 0;
+    // #TODO: Call from public API when ready
+    RAFT_CUBLAS_TRY(raft::linalg::detail::cublasgemv(handle.get_cublas_handle(),
+                                                     CUBLAS_OP_N,
+                                                     n_rows,
+                                                     n_active,
+                                                     &one,
+                                                     X,
+                                                     ld_X,
+                                                     ws,
+                                                     1,
+                                                     &zero,
+                                                     u_eq,
+                                                     1,
+                                                     stream));
+  }
+  return LarsFitStatus::kOk;
+}
+
+/**
+ * @brief Calculate the maximum step size (gamma) in the equiangular direction.
+ *
+ * Let mu = X beta.T be the current prediction vector. The modified solution
+ * after taking step gamma is defined as mu' = mu + gamma u. With this
+ * solution the correlation of the covariates in the active set will decrease
+ * equally, to a new value |c_j(gamma)| = Cmax - gamma A. At the same time
+ * the correlation of the values in the inactive set changes according to the
+ * following formula: c_j(gamma) = c_j - gamma a_j. We increase gamma until
+ * one of correlations from the inactive set becomes equal with the
+ * correlation from the active set.
+ *
+ * References:
+ *  [1] B. Efron, T. Hastie, I. Johnstone, R Tibshirani, Least Angle Regression
+ *  The Annals of Statistics (2004) Vol 32, No 2, 407-499
+ *  http://statweb.stanford.edu/~tibs/ftp/lars.pdf
+ *
+ * @param handle RAFT handle
+ * @param max_iter maximum number of iterations
+ * @param n_rows number of samples
+ * @param n_cols number of valid feature columns
+ * @param n_active size of the active set (n_active <= max_iter <= n_cols)
+ * @param cj value of the maximum correlation
+ * @param A device pointer to a scalar, as defined by eq 2.5 in [1]
+ * @param cor device pointer to correlation vector, size [n_active]
+ * @param G device pointer to Gram matrix of the active set (without signs)
+ *    size [n_active * ld_G]
+ * @param ld_G leading dimension of G (ld_G >= n_cols)
+ * @param X device array of training vectors in column major format,
+ *     size [n_rows * n_cols]. Only used if the gram matrix is not avaiable.
+ * @param ld_X leading dimension of X (ld_X >= n_rows)
+ * @param u device pointer to equiangular vector size [n_rows]. Only used if the
+ *     Gram matrix G is not available.
+ * @param ws device pointer to the ws vector defined in calcEquiangularVec,
+ *    size [n_active]
+ * @param gamma device pointer to a scalar. The max step size is returned here.
+ * @param a_vec device pointer, size [n_cols]
+ * @param stream CUDA stream
+ */
+template <typename math_t, typename idx_t = int>
+void calcMaxStep(const raft::handle_t& handle,
+                 idx_t max_iter,
+                 idx_t n_rows,
+                 idx_t n_cols,
+                 idx_t n_active,
+                 math_t cj,
+                 const math_t* A,
+                 math_t* cor,
+                 const math_t* G,
+                 idx_t ld_G,
+                 const math_t* X,
+                 idx_t ld_X,
+                 const math_t* u,
+                 const math_t* ws,
+                 math_t* gamma,
+                 math_t* a_vec,
+                 cudaStream_t stream)
+{
+  // In the active set each element has the same correlation, whose absolute
+  // value is given by Cmax.
+  math_t Cmax = std::abs(cj);
+  if (n_active == n_cols) {
+    // Last iteration, the inactive set is empty we use equation (2.21)
+    raft::linalg::unaryOp(
+      gamma, A, 1, [Cmax] __device__(math_t A) { return Cmax / A; }, stream);
+  } else {
+    const int n_inactive = n_cols - n_active;
+    if (G == nullptr) {
+      // Calculate a = X.T[:,n_active:] * u                              (2.11)
+      math_t one  = 1;
+      math_t zero = 0;
+      // #TODO: Call from public API when ready
+      RAFT_CUBLAS_TRY(raft::linalg::detail::cublasgemv(handle.get_cublas_handle(),
+                                                       CUBLAS_OP_T,
+                                                       n_rows,
+                                                       n_inactive,
+                                                       &one,
+                                                       X + n_active * ld_X,
+                                                       ld_X,
+                                                       u,
+                                                       1,
+                                                       &zero,
+                                                       a_vec,
+                                                       1,
+                                                       stream));
+    } else {
+      // Calculate a = X.T[:,n_A:] * u = X.T[:, n_A:] * X[:,:n_A] * ws
+      //             = G[n_A:,:n_A] * ws                                 (2.11)
+      math_t one  = 1;
+      math_t zero = 0;
+      // #TODO: Call from public API when ready
+      RAFT_CUBLAS_TRY(raft::linalg::detail::cublasgemv(handle.get_cublas_handle(),
+                                                       CUBLAS_OP_N,
+                                                       n_inactive,
+                                                       n_active,
+                                                       &one,
+                                                       G + n_active,
+                                                       ld_G,
+                                                       ws,
+                                                       1,
+                                                       &zero,
+                                                       a_vec,
+                                                       1,
+                                                       stream));
+    }
+    const math_t tiny = std::numeric_limits<math_t>::min();
+    const math_t huge = std::numeric_limits<math_t>::max();
+    //
+    // gamma = min^+_{j \in inactive} {(Cmax - cor_j) / (A-a_j),
+    //                                 (Cmax + cor_j) / (A+a_j)}         (2.13)
+    auto map = [Cmax, A, tiny, huge] __device__(math_t c, math_t a) -> math_t {
+      math_t tmp1 = (Cmax - c) / (*A - a + tiny);
+      math_t tmp2 = (Cmax + c) / (*A + a + tiny);
+      // We consider only positive elements while we search for the minimum
+      math_t val = (tmp1 > 0) ? tmp1 : huge;
+      if (tmp2 > 0 && tmp2 < val) val = tmp2;
+      return val;
+    };
+    raft::linalg::mapThenReduce(
+      gamma, n_inactive, huge, map, cub::Min(), stream, cor + n_active, a_vec);
+  }
+}
+
+/**
+ * @brief Initialize for Lars training.
+ *
+ * We calculate the initial correlation, initialize the indices array, and set
+ * up pointers to store the Cholesky factorization.
+ *
+ * @param handle RAFT handle
+ * @param X device array of training vectors in column major format,
+ *     size [ld_X * n_cols].
+ * @param n_rows number of samples
+ * @param n_cols number of valid feature columns
+ * @param ld_X leading dimension of X (ld_X >= n_rows)
+ * @param y device pointer to regression targets, size [n_rows]
+ * @param Gram device pointer to Gram matrix (X.T * X), size [n_cols * ld_G],
+ *    can be nullptr
+ * @param ld_G leading dimension of G (ld_G >= n_cols)
+ * @param U_buffer device buffer that will be initialized to store the Cholesky
+ *    factorization. Only used if Gram is nullptr.
+ * @param U device pointer to U
+ * @param ld_U leading dimension of U
+ * @param indices host buffer to store feature column indices
+ * @param cor device pointer to correlation vector, size [n_cols]
+ * @param max_iter host pointer to the maximum number of iterations
+ * @param coef_path device pointer to store coefficients along the
+ *    regularization path size [(max_iter + 1) * max_iter], can be nullptr
+ * @param stream CUDA stream
+ */
+template <typename math_t, typename idx_t>
+void larsInit(const raft::handle_t& handle,
+              const math_t* X,
+              idx_t n_rows,
+              idx_t n_cols,
+              idx_t ld_X,
+              const math_t* y,
+              math_t* Gram,
+              idx_t ld_G,
+              rmm::device_uvector<math_t>& U_buffer,
+              math_t** U,
+              idx_t* ld_U,
+              std::vector<idx_t>& indices,
+              rmm::device_uvector<math_t>& cor,
+              int* max_iter,
+              math_t* coef_path,
+              cudaStream_t stream)
+{
+  if (n_cols < *max_iter) { *max_iter = n_cols; }
+  if (Gram == nullptr) {
+    const idx_t align_bytes = 256;
+    *ld_U                   = raft::alignTo<idx_t>(*max_iter, align_bytes);
+    try {
+      U_buffer.resize((*ld_U) * (*max_iter), stream);
+    } catch (std::bad_alloc const&) {
+      THROW(
+        "Not enough GPU memory! The memory usage depends quadraticaly on the "
+        "n_nonzero_coefs parameter, try to decrease it.");
+    }
+    *U = U_buffer.data();
+  } else {
+    // Set U as G. During the solution in larsFit, the Cholesky factorization
+    // U will overwrite G.
+    *U    = Gram;
+    *ld_U = ld_G;
+  }
+  std::iota(indices.data(), indices.data() + n_cols, 0);
+
+  math_t one  = 1;
+  math_t zero = 0;
+  // Set initial correlation to X.T * y
+  // #TODO: Call from public API when ready
+  RAFT_CUBLAS_TRY(raft::linalg::detail::cublasgemv(handle.get_cublas_handle(),
+                                                   CUBLAS_OP_T,
+                                                   n_rows,
+                                                   n_cols,
+                                                   &one,
+                                                   X,
+                                                   ld_X,
+                                                   y,
+                                                   1,
+                                                   &zero,
+                                                   cor.data(),
+                                                   1,
+                                                   stream));
+  if (coef_path) {
+    RAFT_CUDA_TRY(
+      cudaMemsetAsync(coef_path, 0, sizeof(math_t) * (*max_iter + 1) * (*max_iter), stream));
+  }
+}
+
+/**
+ * @brief Update regression coefficient and correlations
+ *
+ * After we calculated the equiangular vector and the step size (gamma) we
+ * adjust the regression coefficients here.
+ *
+ * See calcEquiangularVec for definition of ws.
+ *
+ * @param handle RAFT handle
+ * @param max_iter maximum number of iterations
+ * @param n_cols number of valid feature columns
+ * @param n_active number of elements in the active set (n_active <= n_cols)
+ * @param gamma device pointer to the maximum step size (scalar)
+ * @param ws device pointer to the ws vector, size [n_cols]
+ * @param cor device pointer to the correlations, size [n_cols]
+ * @param a_vec device pointer to a = X.T[:,n_A:] * u, size [n_cols]
+ * @param beta pointer to regression coefficents, size [max_iter]
+ * @param coef_path device pointer to all the coefficients along the
+ *    regularization path, size [(max_iter + 1) * max_iter]
+ * @param stream CUDA stream
+ */
+template <typename math_t, typename idx_t>
+void updateCoef(const raft::handle_t& handle,
+                idx_t max_iter,
+                idx_t n_cols,
+                idx_t n_active,
+                math_t* gamma,
+                const math_t* ws,
+                math_t* cor,
+                math_t* a_vec,
+                math_t* beta,
+                math_t* coef_path,
+                cudaStream_t stream)
+{
+  // It is sufficient to update correlations only for the inactive set.
+  // cor[n_active:] -= gamma * a_vec
+  int n_inactive = n_cols - n_active;
+  if (n_inactive > 0) {
+    raft::linalg::binaryOp(
+      cor + n_active,
+      cor + n_active,
+      a_vec,
+      n_inactive,
+      [gamma] __device__(math_t c, math_t a) { return c - *gamma * a; },
+      stream);
+  }
+  // beta[:n_active] += gamma * ws
+  raft::linalg::binaryOp(
+    beta,
+    beta,
+    ws,
+    n_active,
+    [gamma] __device__(math_t b, math_t w) { return b + *gamma * w; },
+    stream);
+  if (coef_path) { raft::copy(coef_path + n_active * max_iter, beta, n_active, stream); }
+}
+
+/**
+ * @brief Train a regressor using Least Angre Regression.
+ *
+ * Least Angle Regression (LAR or LARS) is a model selection algorithm. It
+ * builds up the model using the following algorithm:
+ *
+ * 1. We start with all the coefficients equal to zero.
+ * 2. At each step we select the predictor that has the largest absolute
+ *      correlation with the residual.
+ * 3. We take the largest step possible in the direction which is equiangular
+ *    with all the predictors selected so far. The largest step is determined
+ *    such that using this step a new predictor will have as much correlation
+ *    with the residual as any of the currently active predictors.
+ * 4. Stop if max_iter reached or all the predictors are used, or if the
+ *    correlation between any unused predictor and the residual is lower than
+ *    a tolerance.
+ *
+ * The solver is based on [1]. The equations referred in the comments correspond
+ * to the equations in the paper.
+ *
+ * Note: this algorithm assumes that the offset is removed from X and y, and
+ * each feature is normalized:
+ * - sum_i y_i = 0,
+ * - sum_i x_{i,j} = 0, sum_i x_{i,j}^2=1 for j=0..n_col-1
+ *
+ * References:
+ * [1] B. Efron, T. Hastie, I. Johnstone, R Tibshirani, Least Angle Regression
+ * The Annals of Statistics (2004) Vol 32, No 2, 407-499
+ * http://statweb.stanford.edu/~tibs/ftp/lars.pdf
+ *
+ * @param handle RAFT handle
+ * @param X device array of training vectors in column major format,
+ *     size [n_rows * n_cols]. Note that the columns of X will be permuted if
+ *     the Gram matrix is not specified. It is expected that X is normalized so
+ *     that each column has zero mean and unit variance.
+ * @param n_rows number of training samples
+ * @param n_cols number of feature columns
+ * @param y device array of the regression targets, size [n_rows]. y should
+ *     be normalized to have zero mean.
+ * @param beta device array of regression coefficients, has to be allocated on
+ *     entry, size [max_iter]
+ * @param active_idx device array containing the indices of active variables.
+ *     Must be allocated on entry. Size [max_iter]
+ * @param alphas device array to return the maximum correlation along the
+ *     regularization path. Must be allocated on entry, size [max_iter+1].
+ * @param n_active host pointer to return the number of active elements (scalar)
+ * @param Gram device array containing Gram matrix containing X.T * X. Can be
+ *     nullptr.
+ * @param max_iter maximum number of iterations, this equals with the maximum
+ *    number of coefficients returned. max_iter <= n_cols.
+ * @param coef_path coefficients along the regularization path are returned
+ *    here. Must be nullptr, or a device array already allocated on entry.
+ *    Size [max_iter * (max_iter+1)].
+ * @param verbosity verbosity level
+ * @param ld_X leading dimension of X (stride of columns)
+ * @param ld_G leading dimesion of G
+ * @param eps numeric parameter for Cholesky rank one update
+ */
+template <typename math_t, typename idx_t>
+void larsFit(const raft::handle_t& handle,
+             math_t* X,
+             idx_t n_rows,
+             idx_t n_cols,
+             const math_t* y,
+             math_t* beta,
+             idx_t* active_idx,
+             math_t* alphas,
+             idx_t* n_active,
+             math_t* Gram      = nullptr,
+             int max_iter      = 500,
+             math_t* coef_path = nullptr,
+             int verbosity     = 0,
+             idx_t ld_X        = 0,
+             idx_t ld_G        = 0,
+             math_t eps        = -1)
+{
+  ASSERT(n_cols > 0, "Parameter n_cols: number of columns cannot be less than one");
+  ASSERT(n_rows > 0, "Parameter n_rows: number of rows cannot be less than one");
+  ML::Logger::get().setLevel(verbosity);
+
+  // Set default ld parameters if needed.
+  if (ld_X == 0) ld_X = n_rows;
+  if (Gram && ld_G == 0) ld_G = n_cols;
+
+  cudaStream_t stream = handle.get_stream();
+
+  // We will use either U_buffer.data() to store the Cholesky factorization, or
+  // store it in place at Gram. Pointer U will point to the actual storage.
+  rmm::device_uvector<math_t> U_buffer(0, stream);
+  idx_t ld_U = 0;
+  math_t* U  = nullptr;
+
+  // Indices of elements in the active set.
+  std::vector<idx_t> indices(n_cols);
+  // Sign of the correlation at the time when the element was added to the
+  // active set.
+  rmm::device_uvector<math_t> sign(n_cols, stream);
+
+  // Correlation between the residual mu = y - X.T*beta and columns of X
+  rmm::device_uvector<math_t> cor(n_cols, stream);
+
+  // Temporary arrays used by the solver
+  rmm::device_scalar<math_t> A(stream);
+  rmm::device_uvector<math_t> a_vec(n_cols, stream);
+  rmm::device_scalar<math_t> gamma(stream);
+  rmm::device_uvector<math_t> u_eq(n_rows, stream);
+  rmm::device_uvector<math_t> ws(max_iter, stream);
+  rmm::device_uvector<math_t> workspace(n_cols, stream);
+
+  larsInit(handle,
+           X,
+           n_rows,
+           n_cols,
+           ld_X,
+           y,
+           Gram,
+           ld_G,
+           U_buffer,
+           &U,
+           &ld_U,
+           indices,
+           cor,
+           &max_iter,
+           coef_path,
+           stream);
+
+  // If we detect collinear features, then we will move them to the end of the
+  // correlation array and mark them as invalid (simply by decreasing
+  // n_valid_cols). At every iteration the solver is only working with the valid
+  // columns stored at X[:,:n_valid_cols], and G[:n_valid_cols, :n_valid_cols]
+  // cor[:n_valid_cols].
+  int n_valid_cols = n_cols;
+
+  *n_active = 0;
+  for (int i = 0; i < max_iter; i++) {
+    math_t cj;
+    idx_t j;
+    LarsFitStatus status = selectMostCorrelated(
+      *n_active, n_valid_cols, cor.data(), &cj, workspace, &j, n_rows, indices.data(), i, stream);
+    if (status != LarsFitStatus::kOk) { break; }
+
+    moveToActive(handle.get_cublas_handle(),
+                 n_active,
+                 j,
+                 X,
+                 n_rows,
+                 n_valid_cols,
+                 ld_X,
+                 cor.data(),
+                 indices.data(),
+                 Gram,
+                 ld_G,
+                 sign.data(),
+                 stream);
+
+    status = calcEquiangularVec(handle,
+                                *n_active,
+                                X,
+                                n_rows,
+                                n_valid_cols,
+                                ld_X,
+                                sign.data(),
+                                U,
+                                ld_U,
+                                Gram,
+                                ld_G,
+                                workspace,
+                                ws.data(),
+                                A.data(),
+                                u_eq.data(),
+                                eps,
+                                stream);
+
+    if (status == LarsFitStatus::kError) {
+      if (*n_active > 1) { RAFT_LOG_WARN("Returning with last valid model."); }
+      *n_active -= 1;
+      break;
+    } else if (status == LarsFitStatus::kCollinear) {
+      // We move the current feature to the invalid set
+      swapFeatures(handle.get_cublas_handle(),
+                   n_valid_cols - 1,
+                   *n_active - 1,
+                   X,
+                   n_rows,
+                   n_cols,
+                   ld_X,
+                   cor.data(),
+                   indices.data(),
+                   Gram,
+                   ld_G,
+                   stream);
+      *n_active -= 1;
+      n_valid_cols--;
+      continue;
+    }
+
+    calcMaxStep(handle,
+                max_iter,
+                n_rows,
+                n_valid_cols,
+                *n_active,
+                cj,
+                A.data(),
+                cor.data(),
+                Gram,
+                ld_G,
+                X,
+                ld_X,
+                u_eq.data(),
+                ws.data(),
+                gamma.data(),
+                a_vec.data(),
+                stream);
+
+    updateCoef(handle,
+               max_iter,
+               n_valid_cols,
+               *n_active,
+               gamma.data(),
+               ws.data(),
+               cor.data(),
+               a_vec.data(),
+               beta,
+               coef_path,
+               stream);
+  }
+
+  if (*n_active > 0) {
+    // Apply sklearn definition of alphas = cor / n_rows
+    raft::linalg::unaryOp(
+      alphas,
+      cor.data(),
+      *n_active,
+      [n_rows] __device__(math_t c) { return abs(c) / n_rows; },
+      stream);
+
+    // Calculate the final correlation. We use the correlation from the last
+    // iteration and apply the changed during the last LARS iteration:
+    // alpha[n_active] = cor[n_active-1] - gamma * A
+    math_t* gamma_ptr = gamma.data();
+    math_t* A_ptr     = A.data();
+    raft::linalg::unaryOp(
+      alphas + *n_active,
+      cor.data() + *n_active - 1,
+      1,
+      [gamma_ptr, A_ptr, n_rows] __device__(math_t c) {
+        return abs(c - (*gamma_ptr) * (*A_ptr)) / n_rows;
+      },
+      stream);
+
+    raft::update_device(active_idx, indices.data(), *n_active, stream);
+  } else {
+    THROW("Model is not fitted.");
+  }
+}
+
+/**
+ * @brief Predict with least angle regressor.
+ *
+ * @param handle RAFT handle
+ * @param X device array of training vectors in column major format,
+ *     size [n_rows * n_cols].
+ * @param n_rows number of training samples
+ * @param n_cols number of feature columns
+ * @param ld_X leading dimension of X (stride of columns)
+ * @param beta device array of regression coefficients, size [n_active]
+ * @param n_active the number of regression coefficients
+ * @param active_idx device array containing the indices of active variables.
+ *     Only these columns of X will be used for prediction, size [n_active].
+ * @param intercept
+ * @param preds device array to store the predictions, size [n_rows]. Must be
+ *     allocated on entry.
+ */
+template <typename math_t, typename idx_t>
+void larsPredict(const raft::handle_t& handle,
+                 const math_t* X,
+                 idx_t n_rows,
+                 idx_t n_cols,
+                 idx_t ld_X,
+                 const math_t* beta,
+                 idx_t n_active,
+                 idx_t* active_idx,
+                 math_t intercept,
+                 math_t* preds)
+{
+  cudaStream_t stream = handle.get_stream();
+  rmm::device_uvector<math_t> beta_sorted(0, stream);
+  rmm::device_uvector<math_t> X_active_cols(0, stream);
+  auto execution_policy = handle.get_thrust_policy();
+
+  if (n_active == 0 || n_rows == 0) return;
+
+  if (n_active == n_cols) {
+    // We make a copy of the beta coefs and sort them
+    beta_sorted.resize(n_active, stream);
+    rmm::device_uvector<idx_t> idx_sorted(n_active, stream);
+    raft::copy(beta_sorted.data(), beta, n_active, stream);
+    raft::copy(idx_sorted.data(), active_idx, n_active, stream);
+    thrust::device_ptr<math_t> beta_ptr(beta_sorted.data());
+    thrust::device_ptr<idx_t> idx_ptr(idx_sorted.data());
+    thrust::sort_by_key(execution_policy, idx_ptr, idx_ptr + n_active, beta_ptr);
+    beta = beta_sorted.data();
+  } else {
+    // We collect active columns of X to contiguous space
+    X_active_cols.resize(n_active * ld_X, stream);
+    const int TPB = 64;
+    raft::cache::get_vecs<<<raft::ceildiv(n_active * ld_X, TPB), TPB, 0, stream>>>(
+      X, ld_X, active_idx, n_active, X_active_cols.data());
+    RAFT_CUDA_TRY(cudaGetLastError());
+    X = X_active_cols.data();
+  }
+  // Initialize preds = intercept
+  thrust::device_ptr<math_t> pred_ptr(preds);
+  thrust::fill(execution_policy, pred_ptr, pred_ptr + n_rows, intercept);
+  math_t one = 1;
+  // #TODO: Call from public API when ready
+  RAFT_CUBLAS_TRY(raft::linalg::detail::cublasgemv(handle.get_cublas_handle(),
+                                                   CUBLAS_OP_N,
+                                                   n_rows,
+                                                   n_active,
+                                                   &one,
+                                                   X,
+                                                   ld_X,
+                                                   beta,
+                                                   1,
+                                                   &one,
+                                                   preds,
+                                                   1,
+                                                   stream));
+}
+};  // namespace raft::solver::detail

--- a/cpp/include/raft/solver/detail/learning_rate.h
+++ b/cpp/include/raft/solver/detail/learning_rate.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuml/solvers/params.hpp>
+#include <math.h>
+
+namespace raft::solver::detail {
+
+template <typename math_t>
+math_t max(math_t a, math_t b)
+{
+  return (a < b) ? b : a;
+  ;
+}
+
+template <typename math_t>
+math_t invScaling(math_t eta, math_t power_t, int t)
+{
+  return (eta / pow(t, power_t));
+}
+
+template <typename math_t>
+math_t regDLoss(math_t a, math_t b)
+{
+  return a - b;
+}
+
+template <typename math_t>
+math_t calOptimalInit(math_t alpha)
+{
+  math_t typw         = sqrt(math_t(1.0) / sqrt(alpha));
+  math_t initial_eta0 = typw / max(math_t(1.0), regDLoss(-typw, math_t(1.0)));
+  return (math_t(1.0) / (initial_eta0 * alpha));
+}
+
+template <typename math_t>
+math_t optimal(math_t alpha, math_t optimal_init, int t)
+{
+  return math_t(1.0) / (alpha * (optimal_init + t - 1));
+}
+
+template <typename math_t>
+math_t calLearningRate(ML::lr_type lr_type, math_t eta, math_t power_t, math_t alpha, math_t t)
+{
+  if (lr_type == ML::lr_type::CONSTANT) {
+    return eta;
+  } else if (lr_type == ML::lr_type::INVSCALING) {
+    return invScaling(eta, power_t, t);
+  } else if (lr_type == ML::lr_type::OPTIMAL) {
+    return optimal(alpha, eta, t);
+  } else {
+    return math_t(0);
+  }
+}
+
+};  // namespace raft::solver::detail

--- a/cpp/include/raft/solver/detail/objectives/hinge.cuh
+++ b/cpp/include/raft/solver/detail/objectives/hinge.cuh
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "penalty.cuh"
+#include <raft/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/eltwise.cuh>
+#include <raft/linalg/gemm.cuh>
+#include <raft/linalg/matrix_vector_op.cuh>
+#include <raft/linalg/subtract.cuh>
+#include <raft/linalg/transpose.cuh>
+#include <raft/linalg/unary_op.cuh>
+#include <raft/matrix/math.cuh>
+#include <raft/matrix/matrix.cuh>
+#include <raft/stats/mean.cuh>
+#include <raft/stats/sum.cuh>
+#include <rmm/device_uvector.hpp>
+
+namespace raft::solver::detail::objectives {
+
+template <typename math_t, typename idx_type = int>
+void hingeLossGradMult(math_t* data,
+                       const math_t* vec1,
+                       const math_t* vec2,
+                       idx_type n_row,
+                       idx_type n_col,
+                       cudaStream_t stream)
+{
+  raft::linalg::matrixVectorOp(
+    data,
+    data,
+    vec1,
+    vec2,
+    n_col,
+    n_row,
+    false,
+    false,
+    [] __device__(math_t a, math_t b, math_t c) {
+      if (c < math_t(1))
+        return -a * b;
+      else
+        return math_t(0);
+    },
+    stream);
+}
+
+template <typename math_t, typename idx_type = int>
+void hingeLossSubtract(
+  math_t* out, const math_t* in, math_t scalar, idx_type len, cudaStream_t stream)
+{
+  raft::linalg::unaryOp(
+    out,
+    in,
+    len,
+    [scalar] __device__(math_t in) {
+      if (in < scalar)
+        return math_t(1) - in;
+      else
+        return math_t(0);
+    },
+    stream);
+}
+
+template <typename math_t, typename idx_type = int>
+void hingeH(const raft::handle_t& handle,
+            const math_t* input,
+            idx_type n_rows,
+            idx_type n_cols,
+            const math_t* coef,
+            math_t* pred,
+            math_t intercept,
+            cudaStream_t stream)
+{
+  raft::linalg::gemm(
+    handle, input, n_rows, n_cols, coef, pred, n_rows, 1, CUBLAS_OP_N, CUBLAS_OP_N, stream);
+
+  if (intercept != math_t(0)) raft::linalg::addScalar(pred, pred, intercept, n_rows, stream);
+
+  sign(pred, pred, math_t(1.0), n_rows, stream);
+}
+
+template <typename math_t>
+void hingeLossGrads(const raft::handle_t& handle,
+                    math_t* input,
+                    int n_rows,
+                    int n_cols,
+                    const math_t* labels,
+                    const math_t* coef,
+                    math_t* grads,
+                    penalty pen,
+                    math_t alpha,
+                    math_t l1_ratio,
+                    cudaStream_t stream)
+{
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
+
+  raft::linalg::gemm(handle,
+                     input,
+                     n_rows,
+                     n_cols,
+                     coef,
+                     labels_pred.data(),
+                     n_rows,
+                     1,
+                     CUBLAS_OP_N,
+                     CUBLAS_OP_N,
+                     stream);
+
+  raft::linalg::eltwiseMultiply(labels_pred.data(), labels_pred.data(), labels, n_rows, stream);
+  hingeLossGradMult(input, labels, labels_pred.data(), n_rows, n_cols, stream);
+  raft::stats::mean(grads, input, n_cols, n_rows, false, false, stream);
+
+  rmm::device_uvector<math_t> pen_grads(0, stream);
+
+  if (pen != penalty::NONE) pen_grads.resize(n_cols, stream);
+
+  if (pen == penalty::L1) {
+    lassoGrad(pen_grads.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::L2) {
+    ridgeGrad(pen_grads.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::ELASTICNET) {
+    elasticnetGrad(pen_grads.data(), coef, n_cols, alpha, l1_ratio, stream);
+  }
+
+  if (pen != penalty::NONE) { raft::linalg::add(grads, grads, pen_grads.data(), n_cols, stream); }
+}
+
+template <typename math_t>
+void hingeLoss(const raft::handle_t& handle,
+               math_t* input,
+               int n_rows,
+               int n_cols,
+               const math_t* labels,
+               const math_t* coef,
+               math_t* loss,
+               penalty pen,
+               math_t alpha,
+               math_t l1_ratio,
+               cudaStream_t stream)
+{
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
+
+  raft::linalg::gemm(handle,
+                     input,
+                     n_rows,
+                     n_cols,
+                     coef,
+                     labels_pred.data(),
+                     n_rows,
+                     1,
+                     CUBLAS_OP_N,
+                     CUBLAS_OP_N,
+                     stream);
+
+  raft::linalg::eltwiseMultiply(labels_pred.data(), labels_pred.data(), labels, n_rows, stream);
+
+  hingeLossSubtract(labels_pred.data(), labels_pred.data(), math_t(1), n_rows, stream);
+
+  raft::stats::sum(loss, labels_pred.data(), 1, n_rows, false, stream);
+
+  rmm::device_uvector<math_t> pen_val(0, stream);
+
+  if (pen != penalty::NONE) pen_val.resize(1, stream);
+
+  if (pen == penalty::L1) {
+    lasso(pen_val.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::L2) {
+    ridge(pen_val.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::ELASTICNET) {
+    elasticnet(pen_val.data(), coef, n_cols, alpha, l1_ratio, stream);
+  }
+
+  if (pen != penalty::NONE) { raft::linalg::add(loss, loss, pen_val.data(), 1, stream); }
+}
+
+};  // namespace raft::solver::detail::objectives

--- a/cpp/include/raft/solver/detail/objectives/linearReg.cuh
+++ b/cpp/include/raft/solver/detail/objectives/linearReg.cuh
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "penalty.cuh"
+#include <raft/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/eltwise.cuh>
+#include <raft/linalg/gemm.cuh>
+#include <raft/linalg/subtract.cuh>
+#include <raft/linalg/transpose.cuh>
+#include <raft/matrix/math.cuh>
+#include <raft/matrix/matrix.cuh>
+#include <raft/stats/mean.cuh>
+#include <raft/stats/sum.cuh>
+#include <rmm/device_uvector.hpp>
+
+namespace raft::solver::detail::objectives {
+
+template <typename math_t>
+void linearRegH(const raft::handle_t& handle,
+                const math_t* input,
+                int n_rows,
+                int n_cols,
+                const math_t* coef,
+                math_t* pred,
+                math_t intercept,
+                cudaStream_t stream)
+{
+  raft::linalg::gemm(
+    handle, input, n_rows, n_cols, coef, pred, n_rows, 1, CUBLAS_OP_N, CUBLAS_OP_N, stream);
+
+  if (intercept != math_t(0)) raft::linalg::addScalar(pred, pred, intercept, n_rows, stream);
+}
+
+template <typename math_t>
+void linearRegLossGrads(const raft::handle_t& handle,
+                        math_t* input,
+                        int n_rows,
+                        int n_cols,
+                        const math_t* labels,
+                        const math_t* coef,
+                        math_t* grads,
+                        penalty pen,
+                        math_t alpha,
+                        math_t l1_ratio,
+                        cudaStream_t stream)
+{
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
+
+  linearRegH(handle, input, n_rows, n_cols, coef, labels_pred.data(), math_t(0), stream);
+  raft::linalg::subtract(labels_pred.data(), labels_pred.data(), labels, n_rows, stream);
+  raft::matrix::matrixVectorBinaryMult(
+    input, labels_pred.data(), n_rows, n_cols, false, false, stream);
+
+  raft::stats::mean(grads, input, n_cols, n_rows, false, false, stream);
+  raft::linalg::scalarMultiply(grads, grads, math_t(2), n_cols, stream);
+
+  rmm::device_uvector<math_t> pen_grads(0, stream);
+
+  if (pen != penalty::NONE) pen_grads.resize(n_cols, stream);
+
+  if (pen == penalty::L1) {
+    lassoGrad(pen_grads.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::L2) {
+    ridgeGrad(pen_grads.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::ELASTICNET) {
+    elasticnetGrad(pen_grads.data(), coef, n_cols, alpha, l1_ratio, stream);
+  }
+
+  if (pen != penalty::NONE) { raft::linalg::add(grads, grads, pen_grads.data(), n_cols, stream); }
+}
+
+template <typename math_t>
+void linearRegLoss(const raft::handle_t& handle,
+                   math_t* input,
+                   int n_rows,
+                   int n_cols,
+                   const math_t* labels,
+                   const math_t* coef,
+                   math_t* loss,
+                   penalty pen,
+                   math_t alpha,
+                   math_t l1_ratio,
+                   cudaStream_t stream)
+{
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
+
+  linearRegH(handle, input, n_rows, n_cols, coef, labels_pred.data(), math_t(0), stream);
+
+  raft::linalg::subtract(labels_pred.data(), labels, labels_pred.data(), n_rows, stream);
+  raft::matrix::power(labels_pred.data(), n_rows, stream);
+  raft::stats::mean(loss, labels_pred.data(), 1, n_rows, false, false, stream);
+
+  rmm::device_uvector<math_t> pen_val(0, stream);
+
+  if (pen != penalty::NONE) pen_val.resize(1, stream);
+
+  if (pen == penalty::L1) {
+    lasso(pen_val.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::L2) {
+    ridge(pen_val.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::ELASTICNET) {
+    elasticnet(pen_val.data(), coef, n_cols, alpha, l1_ratio, stream);
+  }
+
+  if (pen != penalty::NONE) { raft::linalg::add(loss, loss, pen_val.data(), 1, stream); }
+}
+
+};  // namespace raft::solver::detail::objectives

--- a/cpp/include/raft/solver/detail/objectives/log.cuh
+++ b/cpp/include/raft/solver/detail/objectives/log.cuh
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/linalg/unary_op.cuh>
+
+namespace raft::solver::detail::objectives {
+
+template <typename T, typename IdxType = int>
+void f_log(T* out, T* in, T scalar, IdxType len, cudaStream_t stream)
+{
+  raft::linalg::unaryOp(
+    out, in, len, [scalar] __device__(T in) { return raft::myLog(in) * scalar; }, stream);
+}
+
+};  // end namespace raft::solver::detail::objectives

--- a/cpp/include/raft/solver/detail/objectives/logisticReg.cuh
+++ b/cpp/include/raft/solver/detail/objectives/logisticReg.cuh
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "penalty.cuh"
+#include "sigmoid.cuh"
+#include <raft/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/eltwise.cuh>
+#include <raft/linalg/gemm.cuh>
+#include <raft/linalg/subtract.cuh>
+#include <raft/linalg/transpose.cuh>
+#include <raft/matrix/math.cuh>
+#include <raft/matrix/matrix.cuh>
+#include <raft/stats/mean.cuh>
+#include <raft/stats/sum.cuh>
+#include <rmm/device_uvector.hpp>
+
+namespace raft::solver::detail::objectives {
+
+template <typename math_t>
+void logisticRegH(const raft::handle_t& handle,
+                  const math_t* input,
+                  int n_rows,
+                  int n_cols,
+                  const math_t* coef,
+                  math_t* pred,
+                  math_t intercept,
+                  cudaStream_t stream)
+{
+  raft::linalg::gemm(
+    handle, input, n_rows, n_cols, coef, pred, n_rows, 1, CUBLAS_OP_N, CUBLAS_OP_N, stream);
+
+  if (intercept != math_t(0)) raft::linalg::addScalar(pred, pred, intercept, n_rows, stream);
+
+  sigmoid(pred, pred, n_rows, stream);
+}
+
+template <typename math_t>
+void logisticRegLossGrads(const raft::handle_t& handle,
+                          math_t* input,
+                          int n_rows,
+                          int n_cols,
+                          const math_t* labels,
+                          const math_t* coef,
+                          math_t* grads,
+                          penalty pen,
+                          math_t alpha,
+                          math_t l1_ratio,
+                          cudaStream_t stream)
+{
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
+
+  logisticRegH(handle, input, n_rows, n_cols, coef, labels_pred.data(), math_t(0), stream);
+  raft::linalg::subtract(labels_pred.data(), labels_pred.data(), labels, n_rows, stream);
+  raft::matrix::matrixVectorBinaryMult(
+    input, labels_pred.data(), n_rows, n_cols, false, false, stream);
+
+  raft::stats::mean(grads, input, n_cols, n_rows, false, false, stream);
+
+  rmm::device_uvector<math_t> pen_grads(0, stream);
+
+  if (pen != penalty::NONE) pen_grads.resize(n_cols, stream);
+
+  if (pen == penalty::L1) {
+    lassoGrad(pen_grads.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::L2) {
+    ridgeGrad(pen_grads.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::ELASTICNET) {
+    elasticnetGrad(pen_grads.data(), coef, n_cols, alpha, l1_ratio, stream);
+  }
+
+  if (pen != penalty::NONE) { raft::linalg::add(grads, grads, pen_grads.data(), n_cols, stream); }
+}
+
+template <typename T>
+void logLoss(T* out, T* label, T* label_pred, int len, cudaStream_t stream);
+
+template <>
+inline void logLoss(float* out, float* label, float* label_pred, int len, cudaStream_t stream)
+{
+  raft::linalg::binaryOp(
+    out,
+    label,
+    label_pred,
+    len,
+    [] __device__(float y, float y_pred) { return -y * logf(y_pred) - (1 - y) * logf(1 - y_pred); },
+    stream);
+}
+
+template <>
+inline void logLoss(double* out, double* label, double* label_pred, int len, cudaStream_t stream)
+{
+  raft::linalg::binaryOp(
+    out,
+    label,
+    label_pred,
+    len,
+    [] __device__(double y, double y_pred) {
+      return -y * log(y_pred) - (1 - y) * logf(1 - y_pred);
+    },
+    stream);
+}
+
+template <typename math_t>
+void logisticRegLoss(const raft::handle_t& handle,
+                     math_t* input,
+                     int n_rows,
+                     int n_cols,
+                     math_t* labels,
+                     const math_t* coef,
+                     math_t* loss,
+                     penalty pen,
+                     math_t alpha,
+                     math_t l1_ratio,
+                     cudaStream_t stream)
+{
+  rmm::device_uvector<math_t> labels_pred(n_rows, stream);
+  logisticRegH(handle, input, n_rows, n_cols, coef, labels_pred.data(), math_t(0), stream);
+  logLoss(labels_pred.data(), labels, labels_pred.data(), n_rows, stream);
+
+  raft::stats::mean(loss, labels_pred.data(), 1, n_rows, false, false, stream);
+
+  rmm::device_uvector<math_t> pen_val(0, stream);
+
+  if (pen != penalty::NONE) pen_val.resize(1, stream);
+
+  if (pen == penalty::L1) {
+    lasso(pen_val.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::L2) {
+    ridge(pen_val.data(), coef, n_cols, alpha, stream);
+  } else if (pen == penalty::ELASTICNET) {
+    elasticnet(pen_val.data(), coef, n_cols, alpha, l1_ratio, stream);
+  }
+
+  if (pen != penalty::NONE) { raft::linalg::add(loss, loss, pen_val.data(), 1, stream); }
+}
+
+};  // namespace raft::solver::detail::objectives

--- a/cpp/include/raft/solver/detail/objectives/penalty.cuh
+++ b/cpp/include/raft/solver/detail/objectives/penalty.cuh
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "sign.cuh"
+#include <raft/core/cudart_utils.hpp>
+#include <raft/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/eltwise.cuh>
+#include <raft/linalg/norm.cuh>
+#include <raft/matrix/math.cuh>
+#include <raft/matrix/matrix.cuh>
+#include <rmm/device_scalar.hpp>
+#include <rmm/device_uvector.hpp>
+
+namespace raft::solver::detail::objectives {
+
+enum penalty {
+  NONE,
+  L1,
+  L2,
+  ELASTICNET,
+};
+
+template <typename math_t>
+void lasso(math_t* out, const math_t* coef, const int len, const math_t alpha, cudaStream_t stream)
+{
+  raft::linalg::rowNorm(out, coef, len, 1, raft::linalg::NormType::L1Norm, true, stream);
+  raft::linalg::scalarMultiply(out, out, alpha, 1, stream);
+}
+
+template <typename math_t>
+void lassoGrad(
+  math_t* grad, const math_t* coef, const int len, const math_t alpha, cudaStream_t stream)
+{
+  sign(grad, coef, alpha, len, stream);
+}
+
+template <typename math_t>
+void ridge(math_t* out, const math_t* coef, const int len, const math_t alpha, cudaStream_t stream)
+{
+  raft::linalg::rowNorm(out, coef, len, 1, raft::linalg::NormType::L2Norm, true, stream);
+  raft::linalg::scalarMultiply(out, out, alpha, 1, stream);
+}
+
+template <typename math_t>
+void ridgeGrad(
+  math_t* grad, const math_t* coef, const int len, const math_t alpha, cudaStream_t stream)
+{
+  raft::linalg::scalarMultiply(grad, coef, math_t(2) * alpha, len, stream);
+}
+
+template <typename math_t>
+void elasticnet(math_t* out,
+                const math_t* coef,
+                const int len,
+                const math_t alpha,
+                const math_t l1_ratio,
+                cudaStream_t stream)
+{
+  rmm::device_scalar<math_t> out_lasso(stream);
+
+  ridge(out, coef, len, alpha * (math_t(1) - l1_ratio), stream);
+  lasso(out_lasso.data(), coef, len, alpha * l1_ratio, stream);
+
+  raft::linalg::add(out, out, out_lasso.data(), 1, stream);
+}
+
+template <typename math_t>
+void elasticnetGrad(math_t* grad,
+                    const math_t* coef,
+                    const int len,
+                    const math_t alpha,
+                    const math_t l1_ratio,
+                    cudaStream_t stream)
+{
+  rmm::device_uvector<math_t> grad_lasso(len, stream);
+
+  ridgeGrad(grad, coef, len, alpha * (math_t(1) - l1_ratio), stream);
+  lassoGrad(grad_lasso.data(), coef, len, alpha * l1_ratio, stream);
+
+  raft::linalg::add(grad, grad, grad_lasso.data(), len, stream);
+}
+
+};  // namespace raft::solver::detail::objectives

--- a/cpp/include/raft/solver/detail/objectives/sigmoid.cuh
+++ b/cpp/include/raft/solver/detail/objectives/sigmoid.cuh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/cuda_utils.cuh>
+#include <raft/linalg/unary_op.cuh>
+
+namespace raft::solver::detail::objectives {
+
+template <typename T, typename IdxType = int>
+void sigmoid(T* out, T* in, IdxType len, cudaStream_t stream)
+{
+  T one = T(1);
+  raft::linalg::unaryOp(
+    out, in, len, [one] __device__(T in) { return one / (one + raft::myExp(-in)); }, stream);
+}
+
+};  // end namespace raft::solver::detail::objectives

--- a/cpp/include/raft/solver/detail/objectives/sign.cuh
+++ b/cpp/include/raft/solver/detail/objectives/sign.cuh
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/linalg/unary_op.cuh>
+
+namespace raft::solver::detail::objectives {
+
+template <typename math_t, typename idx_type = int>
+void sign(
+  math_t* out, const math_t* in, const math_t scalar, const idx_type len, cudaStream_t stream)
+{
+  raft::linalg::unaryOp(
+    out,
+    in,
+    len,
+    [scalar] __device__(math_t in) {
+      if (in < math_t(0))
+        return (math_t(-1) * scalar);
+      else if (in > math_t(0))
+        return (math_t(1) * scalar);
+      else
+        return math_t(0);
+    },
+    stream);
+}
+
+template <typename math_t, typename idx_type = int>
+void sign(math_t* out, const math_t* in, const idx_type n_len, cudaStream_t stream)
+{
+  math_t scalar = math_t(1);
+  sign(out, in, scalar, n_len, stream);
+}
+
+};  // namespace raft::solver::detail::objectives

--- a/cpp/include/raft/solver/detail/objectives/softThres.cuh
+++ b/cpp/include/raft/solver/detail/objectives/softThres.cuh
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/linalg/unary_op.cuh>
+
+namespace raft::solver::detail::objectives {
+
+template <typename math_t>
+void softThres(
+  math_t* out, const math_t* in, const math_t thres, const int len, cudaStream_t stream)
+{
+  raft::linalg::unaryOp(
+    out,
+    in,
+    len,
+    [thres] __device__(math_t in) {
+      if (in > math_t(0) && thres < raft::myAbs(in))
+        return in - thres;
+      else if (in < math_t(0) && thres < raft::myAbs(in))
+        return in + thres;
+      else
+        return math_t(0);
+    },
+    stream);
+}
+
+};  // namespace raft::solver::detail::objectives

--- a/cpp/include/raft/solver/detail/qn/objectives/base.cuh
+++ b/cpp/include/raft/solver/detail/qn/objectives/base.cuh
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "../simple_mat.cuh"
+#include <raft/util/cudart_utils.hpp>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/map.cuh>
+#include <raft/linalg/map_then_reduce.cuh>
+#include <raft/linalg/matrix_vector_op.cuh>
+#include <raft/stats/mean.cuh>
+
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/reduce.h>
+
+#include <vector>
+
+namespace raft::solver::quasi_newton::detail::objectives {
+
+template <typename T>
+inline void linearFwd(const raft::handle_t& handle,
+                      SimpleDenseMat<T>& Z,
+                      const SimpleMat<T>& X,
+                      const SimpleDenseMat<T>& W,
+                      cudaStream_t stream)
+{
+  // Forward pass:  compute Z <- W * X.T + bias
+  const bool has_bias = X.n != W.n;
+  const int D         = X.n;
+  if (has_bias) {
+    SimpleVec<T> bias;
+    SimpleDenseMat<T> weights;
+    col_ref(W, bias, D);
+    col_slice(W, weights, 0, D);
+    // We implement Z <- W * X^T + b by
+    // - Z <- b (broadcast): TODO reads Z unnecessarily atm
+    // - Z <- W * X^T + Z    : TODO can be fused in CUTLASS?
+    auto set_bias = [] __device__(const T z, const T b) { return b; };
+    raft::linalg::matrixVectorOp(
+      Z.data, Z.data, bias.data, Z.n, Z.m, false, false, set_bias, stream);
+
+    Z.assign_gemm(handle, 1, weights, false, X, true, 1, stream);
+  } else {
+    Z.assign_gemm(handle, 1, W, false, X, true, 0, stream);
+  }
+}
+
+template <typename T>
+inline void linearBwd(const raft::handle_t& handle,
+                      SimpleDenseMat<T>& G,
+                      const SimpleMat<T>& X,
+                      const SimpleDenseMat<T>& dZ,
+                      bool setZero,
+                      cudaStream_t stream)
+{
+  // Backward pass:
+  // - compute G <- dZ * X.T
+  // - for bias: Gb = mean(dZ, 1)
+
+  const bool has_bias = X.n != G.n;
+  const int D         = X.n;
+  const T beta        = setZero ? T(0) : T(1);
+  if (has_bias) {
+    SimpleVec<T> Gbias;
+    SimpleDenseMat<T> Gweights;
+    col_ref(G, Gbias, D);
+    col_slice(G, Gweights, 0, D);
+
+    // TODO can this be fused somehow?
+    Gweights.assign_gemm(handle, 1.0 / X.m, dZ, false, X, false, beta, stream);
+    raft::stats::mean(Gbias.data, dZ.data, dZ.m, dZ.n, false, true, stream);
+  } else {
+    G.assign_gemm(handle, 1.0 / X.m, dZ, false, X, false, beta, stream);
+  }
+}
+
+
+
+template <typename T, class Loss>
+struct QNLinearBase : LinearDims {
+  typedef SimpleDenseMat<T> Mat;
+  typedef SimpleVec<T> Vec;
+
+  const raft::handle_t& handle;
+  T* sample_weights;
+  T weights_sum;
+
+  QNLinearBase(const raft::handle_t& handle, int D, int C, bool fit_intercept)
+    : LinearDims(C, D, fit_intercept), handle(handle), sample_weights(nullptr), weights_sum(0)
+  {
+  }
+
+  void add_sample_weights(T* sample_weights, int n_samples, cudaStream_t stream)
+  {
+    this->sample_weights = sample_weights;
+    this->weights_sum    = thrust::reduce(thrust::cuda::par.on(stream),
+                                       sample_weights,
+                                       sample_weights + n_samples,
+                                       (T)0,
+                                       thrust::plus<T>());
+  }
+
+  /*
+   * Computes the following:
+   * 1. Z <- dL/DZ
+   * 2. loss_val <- sum loss(Z)
+   *
+   * Default: elementwise application of loss and its derivative
+   *
+   * NB: for this method to work, loss implementations must have two functor fields `lz` and `dlz`.
+   *     These two compute loss value and its derivative w.r.t. `z`.
+   */
+  inline void getLossAndDZ(T* loss_val,
+                           SimpleDenseMat<T>& Z,
+                           const SimpleVec<T>& y,
+                           cudaStream_t stream)
+  {
+    // Base impl assumes simple case C = 1
+    // TODO would be nice to have a kernel that fuses these two steps
+    // This would be easy, if mapThenSumReduce allowed outputing the result of
+    // map (supporting inplace)
+    auto lz_copy  = static_cast<Loss*>(this)->lz;
+    auto dlz_copy = static_cast<Loss*>(this)->dlz;
+    if (this->sample_weights) {  // Sample weights are in use
+      T normalization = 1.0 / this->weights_sum;
+      raft::linalg::mapThenSumReduce(
+        loss_val,
+        y.len,
+        [lz_copy, normalization] __device__(const T y, const T z, const T weight) {
+          return lz_copy(y, z) * (weight * normalization);
+        },
+        stream,
+        y.data,
+        Z.data,
+        sample_weights);
+      raft::linalg::map_k(
+        Z.data,
+        y.len,
+        [dlz_copy] __device__(const T y, const T z, const T weight) {
+          return weight * dlz_copy(y, z);
+        },
+        stream,
+        y.data,
+        Z.data,
+        sample_weights);
+    } else {  // Sample weights are not used
+      T normalization = 1.0 / y.len;
+      raft::linalg::mapThenSumReduce(
+        loss_val,
+        y.len,
+        [lz_copy, normalization] __device__(const T y, const T z) {
+          return lz_copy(y, z) * normalization;
+        },
+        stream,
+        y.data,
+        Z.data);
+      raft::linalg::binaryOp(Z.data, y.data, Z.data, y.len, dlz_copy, stream);
+    }
+  }
+
+  inline void loss_grad(T* loss_val,
+                        Mat& G,
+                        const Mat& W,
+                        const SimpleMat<T>& Xb,
+                        const Vec& yb,
+                        Mat& Zb,
+                        cudaStream_t stream,
+                        bool initGradZero = true)
+  {
+    Loss* loss = static_cast<Loss*>(this);  // static polymorphism
+
+    linearFwd(handle, Zb, Xb, W, stream);          // linear part: forward pass
+    loss->getLossAndDZ(loss_val, Zb, yb, stream);  // loss specific part
+    linearBwd(handle, G, Xb, Zb, initGradZero,
+              stream);  // linear part: backward pass
+  }
+};
+
+template <typename T, class QuasiNewtonObjective>
+struct QNWithData : LinearDims {
+  const SimpleMat<T>* X;
+  const SimpleVec<T>* y;
+  SimpleDenseMat<T>* Z;
+  QuasiNewtonObjective* objective;
+
+  QNWithData(QuasiNewtonObjective* obj, const SimpleMat<T>& X, const SimpleVec<T>& y, SimpleDenseMat<T>& Z)
+    : objective(obj), X(&X), y(&y), Z(&Z), LinearDims(obj->C, obj->D, obj->fit_intercept)
+  {
+  }
+
+  // interface exposed to typical non-linear optimizers
+  inline T operator()(const SimpleVec<T>& wFlat,
+                      SimpleVec<T>& gradFlat,
+                      T* dev_scalar,
+                      cudaStream_t stream)
+  {
+    SimpleDenseMat<T> W(wFlat.data, C, dims);
+    SimpleDenseMat<T> G(gradFlat.data, C, dims);
+    objective->loss_grad(dev_scalar, G, W, *X, *y, *Z, stream);
+    T loss_host;
+    raft::update_host(&loss_host, dev_scalar, 1, stream);
+    raft::interruptible::synchronize(stream);
+    return loss_host;
+  }
+
+  /**
+   * @brief Calculate a norm of the gradient computed using the given Loss instance.
+   *
+   * This function is intended to be used in `check_convergence`; it's output is supposed
+   * to be proportional to the loss value w.r.t. the number of features (D).
+   *
+   * Different loss functions may scale differently with the number of features (D).
+   * This has an effect on the convergence criteria. To account for that, we let a
+   * loss function define its preferred metric. Normally, we differentiate between the
+   * L2 norm (e.g. for Squared loss) and LInf norm (e.g. for Softmax loss).
+   */
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return objective->gradNorm(grad, dev_scalar, stream);
+  }
+};
+
+};  // namespace raft::solver::quasi_newton::detail::objectives

--- a/cpp/include/raft/solver/detail/qn/objectives/hinge.cuh
+++ b/cpp/include/raft/solver/detail/qn/objectives/hinge.cuh
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "base.cuh"
+#include "../simple_mat.cuh"
+#include <raft/util/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+
+namespace raft::solver::quasi_newton::detail::objectives {
+
+template <typename T>
+struct HingeLoss : QNLinearBase<T, HingeLoss<T>> {
+  typedef QNLinearBase<T, HingeLoss<T>> Super;
+
+  const struct Lz {
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T s = 2 * y - 1;
+      return raft::myMax<T>(0, 1 - s * z);
+    }
+  } lz;
+
+  const struct Dlz {
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T s = 2 * y - 1;
+      return s * z <= 1 ? -s : 0;
+    }
+  } dlz;
+
+  HingeLoss(const raft::handle_t& handle, int D, bool has_bias)
+    : Super(handle, D, 1, has_bias), lz{}, dlz{}
+  {
+  }
+
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return nrm1(grad, dev_scalar, stream);
+  }
+};
+
+template <typename T>
+struct SqHingeLoss : QNLinearBase<T, SqHingeLoss<T>> {
+  typedef QNLinearBase<T, SqHingeLoss<T>> Super;
+
+  const struct Lz {
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T s = 2 * y - 1;
+      T t = raft::myMax<T>(0, 1 - s * z);
+      return t * t;
+    }
+  } lz;
+
+  const struct Dlz {
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T s = 2 * y - 1;
+      return s * z <= 1 ? z - s : 0;
+    }
+  } dlz;
+
+  SqHingeLoss(const raft::handle_t& handle, int D, bool has_bias)
+    : Super(handle, D, 1, has_bias), lz{}, dlz{}
+  {
+  }
+
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return squaredNorm(grad, dev_scalar, stream) * 0.5;
+  }
+};
+
+template <typename T>
+struct EpsInsHingeLoss : QNLinearBase<T, EpsInsHingeLoss<T>> {
+  typedef QNLinearBase<T, EpsInsHingeLoss<T>> Super;
+
+  const struct Lz {
+    T sensitivity;
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T t = y - z;
+      return t > sensitivity ? t - sensitivity : t < -sensitivity ? -t - sensitivity : 0;
+    }
+  } lz;
+
+  const struct Dlz {
+    T sensitivity;
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T t = y - z;
+      return t > sensitivity ? -1 : (t < -sensitivity ? 1 : 0);
+    }
+  } dlz;
+
+  EpsInsHingeLoss(const raft::handle_t& handle, int D, bool has_bias, T sensitivity)
+    : Super(handle, D, 1, has_bias), lz{sensitivity}, dlz{sensitivity}
+  {
+  }
+
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return nrm1(grad, dev_scalar, stream);
+  }
+};
+
+template <typename T>
+struct SqEpsInsHingeLoss : QNLinearBase<T, SqEpsInsHingeLoss<T>> {
+  typedef QNLinearBase<T, SqEpsInsHingeLoss<T>> Super;
+
+  const struct Lz {
+    T sensitivity;
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T t = y - z;
+      T s = t > sensitivity ? t - sensitivity : t < -sensitivity ? -t - sensitivity : 0;
+      return s * s;
+    }
+  } lz;
+
+  const struct Dlz {
+    T sensitivity;
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T t = y - z;
+      return -2 * (t > sensitivity ? t - sensitivity : t < -sensitivity ? (t + sensitivity) : 0);
+    }
+  } dlz;
+
+  SqEpsInsHingeLoss(const raft::handle_t& handle, int D, bool has_bias, T sensitivity)
+    : Super(handle, D, 1, has_bias), lz{sensitivity}, dlz{sensitivity}
+  {
+  }
+
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return squaredNorm(grad, dev_scalar, stream) * 0.5;
+  }
+};
+
+};  // namespace raft::solver::quasi_newton::detail::objectives

--- a/cpp/include/raft/solver/detail/qn/objectives/linear.cuh
+++ b/cpp/include/raft/solver/detail/qn/objectives/linear.cuh
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "base.cuh"
+#include "../simple_mat.cuh"
+#include <raft/util/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+
+namespace  raft::solver::quasi_newton::detail::objectives {
+
+template <typename T>
+struct SquaredLoss : QNLinearBase<T, SquaredLoss<T>> {
+  typedef QNLinearBase<T, SquaredLoss<T>> Super;
+
+  const struct Lz {
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T diff = z - y;
+      return diff * diff * 0.5;
+    }
+  } lz;
+
+  const struct Dlz {
+    inline __device__ T operator()(const T y, const T z) const { return z - y; }
+  } dlz;
+
+  SquaredLoss(const raft::handle_t& handle, int D, bool has_bias)
+    : Super(handle, D, 1, has_bias), lz{}, dlz{}
+  {
+  }
+
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return squaredNorm(grad, dev_scalar, stream) * 0.5;
+  }
+};
+
+template <typename T>
+struct AbsLoss : QNLinearBase<T, AbsLoss<T>> {
+  typedef QNLinearBase<T, AbsLoss<T>> Super;
+
+  const struct Lz {
+    inline __device__ T operator()(const T y, const T z) const { return raft::myAbs<T>(z - y); }
+  } lz;
+
+  const struct Dlz {
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      return z > y ? 1 : (z < y ? -1 : 0);
+    }
+  } dlz;
+
+  AbsLoss(const raft::handle_t& handle, int D, bool has_bias)
+    : Super(handle, D, 1, has_bias), lz{}, dlz{}
+  {
+  }
+
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return nrm1(grad, dev_scalar, stream);
+  }
+};
+
+};  // namespace  raft::solver::quasi_newton::detail::objectives

--- a/cpp/include/raft/solver/detail/qn/objectives/logistic.cuh
+++ b/cpp/include/raft/solver/detail/qn/objectives/logistic.cuh
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "base.cuh"
+#include "../simple_mat.cuh"
+#include <raft/util/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+
+namespace  raft::solver::quasi_newton::detail::objectives {
+
+template <typename T>
+struct LogisticLoss : QNLinearBase<T, LogisticLoss<T>> {
+  typedef QNLinearBase<T, LogisticLoss<T>> Super;
+
+  const struct Lz {
+    inline __device__ T log_sigmoid(const T x) const
+    {
+      // To avoid floating point overflow in the exp function
+      T temp = raft::myLog(1 + raft::myExp(x < 0 ? x : -x));
+      return x < 0 ? x - temp : -temp;
+    }
+
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      T ytil = 2 * y - 1;
+      return -log_sigmoid(ytil * z);
+    }
+  } lz;
+
+  const struct Dlz {
+    inline __device__ T operator()(const T y, const T z) const
+    {
+      // To avoid fp overflow with exp(z) when abs(z) is large
+      T ez        = raft::myExp(z < 0 ? z : -z);
+      T numerator = z < 0 ? ez : T(1.0);
+      return numerator / (T(1.0) + ez) - y;
+    }
+  } dlz;
+
+  LogisticLoss(const raft::handle_t& handle, int D, bool has_bias)
+    : Super(handle, D, 1, has_bias), lz{}, dlz{}
+  {
+  }
+
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return nrmMax(grad, dev_scalar, stream);
+  }
+};
+};  // namespace  raft::solver::quasi_newton::detail::objectives

--- a/cpp/include/raft/solver/detail/qn/objectives/regularizer.cuh
+++ b/cpp/include/raft/solver/detail/qn/objectives/regularizer.cuh
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "base.cuh"
+#include "../simple_mat.cuh"
+#include <raft/util/cudart_utils.hpp>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/map_then_reduce.cuh>
+#include <raft/stats/mean.cuh>
+
+namespace  raft::solver::quasi_newton::detail::objectives {
+
+template <typename T>
+struct Tikhonov {
+  T l2_penalty;
+  Tikhonov(T l2) : l2_penalty(l2) {}
+  Tikhonov(const Tikhonov<T>& other) : l2_penalty(other.l2_penalty) {}
+
+  HDI T operator()(const T w) const { return 0.5 * l2_penalty * w * w; }
+
+  inline void reg_grad(T* reg_val,
+                       SimpleDenseMat<T>& G,
+                       const SimpleDenseMat<T>& W,
+                       const bool has_bias,
+                       cudaStream_t stream) const
+  {
+    // NOTE: scikit generally does not penalize biases
+    SimpleDenseMat<T> Gweights;
+    SimpleDenseMat<T> Wweights;
+    col_slice(G, Gweights, 0, G.n - has_bias);
+    col_slice(W, Wweights, 0, G.n - has_bias);
+    Gweights.ax(l2_penalty, Wweights, stream);
+
+    raft::linalg::mapThenSumReduce(reg_val, Wweights.len, *this, stream, Wweights.data);
+  }
+};
+
+template <typename T, class Loss, class Reg>
+struct RegularizedQN : LinearDims {
+  Reg* reg;
+  Loss* loss;
+
+  RegularizedQN(Loss* loss, Reg* reg)
+    : reg(reg), loss(loss), LinearDims(loss->C, loss->D, loss->fit_intercept)
+  {
+  }
+
+  inline void loss_grad(T* loss_val,
+                        SimpleDenseMat<T>& G,
+                        const SimpleDenseMat<T>& W,
+                        const SimpleMat<T>& Xb,
+                        const SimpleVec<T>& yb,
+                        SimpleDenseMat<T>& Zb,
+                        cudaStream_t stream,
+                        bool initGradZero = true)
+  {
+    T reg_host, loss_host;
+    SimpleVec<T> lossVal(loss_val, 1);
+
+    G.fill(0, stream);
+
+    reg->reg_grad(lossVal.data, G, W, loss->fit_intercept, stream);
+    raft::update_host(&reg_host, lossVal.data, 1, stream);
+
+    loss->loss_grad(lossVal.data, G, W, Xb, yb, Zb, stream, false);
+    raft::update_host(&loss_host, lossVal.data, 1, stream);
+
+    raft::interruptible::synchronize(stream);
+
+    lossVal.fill(loss_host + reg_host, stream);
+  }
+
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return loss->gradNorm(grad, dev_scalar, stream);
+  }
+};
+};  // namespace  raft::solver::quasi_newton::detail::objectives

--- a/cpp/include/raft/solver/detail/qn/objectives/softmax.cuh
+++ b/cpp/include/raft/solver/detail/qn/objectives/softmax.cuh
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "base.cuh"
+#include "../simple_mat.cuh"
+#include <raft/util/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+
+namespace  raft::solver::quasi_newton::detail::objectives {
+using raft::ceildiv;
+using raft::myExp;
+using raft::myLog;
+using raft::myMax;
+
+// Input: matrix Z (dims: CxN)
+// Computes softmax cross entropy loss across columns, i.e. normalization
+// column-wise.
+//
+// This kernel performs best for small number of classes C.
+// It's much faster than implementation based on ml-prims (up to ~2x - ~10x for
+// small C <= BX).  More importantly, it does not require another CxN scratch
+// space.  In that case the block covers the whole column and warp reduce is fast
+// TODO for very large C, there should be maybe rather something along the lines
+// of
+//     coalesced reduce, i.e. blocks should take care of columns
+// TODO split into two kernels for small and large case?
+template <typename T, int BX = 32, int BY = 8>
+__global__ void logSoftmaxKernel(
+  T* out, T* dZ, const T* in, const T* labels, int C, int N, bool getDerivative = true)
+{
+  typedef cub::WarpReduce<T, BX> WarpRed;
+  typedef cub::BlockReduce<T, BX, cub::BLOCK_REDUCE_WARP_REDUCTIONS, BY> BlockRed;
+
+  __shared__ union {
+    typename WarpRed::TempStorage warpStore[BY];
+    typename BlockRed::TempStorage blockStore;
+    T sh_val[BY];
+  } shm;
+
+  int y   = threadIdx.y + blockIdx.x * BY;
+  int len = C * N;
+
+  bool delta = false;
+  // TODO is there a better way to read this?
+  if (getDerivative && threadIdx.x == 0) {
+    if (y < N) {
+      shm.sh_val[threadIdx.y] = labels[y];
+    } else {
+      shm.sh_val[threadIdx.y] = std::numeric_limits<T>::lowest();
+    }
+  }
+  __syncthreads();
+  T label = shm.sh_val[threadIdx.y];
+  __syncthreads();
+  T eta_y  = 0;
+  T myEta  = 0;
+  T etaMax = -1e9;
+  T lse    = 0;
+  /*
+   * Phase 1: Find Maximum m over column
+   */
+  for (int x = threadIdx.x; x < C; x += BX) {
+    int idx = x + y * C;
+    if (x < C && idx < len) {
+      myEta = in[idx];
+      if (x == label) {
+        delta = true;
+        eta_y = myEta;
+      }
+      etaMax = myMax<T>(myEta, etaMax);
+    }
+  }
+  T tmpMax = WarpRed(shm.warpStore[threadIdx.y]).Reduce(etaMax, cub::Max());
+  if (threadIdx.x == 0) { shm.sh_val[threadIdx.y] = tmpMax; }
+  __syncthreads();
+  etaMax = shm.sh_val[threadIdx.y];
+  __syncthreads();
+
+  /*
+   * Phase 2: Compute stabilized log-sum-exp over column
+   * lse = m + log(sum(exp(eta - m)))
+   */
+  // TODO there must be a better way to do this...
+  if (C <= BX) {  // this means one block covers a column and myEta is valid
+    int idx = threadIdx.x + y * C;
+    if (threadIdx.x < C && idx < len) { lse = myExp<T>(myEta - etaMax); }
+  } else {
+    for (int x = threadIdx.x; x < C; x += BX) {
+      int idx = x + y * C;
+      if (x < C && idx < len) { lse += myExp<T>(in[idx] - etaMax); }
+    }
+  }
+  T tmpLse = WarpRed(shm.warpStore[threadIdx.y]).Sum(lse);
+  if (threadIdx.x == 0) { shm.sh_val[threadIdx.y] = etaMax + myLog<T>(tmpLse); }
+  __syncthreads();
+  lse = shm.sh_val[threadIdx.y];
+  __syncthreads();
+
+  /*
+   * Phase 3: Compute derivatives dL/dZ = P - delta_y
+   * P is the softmax distribution, delta_y the kronecker delta for the class of
+   * label y If we getDerivative=false, dZ will just contain P, which might be
+   * useful
+   */
+
+  if (C <= BX) {  // this means one block covers a column and myEta is valid
+    int idx = threadIdx.x + y * C;
+    if (threadIdx.x < C && idx < len) {
+      dZ[idx] = (myExp<T>(myEta - lse) - (getDerivative ? (threadIdx.x == label) : T(0)));
+    }
+  } else {
+    for (int x = threadIdx.x; x < C; x += BX) {
+      int idx = x + y * C;
+      if (x < C && idx < len) {
+        T logP  = in[idx] - lse;
+        dZ[idx] = (myExp<T>(logP) - (getDerivative ? (x == label) : T(0)));
+      }
+    }
+  }
+
+  if (!getDerivative)  // no need to continue, lossval will be undefined
+    return;
+
+  T lossVal = 0;
+  if (delta) { lossVal = (lse - eta_y) / N; }
+
+  /*
+   * Phase 4: accumulate loss value
+   */
+  T blockSum = BlockRed(shm.blockStore).Sum(lossVal);
+  if (threadIdx.x == 0 && threadIdx.y == 0) { raft::myAtomicAdd(out, blockSum); }
+}
+
+template <typename T>
+void launchLogsoftmax(
+  T* loss_val, T* dldZ, const T* Z, const T* labels, int C, int N, cudaStream_t stream)
+{
+  RAFT_CUDA_TRY(cudaMemsetAsync(loss_val, 0, sizeof(T), stream));
+  raft::interruptible::synchronize(stream);
+  if (C <= 4) {
+    dim3 bs(4, 64);
+    dim3 gs(ceildiv(N, 64));
+    logSoftmaxKernel<T, 4, 64><<<gs, bs, 0, stream>>>(loss_val, dldZ, Z, labels, C, N);
+  } else if (C <= 8) {
+    dim3 bs(8, 32);
+    dim3 gs(ceildiv(N, 32));
+    logSoftmaxKernel<T, 8, 32><<<gs, bs, 0, stream>>>(loss_val, dldZ, Z, labels, C, N);
+  } else if (C <= 16) {
+    dim3 bs(16, 16);
+    dim3 gs(ceildiv(N, 16));
+    logSoftmaxKernel<T, 16, 16><<<gs, bs, 0, stream>>>(loss_val, dldZ, Z, labels, C, N);
+  } else {
+    dim3 bs(32, 8);
+    dim3 gs(ceildiv(N, 8));
+    logSoftmaxKernel<T, 32, 8><<<gs, bs, 0, stream>>>(loss_val, dldZ, Z, labels, C, N);
+  }
+  RAFT_CUDA_TRY(cudaPeekAtLastError());
+}
+
+template <typename T>
+struct Softmax : QNLinearBase<T, Softmax<T>> {
+  typedef QNLinearBase<T, Softmax<T>> Super;
+
+  Softmax(const raft::handle_t& handle, int D, int C, bool has_bias) : Super(handle, D, C, has_bias)
+  {
+  }
+
+  inline void getLossAndDZ(T* loss_val,
+                           SimpleDenseMat<T>& Z,
+                           const SimpleVec<T>& y,
+                           cudaStream_t stream)
+  {
+    launchLogsoftmax(loss_val, Z.data, Z.data, y.data, Z.m, Z.n, stream);
+  }
+
+  inline T gradNorm(const SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream)
+  {
+    return nrmMax(grad, dev_scalar, stream);
+  }
+};
+
+};  // namespace  raft::solver::quasi_newton::detail::objectives

--- a/cpp/include/raft/solver/detail/qn/qn_decision.cuh
+++ b/cpp/include/raft/solver/detail/qn/qn_decision.cuh
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "objectives/base.cuh"
+#include "objectives/linear.cuh"
+#include "objectives/logistic.cuh"
+#include "objectives/regularizer.cuh"
+#include "objectives/softmax.cuh"
+#include "objectives/hinge.cuh"
+#include "qn_solvers.cuh"
+#include "qn_util.cuh"
+
+#include <raft/solver/solver_types.hpp>
+#include <raft/matrix/math.cuh>
+#include <rmm/device_uvector.hpp>
+
+namespace  raft::solver::quasi_newton::detail {
+
+template <typename T>
+void linear_decision_function(const raft::handle_t& handle,
+                                 const qn_params& pams,
+                                 SimpleMat<T>& X,
+                                 int C,
+                                 T* params,
+                                 T* scores,
+                                 cudaStream_t stream) {
+  // NOTE: While gtests pass X as row-major, and python API passes X as
+  // col-major, no extensive testing has been done to ensure that
+  // this function works correctly for both input types
+  int n_targets = qn_is_classification(pams.loss) && C == 2 ? 1 : C;
+  LinearDims dims(n_targets, X.n, pams.fit_intercept);
+  SimpleDenseMat<T> W(params, n_targets, dims.dims);
+  SimpleDenseMat<T> Z(scores, n_targets, X.m);
+  linearFwd(handle, Z, X, W, stream);
+}
+};  // namespace  raft::solver::quasi_newton::detail

--- a/cpp/include/raft/solver/detail/qn/qn_linesearch.cuh
+++ b/cpp/include/raft/solver/detail/qn/qn_linesearch.cuh
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/core/logger.hpp>
+#include "qn_util.cuh"
+
+/*
+ * Linesearch functions
+ */
+
+namespace  raft::solver::quasi_newton::detail {
+
+template <typename T>
+struct LSProjectedStep {
+  typedef SimpleVec<T> Vector;
+  struct op_pstep {
+    T step;
+    op_pstep(const T s) : step(s) {}
+
+    HDI T operator()(const T xp, const T drt, const T pg) const
+    {
+      T xi = xp == 0 ? -pg : xp;
+      return project_orth(xp + step * drt, xi);
+    }
+  };
+
+  void operator()(const T step,
+                  Vector& x,
+                  const Vector& drt,
+                  const Vector& xp,
+                  const Vector& pgrad,
+                  cudaStream_t stream) const
+  {
+    op_pstep pstep(step);
+    x.assign_ternary(xp, drt, pgrad, pstep, stream);
+  }
+};
+
+template <typename T>
+inline bool ls_success(const LBFGSParam<T>& param,
+                       const T fx_init,
+                       const T dg_init,
+                       const T fx,
+                       const T dg_test,
+                       const T step,
+                       const SimpleVec<T>& grad,
+                       const SimpleVec<T>& drt,
+                       T* width,
+                       T* dev_scalar,
+                       cudaStream_t stream)
+{
+  if (fx > fx_init + step * dg_test) {
+    *width = param.ls_dec;
+  } else {
+    // Armijo condition is met
+    if (param.linesearch == LBFGS_LS_BT_ARMIJO) return true;
+
+    const T dg = dot(grad, drt, dev_scalar, stream);
+    if (dg < param.wolfe * dg_init) {
+      *width = param.ls_inc;
+    } else {
+      // Regular Wolfe condition is met
+      if (param.linesearch == LBFGS_LS_BT_WOLFE) return true;
+
+      if (dg > -param.wolfe * dg_init) {
+        *width = param.ls_dec;
+      } else {
+        // Strong Wolfe condition is met
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Backtracking linesearch
+ *
+ * \param param        LBFGS parameters
+ * \param f            A function object such that `f(x, grad)` returns the
+ *                     objective function value at `x`, and overwrites `grad`
+ *                     with the gradient.
+ * \param fx           In: The objective function value at the current point.
+ *                     Out: The function value at the new point.
+ * \param x            Out: The new point moved to.
+ * \param grad         In: The current gradient vector.
+ *                     Out: The gradient at the new point.
+ * \param step         In: The initial step length.
+ *                     Out: The calculated step length.
+ * \param drt          The current moving direction.
+ * \param xp           The current point.
+ * \param dev_scalar   Device pointer to workspace of at least 1
+ * \param stream Device pointer to workspace of at least 1
+ */
+template <typename T, typename Function>
+LINE_SEARCH_RETCODE ls_backtrack(const LBFGSParam<T>& param,
+                                 Function& f,
+                                 T& fx,
+                                 SimpleVec<T>& x,
+                                 SimpleVec<T>& grad,
+                                 T& step,
+                                 const SimpleVec<T>& drt,
+                                 const SimpleVec<T>& xp,
+                                 T* dev_scalar,
+                                 cudaStream_t stream)
+{
+  // Check the value of step
+  if (step <= T(0)) return LS_INVALID_STEP;
+
+  // Save the function value at the current x
+  const T fx_init = fx;
+  // Projection of gradient on the search direction
+  const T dg_init = dot(grad, drt, dev_scalar, stream);
+  // Make sure d points to a descent direction
+  if (dg_init > 0) return LS_INVALID_DIR;
+
+  const T dg_test = param.ftol * dg_init;
+  T width;
+
+  RAFT_LOG_TRACE("Starting line search fx_init=%f, dg_init=%f", fx_init, dg_init);
+
+  int iter;
+  for (iter = 0; iter < param.max_linesearch; iter++) {
+    // x_{k+1} = x_k + step * d_k
+    x.axpy(step, drt, xp, stream);
+    // Evaluate this candidate
+    fx = f(x, grad, dev_scalar, stream);
+    RAFT_LOG_TRACE("Line search iter %d, fx=%f", iter, fx);
+    // if (is_success(fx_init, dg_init, fx, dg_test, step, grad, drt, &width))
+    if (ls_success(
+          param, fx_init, dg_init, fx, dg_test, step, grad, drt, &width, dev_scalar, stream))
+      return LS_SUCCESS;
+
+    if (step < param.min_step) return LS_INVALID_STEP_MIN;
+
+    if (step > param.max_step) return LS_INVALID_STEP_MAX;
+
+    step *= width;
+  }
+  return LS_MAX_ITERS_REACHED;
+}
+
+template <typename T, typename Function>
+LINE_SEARCH_RETCODE ls_backtrack_projected(const LBFGSParam<T>& param,
+                                           Function& f,
+                                           T& fx,
+                                           SimpleVec<T>& x,
+                                           SimpleVec<T>& grad,
+                                           const SimpleVec<T>& pseudo_grad,
+                                           T& step,
+                                           const SimpleVec<T>& drt,
+                                           const SimpleVec<T>& xp,
+                                           T l1_penalty,
+                                           T* dev_scalar,
+                                           cudaStream_t stream)
+{
+  LSProjectedStep<T> lsstep;
+
+  // Check the value of step
+  if (step <= T(0)) return LS_INVALID_STEP;
+
+  // Save the function value at the current x
+  const T fx_init = fx;
+  // Projection of gradient on the search direction
+  const T dg_init = dot(pseudo_grad, drt, dev_scalar, stream);
+  // Make sure d points to a descent direction
+  if (dg_init > 0) return LS_INVALID_DIR;
+
+  const T dg_test = param.ftol * dg_init;
+  T width;
+
+  int iter;
+  for (iter = 0; iter < param.max_linesearch; iter++) {
+    // x_{k+1} = proj_orth(x_k + step * d_k)
+    lsstep(step, x, drt, xp, pseudo_grad, stream);
+    // evaluates fx with l1 term, but only grad of the loss term
+    fx = f(x, grad, dev_scalar, stream);
+
+    // if (is_success(fx_init, dg_init, fx, dg_test, step, pseudo_grad, drt,
+    // &width))
+    if (ls_success(
+          param, fx_init, dg_init, fx, dg_test, step, pseudo_grad, drt, &width, dev_scalar, stream))
+      return LS_SUCCESS;
+
+    if (step < param.min_step) return LS_INVALID_STEP_MIN;
+
+    if (step > param.max_step) return LS_INVALID_STEP_MAX;
+
+    step *= width;
+  }
+  return LS_MAX_ITERS_REACHED;
+}
+
+};  // namespace  raft::solver::quasi_newton::detail

--- a/cpp/include/raft/solver/detail/qn/qn_solvers.cuh
+++ b/cpp/include/raft/solver/detail/qn/qn_solvers.cuh
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+/*
+ * This file contains implementations of two popular Quasi-Newton methods:
+ * - Limited-memory Broyden Fletcher Goldfarb Shanno (L-BFGS) [Nocedal, Wright -
+ * Numerical Optimization (1999)]
+ * - Orthant-wise limited-memory quasi-newton (OWL-QN) [Andrew, Gao - ICML 2007]
+ *   https://www.microsoft.com/en-us/research/publication/scalable-training-of-l1-regularized-log-linear-models/
+ *
+ * L-BFGS is a classical method to solve unconstrained optimization problems of
+ * differentiable multi-variate functions f: R^D \mapsto R, i.e. it solves
+ *
+ * \min_{x \in R^D} f(x)
+ *
+ * iteratively by building up a m-dimensional (inverse) Hessian approximation.
+ *
+ * OWL-QN is an extension of L-BFGS that is specifically designed to optimize
+ * functions of the form
+ *
+ * f(x) + \lambda * \sum_i |x_i|,
+ *
+ * i.e. functions with an l1 penalty, by leveraging that |z| is differentiable
+ * when restricted to an orthant.
+ *
+ */
+
+#include "qn_linesearch.cuh"
+#include "qn_util.cuh"
+#include "simple_mat.cuh"
+#include <raft/core/logger.hpp>
+#include <raft/util/cuda_utils.cuh>
+#include <rmm/device_uvector.hpp>
+
+namespace  raft::solver::quasi_newton::detail {
+
+// TODO better way to deal with alignment? Smaller aligne possible?
+constexpr size_t qn_align = 256;
+
+template <typename T>
+inline size_t lbfgs_workspace_size(const LBFGSParam<T>& param, const int n)
+{
+  size_t mat_size = raft::alignTo<size_t>(sizeof(T) * param.m * n, qn_align);
+  size_t vec_size = raft::alignTo<size_t>(sizeof(T) * n, qn_align);
+  return 2 * mat_size + 4 * vec_size + qn_align;
+}
+
+template <typename T>
+inline size_t owlqn_workspace_size(const LBFGSParam<T>& param, const int n)
+{
+  size_t vec_size = raft::alignTo<size_t>(sizeof(T) * n, qn_align);
+  return lbfgs_workspace_size(param, n) + vec_size;
+}
+
+template <typename T>
+inline bool update_and_check(const char* solver,
+                             const LBFGSParam<T>& param,
+                             int iter,
+                             LINE_SEARCH_RETCODE lsret,
+                             T& fx,
+                             T& fxp,
+                             const T& gnorm,
+                             ML::SimpleVec<T>& x,
+                             ML::SimpleVec<T>& xp,
+                             ML::SimpleVec<T>& grad,
+                             ML::SimpleVec<T>& gradp,
+                             std::vector<T>& fx_hist,
+                             T* dev_scalar,
+                             OPT_RETCODE& outcode,
+                             cudaStream_t stream)
+{
+  bool stop      = false;
+  bool converged = false;
+  bool isLsValid = !isnan(fx) && !isinf(fx);
+  // Linesearch may fail to converge, but still come closer to the solution;
+  // if that is not the case, let `check_convergence` ("insufficient change")
+  // below terminate the loop.
+  bool isLsNonCritical = lsret == LS_INVALID_STEP_MIN || lsret == LS_MAX_ITERS_REACHED;
+  // If the error is not critical, check that the target function does not grow.
+  // This shouldn't really happen, but weird things can happen if the convergence
+  // thresholds are too small.
+  bool isLsInDoubt = isLsValid && fx <= fxp + param.ftol && isLsNonCritical;
+  bool isLsSuccess = lsret == LS_SUCCESS || isLsInDoubt;
+
+  RAFT_LOG_TRACE("%s iteration %d, fx=%f", solver, iter, fx);
+
+  // if the target is at least finite, we can check the convergence
+  if (isLsValid) converged = check_convergence(param, iter, fx, gnorm, fx_hist);
+
+  if (!isLsSuccess && !converged) {
+    RAFT_LOG_WARN(
+      "%s line search failed (code %d); stopping at the last valid step", solver, lsret);
+    outcode = OPT_LS_FAILED;
+    stop    = true;
+  } else if (!isLsValid) {
+    RAFT_LOG_ERROR(
+      "%s error fx=%f at iteration %d; stopping at the last valid step", solver, fx, iter);
+    outcode = OPT_NUMERIC_ERROR;
+    stop    = true;
+  } else if (converged) {
+    RAFT_LOG_DEBUG("%s converged", solver);
+    outcode = OPT_SUCCESS;
+    stop    = true;
+  } else if (isLsInDoubt && fx + param.ftol >= fxp) {
+    // If a non-critical error has happened during the line search, check if the target
+    // is improved at least a bit. Otherwise, stop to avoid spinning till the iteration limit.
+    RAFT_LOG_WARN(
+      "%s stopped, because the line search failed to advance (step delta = %f)", solver, fx - fxp);
+    outcode = OPT_LS_FAILED;
+    stop    = true;
+  }
+
+  // if lineseach wasn't successful, undo the update.
+  if (!isLsSuccess || !isLsValid) {
+    fx = fxp;
+    x.copy_async(xp, stream);
+    grad.copy_async(gradp, stream);
+  }
+
+  return stop;
+}
+
+template <typename T, typename Function>
+inline OPT_RETCODE min_lbfgs(const LBFGSParam<T>& param,
+                             Function& f,              // function to minimize
+                             SimpleVec<T>& x,          // initial point, holds result
+                             T& fx,                    // output function value
+                             int* k,                   // output iterations
+                             SimpleVec<T>& workspace,  // scratch space
+                             cudaStream_t stream,
+                             int verbosity = 0)
+{
+  int n                    = x.len;
+  const int workspace_size = lbfgs_workspace_size(param, n);
+  ASSERT(workspace.len >= workspace_size, "LBFGS: workspace insufficient");
+
+  // SETUP WORKSPACE
+  size_t mat_size = raft::alignTo<size_t>(sizeof(T) * param.m * n, qn_align);
+  size_t vec_size = raft::alignTo<size_t>(sizeof(T) * n, qn_align);
+  T* p_ws         = workspace.data;
+  SimpleDenseMat<T> S(p_ws, n, param.m);
+  p_ws += mat_size;
+  SimpleDenseMat<T> Y(p_ws, n, param.m);
+  p_ws += mat_size;
+  SimpleVec<T> xp(p_ws, n);
+  p_ws += vec_size;
+  SimpleVec<T> grad(p_ws, n);
+  p_ws += vec_size;
+  SimpleVec<T> gradp(p_ws, n);
+  p_ws += vec_size;
+  SimpleVec<T> drt(p_ws, n);
+  p_ws += vec_size;
+  T* dev_scalar = p_ws;
+
+  SimpleVec<T> svec, yvec;  // mask vectors
+
+  std::vector<T> ys(param.m);
+  std::vector<T> alpha(param.m);
+  std::vector<T> fx_hist(param.past > 0 ? param.past : 0);
+
+  *k = 0;
+  ML::Logger::get().setLevel(verbosity);
+  RAFT_LOG_DEBUG("Running L-BFGS");
+
+  // Evaluate function and compute gradient
+  fx      = f(x, grad, dev_scalar, stream);
+  T gnorm = f.gradNorm(grad, dev_scalar, stream);
+
+  if (param.past > 0) fx_hist[0] = fx;
+
+  // Early exit if the initial x is already a minimizer
+  if (check_convergence(param, *k, fx, gnorm, fx_hist)) {
+    RAFT_LOG_DEBUG("Initial solution fulfills optimality condition.");
+    return OPT_SUCCESS;
+  }
+
+  // Initial direction
+  drt.ax(-1.0, grad, stream);
+
+  // Initial step
+  T step = T(1.0) / nrm2(drt, dev_scalar, stream);
+  T fxp  = fx;
+
+  *k        = 1;
+  int end   = 0;
+  int n_vec = 0;  // number of vector updates made in lbfgs_search_dir
+  OPT_RETCODE retcode;
+  LINE_SEARCH_RETCODE lsret;
+  for (; *k <= param.max_iterations; (*k)++) {
+    // Save the curent x and gradient
+    xp.copy_async(x, stream);
+    gradp.copy_async(grad, stream);
+    fxp = fx;
+
+    // Line search to update x, fx and gradient
+    lsret = ls_backtrack(param, f, fx, x, grad, step, drt, xp, dev_scalar, stream);
+    gnorm = f.gradNorm(grad, dev_scalar, stream);
+
+    if (update_and_check("L-BFGS",
+                         param,
+                         *k,
+                         lsret,
+                         fx,
+                         fxp,
+                         gnorm,
+                         x,
+                         xp,
+                         grad,
+                         gradp,
+                         fx_hist,
+                         dev_scalar,
+                         retcode,
+                         stream))
+      return retcode;
+
+    // Update s and y
+    // s_{k+1} = x_{k+1} - x_k
+    // y_{k+1} = g_{k+1} - g_k
+    col_ref(S, svec, end);
+    col_ref(Y, yvec, end);
+    svec.axpy(-1.0, xp, x, stream);
+    yvec.axpy(-1.0, gradp, grad, stream);
+    // drt <- -H * g
+    end = lbfgs_search_dir(
+      param, &n_vec, end, S, Y, grad, svec, yvec, drt, ys, alpha, dev_scalar, stream);
+
+    // step = 1.0 as initial guess
+    step = T(1.0);
+  }
+  RAFT_LOG_WARN("L-BFGS: max iterations reached");
+  return OPT_MAX_ITERS_REACHED;
+}
+
+template <typename T>
+inline void update_pseudo(const SimpleVec<T>& x,
+                          const SimpleVec<T>& grad,
+                          const op_pseudo_grad<T>& pseudo_grad,
+                          const int pg_limit,
+                          SimpleVec<T>& pseudo,
+                          cudaStream_t stream)
+{
+  if (grad.len > pg_limit) {
+    pseudo.copy_async(grad, stream);
+    SimpleVec<T> mask(pseudo.data, pg_limit);
+    mask.assign_binary(x, grad, pseudo_grad, stream);
+  } else {
+    pseudo.assign_binary(x, grad, pseudo_grad, stream);
+  }
+}
+
+template <typename T, typename Function>
+inline OPT_RETCODE min_owlqn(const LBFGSParam<T>& param,
+                             Function& f,
+                             const T l1_penalty,
+                             const int pg_limit,
+                             SimpleVec<T>& x,
+                             T& fx,
+                             int* k,
+                             SimpleVec<T>& workspace,  // scratch space
+                             cudaStream_t stream,
+                             const int verbosity = 0)
+{
+  int n                    = x.len;
+  const int workspace_size = owlqn_workspace_size(param, n);
+  ASSERT(workspace.len >= workspace_size, "LBFGS: workspace insufficient");
+  ASSERT(pg_limit <= n && pg_limit > 0, "OWL-QN: Invalid pseudo grad limit parameter");
+
+  // SETUP WORKSPACE
+  size_t mat_size = raft::alignTo<size_t>(sizeof(T) * param.m * n, qn_align);
+  size_t vec_size = raft::alignTo<size_t>(sizeof(T) * n, qn_align);
+  T* p_ws         = workspace.data;
+  SimpleDenseMat<T> S(p_ws, n, param.m);
+  p_ws += mat_size;
+  SimpleDenseMat<T> Y(p_ws, n, param.m);
+  p_ws += mat_size;
+  SimpleVec<T> xp(p_ws, n);
+  p_ws += vec_size;
+  SimpleVec<T> grad(p_ws, n);
+  p_ws += vec_size;
+  SimpleVec<T> gradp(p_ws, n);
+  p_ws += vec_size;
+  SimpleVec<T> drt(p_ws, n);
+  p_ws += vec_size;
+  SimpleVec<T> pseudo(p_ws, n);
+  p_ws += vec_size;
+  T* dev_scalar = p_ws;
+
+  ML::Logger::get().setLevel(verbosity);
+
+  SimpleVec<T> svec, yvec;  // mask vectors
+
+  std::vector<T> ys(param.m);
+  std::vector<T> alpha(param.m);
+  std::vector<T> fx_hist(param.past > 0 ? param.past : 0);
+
+  op_project<T> project_neg(T(-1.0));
+
+  auto f_wrap = [&f, &l1_penalty, &pg_limit](
+                  SimpleVec<T>& x, SimpleVec<T>& grad, T* dev_scalar, cudaStream_t stream) {
+    T tmp = f(x, grad, dev_scalar, stream);
+    SimpleVec<T> mask(x.data, pg_limit);
+    return tmp + l1_penalty * nrm1(mask, dev_scalar, stream);
+  };
+
+  *k = 0;
+  RAFT_LOG_DEBUG("Running OWL-QN with lambda=%f", l1_penalty);
+
+  // op to compute the pseudo gradients
+  op_pseudo_grad<T> pseudo_grad(l1_penalty);
+
+  fx      = f_wrap(x, grad, dev_scalar,
+              stream);  // fx is loss+regularizer, grad is grad of loss only
+  T gnorm = f.gradNorm(grad, dev_scalar, stream);
+
+  // compute pseudo grad, but don't overwrite grad: used to build H
+  // pseudo.assign_binary(x, grad, pseudo_grad);
+  update_pseudo(x, grad, pseudo_grad, pg_limit, pseudo, stream);
+
+  if (param.past > 0) fx_hist[0] = fx;
+
+  // Early exit if the initial x is already a minimizer
+  if (check_convergence(param, *k, fx, gnorm, fx_hist)) {
+    RAFT_LOG_DEBUG("Initial solution fulfills optimality condition.");
+    return OPT_SUCCESS;
+  }
+
+  // Initial direction
+  drt.ax(-1.0, pseudo, stream);  // using Pseudo gradient here
+  // below should be done for consistency but seems unnecessary
+  // drt.assign_k_ary(project, pseudo, x);
+
+  // Initial step
+  T step = T(1.0) / std::max(T(1), nrm2(drt, dev_scalar, stream));
+  T fxp  = fx;
+
+  int end   = 0;
+  int n_vec = 0;  // number of vector updates made in lbfgs_search_dir
+  OPT_RETCODE retcode;
+  LINE_SEARCH_RETCODE lsret;
+  for ((*k) = 1; (*k) <= param.max_iterations; (*k)++) {
+    // Save the curent x and gradient
+    xp.copy_async(x, stream);
+    gradp.copy_async(grad, stream);
+    fxp = fx;
+
+    // Projected line search to update x, fx and gradient
+    lsret = ls_backtrack_projected(
+      param, f_wrap, fx, x, grad, pseudo, step, drt, xp, l1_penalty, dev_scalar, stream);
+    gnorm = f.gradNorm(grad, dev_scalar, stream);
+
+    if (update_and_check("QWL-QN",
+                         param,
+                         *k,
+                         lsret,
+                         fx,
+                         fxp,
+                         gnorm,
+                         x,
+                         xp,
+                         grad,
+                         gradp,
+                         fx_hist,
+                         dev_scalar,
+                         retcode,
+                         stream))
+      return retcode;
+
+    // recompute pseudo
+    //  pseudo.assign_binary(x, grad, pseudo_grad);
+    update_pseudo(x, grad, pseudo_grad, pg_limit, pseudo, stream);
+
+    // Update s and y - We should only do this if there is no skipping condition
+
+    col_ref(S, svec, end);
+    col_ref(Y, yvec, end);
+    svec.axpy(-1.0, xp, x, stream);
+    yvec.axpy(-1.0, gradp, grad, stream);
+    // drt <- -H * -> pseudo grad <-
+    end = lbfgs_search_dir(
+      param, &n_vec, end, S, Y, pseudo, svec, yvec, drt, ys, alpha, dev_scalar, stream);
+
+    // Project drt onto orthant of -pseudog
+    drt.assign_binary(drt, pseudo, project_neg, stream);
+
+    // step = 1.0 as initial guess
+    step = T(1.0);
+  }
+  RAFT_LOG_WARN("QWL-QN: max iterations reached");
+  return OPT_MAX_ITERS_REACHED;
+}
+/*
+ * Chooses the right algorithm, depending on presence of l1 term
+ */
+template <typename T, typename LossFunction>
+inline int qn_minimize(const raft::handle_t& handle,
+                       SimpleVec<T>& x,
+                       T* fx,
+                       int* num_iters,
+                       LossFunction& loss,
+                       const T l1,
+                       const LBFGSParam<T>& opt_param,
+                       cudaStream_t stream,
+                       const int verbosity = 0)
+{
+  // TODO should the worksapce allocation happen outside?
+  OPT_RETCODE ret;
+  if (l1 == 0.0) {
+    rmm::device_uvector<T> tmp(lbfgs_workspace_size(opt_param, x.len), stream);
+    SimpleVec<T> workspace(tmp.data(), tmp.size());
+
+    ret = min_lbfgs(opt_param,
+                    loss,       // function to minimize
+                    x,          // initial point, holds result
+                    *fx,        // output function value
+                    num_iters,  // output iterations
+                    workspace,  // scratch space
+                    stream,
+                    verbosity);
+
+    RAFT_LOG_DEBUG("L-BFGS Done");
+  } else {
+    // There might not be a better way to deal with dispatching
+    // for the l1 case:
+    // The algorithm explicitely expects a differentiable
+    // function f(x). It takes care of adding and
+    // handling the term l1norm(x) * l1_pen explicitely, i.e.
+    // it needs to evaluate f(x) and its gradient separately
+
+    rmm::device_uvector<T> tmp(owlqn_workspace_size(opt_param, x.len), stream);
+    SimpleVec<T> workspace(tmp.data(), tmp.size());
+
+    ret = min_owlqn(opt_param,
+                    loss,  // function to minimize
+                    l1,
+                    loss.D * loss.C,
+                    x,          // initial point, holds result
+                    *fx,        // output function value
+                    num_iters,  // output iterations
+                    workspace,  // scratch space
+                    stream,
+                    verbosity);
+
+    RAFT_LOG_DEBUG("OWL-QN Done");
+  }
+  if (ret == OPT_MAX_ITERS_REACHED) {
+    RAFT_LOG_WARN(
+      "Maximum iterations reached before solver is converged. To increase "
+      "model accuracy you can increase the number of iterations (max_iter) or "
+      "improve the scaling of the input data.");
+  }
+  return ret;
+}
+
+};  // namespace  raft::solver::quasi_newton::detail

--- a/cpp/include/raft/solver/detail/qn/qn_util.cuh
+++ b/cpp/include/raft/solver/detail/qn/qn_util.cuh
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/core/logger.hpp>
+#include <limits>
+#include <raft/util/cuda_utils.cuh>
+
+namespace  raft::solver::quasi_newton::detail {
+
+
+
+inline bool qn_is_classification(qn_loss_type t)
+{
+  switch (t) {
+    case QN_LOSS_LOGISTIC:
+    case QN_LOSS_SOFTMAX:
+    case QN_LOSS_SVC_L1:
+    case QN_LOSS_SVC_L2: return true;
+    default: return false;
+  }
+}
+
+template <typename T>
+HDI T project_orth(T x, T y) {
+  return x * y <= T(0) ? T(0) : x;
+}
+
+template <typename T>
+inline bool check_convergence(
+  const LBFGSParam<T>& param, const int k, const T fx, const T gnorm, std::vector<T>& fx_hist)
+{
+  // Positive scale factor for the stop condition
+  T fmag = std::max(fx, param.epsilon);
+
+  RAFT_LOG_DEBUG(
+    "%04d: f(x)=%.8f conv.crit=%.8f (gnorm=%.8f, fmag=%.8f)", k, fx, gnorm / fmag, gnorm, fmag);
+  // Convergence test -- gradient
+  if (gnorm <= param.epsilon * fmag) {
+    RAFT_LOG_DEBUG("Converged after %d iterations: f(x)=%.6f", k, fx);
+    return true;
+  }
+  // Convergence test -- objective function value
+  if (param.past > 0) {
+    if (k >= param.past && std::abs(fx_hist[k % param.past] - fx) <= param.delta * fmag) {
+      RAFT_LOG_DEBUG("Insufficient change in objective value");
+      return true;
+    }
+
+    fx_hist[k % param.past] = fx;
+  }
+  return false;
+}
+
+/*
+ * Multiplies a vector g with the inverse hessian approximation, i.e.
+ * drt = - H * g,
+ * e.g. to compute the new search direction for g = \nabla f(x)
+ */
+template <typename T>
+inline int lbfgs_search_dir(const LBFGSParam<T>& param,
+                            int* n_vec,
+                            const int end_prev,
+                            const SimpleDenseMat<T>& S,
+                            const SimpleDenseMat<T>& Y,
+                            const SimpleVec<T>& g,
+                            const SimpleVec<T>& svec,
+                            const SimpleVec<T>& yvec,
+                            SimpleVec<T>& drt,
+                            std::vector<T>& yhist,
+                            std::vector<T>& alpha,
+                            T* dev_scalar,
+                            cudaStream_t stream)
+{
+  SimpleVec<T> sj, yj;  // mask vectors
+  int end = end_prev;
+  // note: update_state assigned svec, yvec to m_s[:,end], m_y[:,end]
+  T ys = dot(svec, yvec, dev_scalar, stream);
+  T yy = dot(yvec, yvec, dev_scalar, stream);
+  RAFT_LOG_TRACE("ys=%e, yy=%e", ys, yy);
+  // Skipping test:
+  if (ys <= std::numeric_limits<T>::epsilon() * yy) {
+    // We can land here for example if yvec == 0 (no change in the gradient,
+    // g_k == g_k+1). That means the Hessian is approximately zero. We cannot
+    // use the QN model to update the search dir, we just continue along the
+    // previous direction.
+    //
+    // See eq (3.9) and Section 6 in "A limited memory algorithm for bound
+    // constrained optimization" Richard H. Byrd, Peihuang Lu, Jorge Nocedal and
+    // Ciyou Zhu Technical Report NAM-08 (1994) NORTHWESTERN UNIVERSITY.
+    //
+    // Alternative condition to skip update is: ys / (-gs) <= epsmch,
+    // (where epsmch = std::numeric_limits<T>::epsilon) given in Section 5 of
+    // "L-BFGS-B Fortran subroutines for large-scale bound constrained
+    // optimization" Ciyou Zhu, Richard H. Byrd, Peihuang Lu and Jorge Nocedal
+    // (1994).
+    RAFT_LOG_DEBUG("L-BFGS WARNING: skipping update step ys=%f, yy=%f", ys, yy);
+    return end;
+  }
+  (*n_vec)++;
+  yhist[end] = ys;
+
+  // Recursive formula to compute d = -H * g
+  drt.ax(-1.0, g, stream);
+  int bound = std::min(param.m, *n_vec);
+  end       = (end + 1) % param.m;
+  int j     = end;
+  for (int i = 0; i < bound; i++) {
+    j = (j + param.m - 1) % param.m;
+    col_ref(S, sj, j);
+    col_ref(Y, yj, j);
+    alpha[j] = dot(sj, drt, dev_scalar, stream) / yhist[j];
+    drt.axpy(-alpha[j], yj, drt, stream);
+  }
+
+  drt.ax(ys / yy, drt, stream);
+
+  for (int i = 0; i < bound; i++) {
+    col_ref(S, sj, j);
+    col_ref(Y, yj, j);
+    T beta = dot(yj, drt, dev_scalar, stream) / yhist[j];
+    drt.axpy((alpha[j] - beta), sj, drt, stream);
+    j = (j + 1) % param.m;
+  }
+
+  return end;
+}
+
+template <typename T>
+HDI T get_pseudo_grad(T x, T dlossx, T C)
+{
+  if (x != 0) { return dlossx + raft::sgn(x) * C; }
+  T dplus = dlossx + C;
+  T dmins = dlossx - C;
+  if (dmins > T(0)) return dmins;
+  if (dplus < T(0)) return dplus;
+  return T(0);
+}
+
+template <typename T>
+struct op_project {
+  T scal;
+  op_project(T s) : scal(s) {}
+
+  HDI T operator()(const T x, const T y) const { return project_orth(x, scal * y); }
+};
+
+template <typename T>
+struct op_pseudo_grad {
+  T l1;
+  op_pseudo_grad(const T lam) : l1(lam) {}
+
+  HDI T operator()(const T x, const T dlossx) const { return get_pseudo_grad(x, dlossx, l1); }
+};
+
+};  // namespace  raft::solver::quasi_newton::detail

--- a/cpp/include/raft/solver/detail/qn/simple_mat.cuh
+++ b/cpp/include/raft/solver/detail/qn/simple_mat.cuh
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "simple_mat/base.hpp"
+#include "simple_mat/dense.hpp"
+#include "simple_mat/sparse.hpp"

--- a/cpp/include/raft/solver/detail/qn/simple_mat/base.hpp
+++ b/cpp/include/raft/solver/detail/qn/simple_mat/base.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <raft/core/handle.hpp>
+#include <raft/core/interruptible.hpp>
+#include <raft/util/cuda_utils.cuh>
+
+namespace raft::solver::detail {
+
+template <typename T>
+struct SimpleDenseMat;
+
+template <typename T>
+struct SimpleMat {
+  int m, n;
+
+  SimpleMat(int m, int n) : m(m), n(n) {}
+
+  void operator=(const SimpleMat<T>& other) = delete;
+
+  virtual void print(std::ostream& oss) const = 0;
+
+  /**
+   * GEMM assigning to C where `this` refers to B.
+   *
+   * ```
+   * C <- alpha * A^transA * (*this)^transB + beta * C
+   * ```
+   */
+  virtual void gemmb(const raft::handle_t& handle,
+                     const T alpha,
+                     const SimpleDenseMat<T>& A,
+                     const bool transA,
+                     const bool transB,
+                     const T beta,
+                     SimpleDenseMat<T>& C,
+                     cudaStream_t stream) const = 0;
+};
+
+};  // namespace raft::solver::detail

--- a/cpp/include/raft/solver/detail/qn/simple_mat/dense.hpp
+++ b/cpp/include/raft/solver/detail/qn/simple_mat/dense.hpp
@@ -1,0 +1,413 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <iostream>
+#include <vector>
+
+#include "base.hpp"
+#include <raft/util/cudart_utils.hpp>
+#include <raft/core/handle.hpp>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/ternary_op.cuh>
+// #TODO: Replace with public header when ready
+#include <raft/linalg/detail/cublas_wrappers.hpp>
+#include <raft/linalg/map_then_reduce.cuh>
+#include <raft/linalg/norm.cuh>
+#include <raft/linalg/unary_op.cuh>
+#include <rmm/device_uvector.hpp>
+
+namespace raft::solver::detail {
+
+enum STORAGE_ORDER { COL_MAJOR = 0, ROW_MAJOR = 1 };
+
+template <typename T>
+struct SimpleDenseMat : SimpleMat<T> {
+  typedef SimpleMat<T> Super;
+  int len;
+  T* data;
+
+  STORAGE_ORDER ord;  // storage order: runtime param for compile time sake
+
+  SimpleDenseMat(STORAGE_ORDER order = COL_MAJOR) : Super(0, 0), data(nullptr), len(0), ord(order)
+  {
+  }
+
+  SimpleDenseMat(T* data, int m, int n, STORAGE_ORDER order = COL_MAJOR)
+    : Super(m, n), data(data), len(m * n), ord(order)
+  {
+  }
+
+  void reset(T* data_, int m_, int n_)
+  {
+    this->m = m_;
+    this->n = n_;
+    data    = data_;
+    len     = m_ * n_;
+  }
+
+  // Implemented GEMM as a static method here to improve readability
+  inline static void gemm(const raft::handle_t& handle,
+                          const T alpha,
+                          const SimpleDenseMat<T>& A,
+                          const bool transA,
+                          const SimpleDenseMat<T>& B,
+                          const bool transB,
+                          const T beta,
+                          SimpleDenseMat<T>& C,
+                          cudaStream_t stream)
+  {
+    int kA = A.n;
+    int kB = B.m;
+
+    if (transA) {
+      ASSERT(A.n == C.m, "GEMM invalid dims: m");
+      kA = A.m;
+    } else {
+      ASSERT(A.m == C.m, "GEMM invalid dims: m");
+    }
+
+    if (transB) {
+      ASSERT(B.m == C.n, "GEMM invalid dims: n");
+      kB = B.n;
+    } else {
+      ASSERT(B.n == C.n, "GEMM invalid dims: n");
+    }
+    ASSERT(kA == kB, "GEMM invalid dims: k");
+
+    if (A.ord == COL_MAJOR && B.ord == COL_MAJOR && C.ord == COL_MAJOR) {
+      // #TODO: Call from public API when ready
+      raft::linalg::detail::cublasgemm(handle.get_cublas_handle(),          // handle
+                                       transA ? CUBLAS_OP_T : CUBLAS_OP_N,  // transA
+                                       transB ? CUBLAS_OP_T : CUBLAS_OP_N,  // transB
+                                       C.m,
+                                       C.n,
+                                       kA,  // dimensions m,n,k
+                                       &alpha,
+                                       A.data,
+                                       A.m,  // lda
+                                       B.data,
+                                       B.m,  // ldb
+                                       &beta,
+                                       C.data,
+                                       C.m,  // ldc,
+                                       stream);
+      return;
+    }
+    if (A.ord == ROW_MAJOR) {
+      const SimpleDenseMat<T> Acm(A.data, A.n, A.m, COL_MAJOR);
+      gemm(handle, alpha, Acm, !transA, B, transB, beta, C, stream);
+      return;
+    }
+    if (B.ord == ROW_MAJOR) {
+      const SimpleDenseMat<T> Bcm(B.data, B.n, B.m, COL_MAJOR);
+      gemm(handle, alpha, A, transA, Bcm, !transB, beta, C, stream);
+      return;
+    }
+    if (C.ord == ROW_MAJOR) {
+      SimpleDenseMat<T> Ccm(C.data, C.n, C.m, COL_MAJOR);
+      gemm(handle, alpha, B, !transB, A, !transA, beta, Ccm, stream);
+      return;
+    }
+  }
+
+  inline void gemmb(const raft::handle_t& handle,
+                    const T alpha,
+                    const SimpleDenseMat<T>& A,
+                    const bool transA,
+                    const bool transB,
+                    const T beta,
+                    SimpleDenseMat<T>& C,
+                    cudaStream_t stream) const override
+  {
+    SimpleDenseMat<T>::gemm(handle, alpha, A, transA, *this, transB, beta, C, stream);
+  }
+
+  /**
+   * GEMM assigning to C where `this` refers to C.
+   *
+   * ```
+   * *this <- alpha * A^transA * B^transB + beta * (*this)
+   * ```
+   */
+  inline void assign_gemm(const raft::handle_t& handle,
+                          const T alpha,
+                          const SimpleDenseMat<T>& A,
+                          const bool transA,
+                          const SimpleMat<T>& B,
+                          const bool transB,
+                          const T beta,
+                          cudaStream_t stream)
+  {
+    B.gemmb(handle, alpha, A, transA, transB, beta, *this, stream);
+  }
+
+  // this = a*x
+  inline void ax(const T a, const SimpleDenseMat<T>& x, cudaStream_t stream)
+  {
+    ASSERT(ord == x.ord, "SimpleDenseMat::ax: Storage orders must match");
+
+    auto scale = [a] __device__(const T x) { return a * x; };
+    raft::linalg::unaryOp(data, x.data, len, scale, stream);
+  }
+
+  // this = a*x + y
+  inline void axpy(const T a,
+                   const SimpleDenseMat<T>& x,
+                   const SimpleDenseMat<T>& y,
+                   cudaStream_t stream)
+  {
+    ASSERT(ord == x.ord, "SimpleDenseMat::axpy: Storage orders must match");
+    ASSERT(ord == y.ord, "SimpleDenseMat::axpy: Storage orders must match");
+
+    auto axpy = [a] __device__(const T x, const T y) { return a * x + y; };
+    raft::linalg::binaryOp(data, x.data, y.data, len, axpy, stream);
+  }
+
+  template <typename Lambda>
+  inline void assign_unary(const SimpleDenseMat<T>& other, Lambda f, cudaStream_t stream)
+  {
+    ASSERT(ord == other.ord, "SimpleDenseMat::assign_unary: Storage orders must match");
+
+    raft::linalg::unaryOp(data, other.data, len, f, stream);
+  }
+
+  template <typename Lambda>
+  inline void assign_binary(const SimpleDenseMat<T>& other1,
+                            const SimpleDenseMat<T>& other2,
+                            Lambda& f,
+                            cudaStream_t stream)
+  {
+    ASSERT(ord == other1.ord, "SimpleDenseMat::assign_binary: Storage orders must match");
+    ASSERT(ord == other2.ord, "SimpleDenseMat::assign_binary: Storage orders must match");
+
+    raft::linalg::binaryOp(data, other1.data, other2.data, len, f, stream);
+  }
+
+  template <typename Lambda>
+  inline void assign_ternary(const SimpleDenseMat<T>& other1,
+                             const SimpleDenseMat<T>& other2,
+                             const SimpleDenseMat<T>& other3,
+                             Lambda& f,
+                             cudaStream_t stream)
+  {
+    ASSERT(ord == other1.ord, "SimpleDenseMat::assign_ternary: Storage orders must match");
+    ASSERT(ord == other2.ord, "SimpleDenseMat::assign_ternary: Storage orders must match");
+    ASSERT(ord == other3.ord, "SimpleDenseMat::assign_ternary: Storage orders must match");
+
+    raft::linalg::ternaryOp(data, other1.data, other2.data, other3.data, len, f, stream);
+  }
+
+  inline void fill(const T val, cudaStream_t stream)
+  {
+    // TODO this reads data unnecessary, though it's mostly used for testing
+    auto f = [val] __device__(const T x) { return val; };
+    raft::linalg::unaryOp(data, data, len, f, stream);
+  }
+
+  inline void copy_async(const SimpleDenseMat<T>& other, cudaStream_t stream)
+  {
+    ASSERT((ord == other.ord) && (this->m == other.m) && (this->n == other.n),
+           "SimpleDenseMat::copy: matrices not compatible");
+
+    RAFT_CUDA_TRY(
+      cudaMemcpyAsync(data, other.data, len * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+  }
+
+  void print(std::ostream& oss) const override { oss << (*this) << std::endl; }
+
+  void operator=(const SimpleDenseMat<T>& other) = delete;
+};
+
+template <typename T>
+struct SimpleVec : SimpleDenseMat<T> {
+  typedef SimpleDenseMat<T> Super;
+
+  SimpleVec(T* data, const int n) : Super(data, n, 1, COL_MAJOR) {}
+  // this = alpha * A * x + beta * this
+  void assign_gemv(const raft::handle_t& handle,
+                   const T alpha,
+                   const SimpleDenseMat<T>& A,
+                   bool transA,
+                   const SimpleVec<T>& x,
+                   const T beta,
+                   cudaStream_t stream)
+  {
+    Super::assign_gemm(handle, alpha, A, transA, x, false, beta, stream);
+  }
+
+  SimpleVec() : Super(COL_MAJOR) {}
+
+  inline void reset(T* new_data, int n) { Super::reset(new_data, n, 1); }
+};
+
+template <typename T>
+inline void col_ref(const SimpleDenseMat<T>& mat, SimpleVec<T>& mask_vec, int c)
+{
+  ASSERT(mat.ord == COL_MAJOR, "col_ref only available for column major mats");
+  T* tmp = &mat.data[mat.m * c];
+  mask_vec.reset(tmp, mat.m);
+}
+
+template <typename T>
+inline void col_slice(const SimpleDenseMat<T>& mat,
+                      SimpleDenseMat<T>& mask_mat,
+                      int c_from,
+                      int c_to)
+{
+  ASSERT(c_from >= 0 && c_from < mat.n, "col_slice: invalid from");
+  ASSERT(c_to >= 0 && c_to <= mat.n, "col_slice: invalid to");
+
+  ASSERT(mat.ord == COL_MAJOR, "col_ref only available for column major mats");
+  ASSERT(mask_mat.ord == COL_MAJOR, "col_ref only available for column major mask");
+  T* tmp = &mat.data[mat.m * c_from];
+  mask_mat.reset(tmp, mat.m, c_to - c_from);
+}
+
+// Reductions such as dot or norm require an additional location in dev mem
+// to hold the result. We don't want to deal with this in the SimpleVec class
+// as it  impedes thread safety and constness
+
+template <typename T>
+inline T dot(const SimpleVec<T>& u, const SimpleVec<T>& v, T* tmp_dev, cudaStream_t stream)
+{
+  auto f = [] __device__(const T x, const T y) { return x * y; };
+  raft::linalg::mapThenSumReduce(tmp_dev, u.len, f, stream, u.data, v.data);
+  T tmp_host;
+  raft::update_host(&tmp_host, tmp_dev, 1, stream);
+
+  raft::interruptible::synchronize(stream);
+  return tmp_host;
+}
+
+template <typename T>
+inline T squaredNorm(const SimpleVec<T>& u, T* tmp_dev, cudaStream_t stream)
+{
+  return dot(u, u, tmp_dev, stream);
+}
+
+template <typename T>
+inline T nrmMax(const SimpleVec<T>& u, T* tmp_dev, cudaStream_t stream)
+{
+  auto f = [] __device__(const T x) { return raft::myAbs<T>(x); };
+  auto r = [] __device__(const T x, const T y) { return raft::myMax<T>(x, y); };
+  raft::linalg::mapThenReduce(tmp_dev, u.len, T(0), f, r, stream, u.data);
+  T tmp_host;
+  raft::update_host(&tmp_host, tmp_dev, 1, stream);
+  raft::interruptible::synchronize(stream);
+  return tmp_host;
+}
+
+template <typename T>
+inline T nrm2(const SimpleVec<T>& u, T* tmp_dev, cudaStream_t stream)
+{
+  return raft::mySqrt<T>(squaredNorm(u, tmp_dev, stream));
+}
+
+template <typename T>
+inline T nrm1(const SimpleVec<T>& u, T* tmp_dev, cudaStream_t stream)
+{
+  raft::linalg::rowNorm(
+    tmp_dev, u.data, u.len, 1, raft::linalg::L1Norm, true, stream, raft::Nop<T>());
+  T tmp_host;
+  raft::update_host(&tmp_host, tmp_dev, 1, stream);
+  raft::interruptible::synchronize(stream);
+  return tmp_host;
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const SimpleVec<T>& v)
+{
+  std::vector<T> out(v.len);
+  raft::update_host(&out[0], v.data, v.len, 0);
+  raft::interruptible::synchronize(rmm::cuda_stream_view());
+  int it = 0;
+  for (; it < v.len - 1;) {
+    os << out[it] << " ";
+    it++;
+  }
+  os << out[it];
+  return os;
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const SimpleDenseMat<T>& mat)
+{
+  os << "ord=" << (mat.ord == COL_MAJOR ? "CM" : "RM") << "\n";
+  std::vector<T> out(mat.len);
+  raft::update_host(&out[0], mat.data, mat.len, rmm::cuda_stream_default);
+  raft::interruptible::synchronize(rmm::cuda_stream_view());
+  if (mat.ord == COL_MAJOR) {
+    for (int r = 0; r < mat.m; r++) {
+      int idx = r;
+      for (int c = 0; c < mat.n - 1; c++) {
+        os << out[idx] << ",";
+        idx += mat.m;
+      }
+      os << out[idx] << std::endl;
+    }
+  } else {
+    for (int c = 0; c < mat.m; c++) {
+      int idx = c * mat.n;
+      for (int r = 0; r < mat.n - 1; r++) {
+        os << out[idx] << ",";
+        idx += 1;
+      }
+      os << out[idx] << std::endl;
+    }
+  }
+
+  return os;
+}
+
+template <typename T>
+struct SimpleVecOwning : SimpleVec<T> {
+  typedef SimpleVec<T> Super;
+  typedef rmm::device_uvector<T> Buffer;
+  Buffer buf;
+
+  SimpleVecOwning() = delete;
+
+  SimpleVecOwning(int n, cudaStream_t stream) : Super(), buf(n, stream)
+  {
+    Super::reset(buf.data(), n);
+  }
+
+  void operator=(const SimpleVec<T>& other) = delete;
+};
+
+template <typename T>
+struct SimpleMatOwning : SimpleDenseMat<T> {
+  typedef SimpleDenseMat<T> Super;
+  typedef rmm::device_uvector<T> Buffer;
+  Buffer buf;
+  using Super::m;
+  using Super::n;
+  using Super::ord;
+
+  SimpleMatOwning() = delete;
+
+  SimpleMatOwning(int m, int n, cudaStream_t stream, STORAGE_ORDER order = COL_MAJOR)
+    : Super(order), buf(m * n, stream)
+  {
+    Super::reset(buf.data(), m, n);
+  }
+
+  void operator=(const SimpleVec<T>& other) = delete;
+};
+
+};  // namespace raft::solver::detail

--- a/cpp/include/raft/solver/detail/qn/simple_mat/sparse.hpp
+++ b/cpp/include/raft/solver/detail/qn/simple_mat/sparse.hpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <iostream>
+#include <vector>
+
+#include "base.hpp"
+#include <raft/util//cudart_utils.hpp>
+#include <raft/core/handle.hpp>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/linalg/ternary_op.cuh>
+
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/map_then_reduce.cuh>
+#include <raft/linalg/norm.cuh>
+#include <raft/linalg/unary_op.cuh>
+#include <raft/sparse/detail/cusparse_wrappers.h>
+#include <rmm/device_uvector.hpp>
+
+#include <raft/sparse/detail/cusparse_wrappers.h>
+
+namespace raft::solver::detail {
+
+/**
+ * Sparse matrix in CSR format.
+ *
+ * Note, we use cuSPARSE to manimulate matrices, and it guarantees:
+ *
+ *  1. row_ids[m] == nnz
+ *  2. cols are sorted within rows.
+ *
+ * However, when the data comes from the outside, we cannot guarantee that.
+ */
+template <typename T>
+struct SimpleSparseMat : SimpleMat<T> {
+  typedef SimpleMat<T> Super;
+  T* values;
+  int* cols;
+  int* row_ids;
+  int nnz;
+
+  SimpleSparseMat() : Super(0, 0), values(nullptr), cols(nullptr), row_ids(nullptr), nnz(0) {}
+
+  SimpleSparseMat(T* values, int* cols, int* row_ids, int nnz, int m, int n)
+    : Super(m, n), values(values), cols(cols), row_ids(row_ids), nnz(nnz)
+  {
+    check_csr(*this, 0);
+  }
+
+  void print(std::ostream& oss) const override { oss << (*this) << std::endl; }
+
+  void operator=(const SimpleSparseMat<T>& other) = delete;
+
+  inline void gemmb(const raft::handle_t& handle,
+                    const T alpha,
+                    const SimpleDenseMat<T>& A,
+                    const bool transA,
+                    const bool transB,
+                    const T beta,
+                    SimpleDenseMat<T>& C,
+                    cudaStream_t stream) const override
+  {
+    const SimpleSparseMat<T>& B = *this;
+    int kA                      = A.n;
+    int kB                      = B.m;
+
+    if (transA) {
+      ASSERT(A.n == C.m, "GEMM invalid dims: m");
+      kA = A.m;
+    } else {
+      ASSERT(A.m == C.m, "GEMM invalid dims: m");
+    }
+
+    if (transB) {
+      ASSERT(B.m == C.n, "GEMM invalid dims: n");
+      kB = B.n;
+    } else {
+      ASSERT(B.n == C.n, "GEMM invalid dims: n");
+    }
+    ASSERT(kA == kB, "GEMM invalid dims: k");
+
+    // matrix C must change the order and be transposed, because we need
+    // to swap arguments A and B in cusparseSpMM.
+    cusparseDnMatDescr_t descrC;
+    auto order = C.ord == COL_MAJOR ? CUSPARSE_ORDER_ROW : CUSPARSE_ORDER_COL;
+    RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsecreatednmat(
+      &descrC, C.n, C.m, order == CUSPARSE_ORDER_COL ? C.n : C.m, C.data, order));
+
+    /*
+      The matrix A must have the same order as the matrix C in the input
+      of function cusparseSpMM (i.e. swapped order w.r.t. original C).
+      To account this requirement, I may need to flip transA (whether to transpose A).
+
+         C   C' rowsC' colsC' ldC'   A  A' rowsA' colsA' ldA'  flipTransA
+         c   r    n      m     m     c  r    n      m     m       x
+         c   r    n      m     m     r  r    m      n     n       o
+         r   c    n      m     n     c  c    m      n     m       o
+         r   c    n      m     n     r  c    n      m     n       x
+
+      where:
+        c/r    - column/row major order
+        A,C    - input to gemmb
+        A', C' - input to cusparseSpMM
+        ldX'   - leading dimension - m or n, depending on order and transX
+     */
+    cusparseDnMatDescr_t descrA;
+    RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsecreatednmat(&descrA,
+                                                                C.ord == A.ord ? A.n : A.m,
+                                                                C.ord == A.ord ? A.m : A.n,
+                                                                A.ord == COL_MAJOR ? A.m : A.n,
+                                                                A.data,
+                                                                order));
+    auto opA =
+      transA ^ (C.ord == A.ord) ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE;
+
+    cusparseSpMatDescr_t descrB;
+    RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsecreatecsr(
+      &descrB, B.m, B.n, B.nnz, B.row_ids, B.cols, B.values));
+    auto opB = transB ? CUSPARSE_OPERATION_NON_TRANSPOSE : CUSPARSE_OPERATION_TRANSPOSE;
+
+    auto alg = order == CUSPARSE_ORDER_COL ? CUSPARSE_SPMM_CSR_ALG1 : CUSPARSE_SPMM_CSR_ALG2;
+
+    size_t bufferSize;
+    RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsespmm_bufferSize(handle.get_cusparse_handle(),
+                                                                    opB,
+                                                                    opA,
+                                                                    &alpha,
+                                                                    descrB,
+                                                                    descrA,
+                                                                    &beta,
+                                                                    descrC,
+                                                                    alg,
+                                                                    &bufferSize,
+                                                                    stream));
+
+    raft::interruptible::synchronize(stream);
+    rmm::device_uvector<T> tmp(bufferSize, stream);
+
+    RAFT_CUSPARSE_TRY(raft::sparse::detail::cusparsespmm(handle.get_cusparse_handle(),
+                                                         opB,
+                                                         opA,
+                                                         &alpha,
+                                                         descrB,
+                                                         descrA,
+                                                         &beta,
+                                                         descrC,
+                                                         alg,
+                                                         tmp.data(),
+                                                         stream));
+
+    RAFT_CUSPARSE_TRY(cusparseDestroyDnMat(descrA));
+    RAFT_CUSPARSE_TRY(cusparseDestroySpMat(descrB));
+    RAFT_CUSPARSE_TRY(cusparseDestroyDnMat(descrC));
+  }
+};
+
+template <typename T>
+inline void check_csr(const SimpleSparseMat<T>& mat, cudaStream_t stream)
+{
+  int row_ids_nnz;
+  raft::update_host(&row_ids_nnz, &mat.row_ids[mat.m], 1, stream);
+  raft::interruptible::synchronize(stream);
+  ASSERT(row_ids_nnz == mat.nnz,
+         "SimpleSparseMat: the size of CSR row_ids array must be `m + 1`, and "
+         "the last element must be equal nnz.");
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const SimpleSparseMat<T>& mat)
+{
+  check_csr(mat, 0);
+  os << "SimpleSparseMat (CSR)"
+     << "\n";
+  std::vector<T> values(mat.nnz);
+  std::vector<int> cols(mat.nnz);
+  std::vector<int> row_ids(mat.m + 1);
+  raft::update_host(&values[0], mat.values, mat.nnz, rmm::cuda_stream_default);
+  raft::update_host(&cols[0], mat.cols, mat.nnz, rmm::cuda_stream_default);
+  raft::update_host(&row_ids[0], mat.row_ids, mat.m + 1, rmm::cuda_stream_default);
+  raft::interruptible::synchronize(rmm::cuda_stream_view());
+
+  int i, row_end = 0;
+  for (int row = 0; row < mat.m; row++) {
+    i       = row_end;
+    row_end = row_ids[row + 1];
+    for (int col = 0; col < mat.n; col++) {
+      if (i >= row_end || col < cols[i]) {
+        os << "0";
+      } else {
+        os << values[i];
+        i++;
+      }
+      if (col < mat.n - 1) os << ",";
+    }
+
+    os << std::endl;
+  }
+
+  return os;
+}
+
+};  // namespace raft::solver::detail

--- a/cpp/include/raft/solver/detail/sgd.cuh
+++ b/cpp/include/raft/solver/detail/sgd.cuh
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) 2018-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "learning_rate.h"
+#include "shuffle.h"
+#include <cuml/solvers/params.hpp>
+#include <functions/hinge.cuh>
+#include <functions/linearReg.cuh>
+#include <functions/logisticReg.cuh>
+#include <glm/preprocess.cuh>
+#include <raft/core/cudart_utils.hpp>
+#include <raft/cuda_utils.cuh>
+#include <raft/linalg/add.cuh>
+#include <raft/linalg/eltwise.cuh>
+#include <raft/linalg/gemv.cuh>
+#include <raft/linalg/norm.cuh>
+#include <raft/linalg/subtract.cuh>
+#include <raft/linalg/unary_op.cuh>
+#include <raft/matrix/math.cuh>
+#include <raft/matrix/matrix.cuh>
+#include <raft/stats/mean.cuh>
+#include <raft/stats/mean_center.cuh>
+#include <rmm/device_uvector.hpp>
+
+namespace raft::solver::detail {
+
+/**
+ * Fits a linear, lasso, and elastic-net regression model using Coordinate Descent solver
+ * @param handle
+ *        Reference of raft::handle_t
+ * @param input
+ *        pointer to an array in column-major format (size of n_rows, n_cols)
+ * @param n_rows
+ *        n_samples or rows in input
+ * @param n_cols
+ *        n_features or columns in X
+ * @param labels
+ *        pointer to an array for labels (size of n_rows)
+ * @param coef
+ *        pointer to an array for coefficients (size of n_cols). This will be filled with
+ * coefficients once the function is executed.
+ * @param intercept
+ *        pointer to a scalar for intercept. This will be filled
+ *        once the function is executed
+ * @param fit_intercept
+ *        boolean parameter to control if the intercept will be fitted or not
+ * @param batch_size
+ *        number of rows in the minibatch
+ * @param epochs
+ *        number of iterations that the solver will run
+ * @param lr_type
+ *        type of the learning rate function (i.e. OPTIMAL, CONSTANT, INVSCALING, ADAPTIVE)
+ * @param eta0
+ *        learning rate for contant lr_type. It's used to calculate learning rate function for other
+ * types of lr_type
+ * @param power_t
+ *        power value in the INVSCALING lr_type
+ * @param loss
+ *        enum to use different loss functions.
+ * @param penalty
+ *        None, L1, L2, or Elastic-net penalty
+ * @param alpha
+ *        alpha value in L1
+ * @param l1_ratio
+ *        ratio of alpha will be used for L1. (1 - l1_ratio) * alpha will be used for L2.
+ * @param shuffle
+ *        boolean parameter to control whether coordinates will be picked randomly or not.
+ * @param tol
+ *        tolerance to stop the solver
+ * @param n_iter_no_change
+ *        solver stops if there is no update greater than tol after n_iter_no_change iterations
+ * @param stream
+ *        cuda stream
+ */
+template <typename math_t>
+void sgdFit(const raft::handle_t& handle,
+            math_t* input,
+            int n_rows,
+            int n_cols,
+            math_t* labels,
+            math_t* coef,
+            math_t* intercept,
+            bool fit_intercept,
+            int batch_size,
+            int epochs,
+            ML::lr_type lr_type,
+            math_t eta0,
+            math_t power_t,
+            ML::loss_funct loss,
+            Functions::penalty penalty,
+            math_t alpha,
+            math_t l1_ratio,
+            bool shuffle,
+            math_t tol,
+            int n_iter_no_change,
+            cudaStream_t stream)
+{
+  ASSERT(n_cols > 0, "Parameter n_cols: number of columns cannot be less than one");
+  ASSERT(n_rows > 1, "Parameter n_rows: number of rows cannot be less than two");
+
+  cublasHandle_t cublas_handle = handle.get_cublas_handle();
+
+  rmm::device_uvector<math_t> mu_input(0, stream);
+  rmm::device_uvector<math_t> mu_labels(0, stream);
+  rmm::device_uvector<math_t> norm2_input(0, stream);
+
+  if (fit_intercept) {
+    mu_input.resize(n_cols, stream);
+    mu_labels.resize(1, stream);
+
+    GLM::preProcessData(handle,
+                        input,
+                        n_rows,
+                        n_cols,
+                        labels,
+                        intercept,
+                        mu_input.data(),
+                        mu_labels.data(),
+                        norm2_input.data(),
+                        fit_intercept,
+                        false);
+  }
+
+  rmm::device_uvector<math_t> grads(n_cols, stream);
+  rmm::device_uvector<int> indices(batch_size, stream);
+  rmm::device_uvector<math_t> input_batch(batch_size * n_cols, stream);
+  rmm::device_uvector<math_t> labels_batch(batch_size, stream);
+  rmm::device_scalar<math_t> loss_value(stream);
+
+  math_t prev_loss_value = math_t(0);
+  math_t curr_loss_value = math_t(0);
+
+  std::vector<int> rand_indices(n_rows);
+  std::mt19937 g(rand());
+  initShuffle(rand_indices, g);
+
+  math_t t             = math_t(1);
+  math_t learning_rate = math_t(0);
+  if (lr_type == ML::lr_type::ADAPTIVE) {
+    learning_rate = eta0;
+  } else if (lr_type == ML::lr_type::OPTIMAL) {
+    eta0 = calOptimalInit(alpha);
+  }
+
+  int n_iter_no_change_curr = 0;
+
+  for (int i = 0; i < epochs; i++) {
+    int cbs = 0;
+    int j   = 0;
+
+    if (i > 0 && shuffle) { Solver::shuffle(rand_indices, g); }
+
+    while (j < n_rows) {
+      if ((j + batch_size) > n_rows) {
+        cbs = n_rows - j;
+      } else {
+        cbs = batch_size;
+      }
+
+      if (cbs == 0) break;
+
+      raft::update_device(indices.data(), &rand_indices[j], cbs, stream);
+      raft::matrix::copyRows(
+        input, n_rows, n_cols, input_batch.data(), indices.data(), cbs, stream);
+      raft::matrix::copyRows(labels, n_rows, 1, labels_batch.data(), indices.data(), cbs, stream);
+
+      if (loss == ML::loss_funct::SQRD_LOSS) {
+        Functions::linearRegLossGrads(handle,
+                                      input_batch.data(),
+                                      cbs,
+                                      n_cols,
+                                      labels_batch.data(),
+                                      coef,
+                                      grads.data(),
+                                      penalty,
+                                      alpha,
+                                      l1_ratio,
+                                      stream);
+      } else if (loss == ML::loss_funct::LOG) {
+        Functions::logisticRegLossGrads(handle,
+                                        input_batch.data(),
+                                        cbs,
+                                        n_cols,
+                                        labels_batch.data(),
+                                        coef,
+                                        grads.data(),
+                                        penalty,
+                                        alpha,
+                                        l1_ratio,
+                                        stream);
+      } else if (loss == ML::loss_funct::HINGE) {
+        Functions::hingeLossGrads(handle,
+                                  input_batch.data(),
+                                  cbs,
+                                  n_cols,
+                                  labels_batch.data(),
+                                  coef,
+                                  grads.data(),
+                                  penalty,
+                                  alpha,
+                                  l1_ratio,
+                                  stream);
+      } else {
+        ASSERT(false, "sgd.cuh: Other loss functions have not been implemented yet!");
+      }
+
+      if (lr_type != ML::lr_type::ADAPTIVE)
+        learning_rate = calLearningRate(lr_type, eta0, power_t, alpha, t);
+
+      raft::linalg::scalarMultiply(grads.data(), grads.data(), learning_rate, n_cols, stream);
+      raft::linalg::subtract(coef, coef, grads.data(), n_cols, stream);
+
+      j = j + cbs;
+      t = t + 1;
+    }
+
+    if (tol > math_t(0)) {
+      if (loss == ML::loss_funct::SQRD_LOSS) {
+        Functions::linearRegLoss(handle,
+                                 input,
+                                 n_rows,
+                                 n_cols,
+                                 labels,
+                                 coef,
+                                 loss_value.data(),
+                                 penalty,
+                                 alpha,
+                                 l1_ratio,
+                                 stream);
+      } else if (loss == ML::loss_funct::LOG) {
+        Functions::logisticRegLoss(handle,
+                                   input,
+                                   n_rows,
+                                   n_cols,
+                                   labels,
+                                   coef,
+                                   loss_value.data(),
+                                   penalty,
+                                   alpha,
+                                   l1_ratio,
+                                   stream);
+      } else if (loss == ML::loss_funct::HINGE) {
+        Functions::hingeLoss(handle,
+                             input,
+                             n_rows,
+                             n_cols,
+                             labels,
+                             coef,
+                             loss_value.data(),
+                             penalty,
+                             alpha,
+                             l1_ratio,
+                             stream);
+      }
+
+      raft::update_host(&curr_loss_value, loss_value.data(), 1, stream);
+      handle.sync_stream(stream);
+
+      if (i > 0) {
+        if (curr_loss_value > (prev_loss_value - tol)) {
+          n_iter_no_change_curr = n_iter_no_change_curr + 1;
+          if (n_iter_no_change_curr > n_iter_no_change) {
+            if (lr_type == ML::lr_type::ADAPTIVE && learning_rate > math_t(1e-6)) {
+              learning_rate         = learning_rate / math_t(5);
+              n_iter_no_change_curr = 0;
+            } else {
+              break;
+            }
+          }
+        } else {
+          n_iter_no_change_curr = 0;
+        }
+      }
+
+      prev_loss_value = curr_loss_value;
+    }
+  }
+
+  if (fit_intercept) {
+    GLM::postProcessData(handle,
+                         input,
+                         n_rows,
+                         n_cols,
+                         labels,
+                         coef,
+                         intercept,
+                         mu_input.data(),
+                         mu_labels.data(),
+                         norm2_input.data(),
+                         fit_intercept,
+                         false);
+  } else {
+    *intercept = math_t(0);
+  }
+}
+
+/**
+ * Make predictions
+ * @param handle
+ *        Reference of raft::handle_t
+ * @param input
+ *        pointer to an array in column-major format (size of n_rows, n_cols)
+ * @param n_rows
+ *        n_samples or rows in input
+ * @param n_cols
+ *        n_features or columns in X
+ * @param coef
+ *        pointer to an array for coefficients (size of n_cols). Calculated in cdFit function.
+ * @param intercept
+ *        intercept value calculated in cdFit function
+ * @param preds
+ *        pointer to an array for predictions (size of n_rows). This will be fitted once functions
+ * is executed.
+ * @param loss
+ *        enum to use different loss functions. Only linear regression loss functions is supported
+ * right now.
+ * @param stream
+ *        cuda stream
+ */
+template <typename math_t>
+void sgdPredict(const raft::handle_t& handle,
+                const math_t* input,
+                int n_rows,
+                int n_cols,
+                const math_t* coef,
+                math_t intercept,
+                math_t* preds,
+                ML::loss_funct loss,
+                cudaStream_t stream)
+{
+  ASSERT(n_cols > 0, "Parameter n_cols: number of columns cannot be less than one");
+  ASSERT(n_rows > 1, "Parameter n_rows: number of rows cannot be less than two");
+
+  if (loss == ML::loss_funct::SQRD_LOSS) {
+    Functions::linearRegH(handle, input, n_rows, n_cols, coef, preds, intercept, stream);
+  } else if (loss == ML::loss_funct::LOG) {
+    Functions::logisticRegH(handle, input, n_rows, n_cols, coef, preds, intercept, stream);
+  } else if (loss == ML::loss_funct::HINGE) {
+    Functions::hingeH(handle, input, n_rows, n_cols, coef, preds, intercept, stream);
+  }
+}
+
+/**
+ * Make binary classifications
+ * @param handle
+ *        Reference of raft::handle_t
+ * @param input
+ *        pointer to an array in column-major format (size of n_rows, n_cols)
+ * @param n_rows
+ *        n_samples or rows in input
+ * @param n_cols
+ *        n_features or columns in X
+ * @param coef
+ *        pointer to an array for coefficients (size of n_cols). Calculated in cdFit function.
+ * @param intercept
+ *        intercept value calculated in cdFit function
+ * @param preds
+ *        pointer to an array for predictions (size of n_rows). This will be fitted once functions
+ * is executed.
+ * @param loss
+ *        enum to use different loss functions. Only linear regression loss functions is supported
+ * right now.
+ * @param stream
+ *        cuda stream
+ */
+template <typename math_t>
+void sgdPredictBinaryClass(const raft::handle_t& handle,
+                           const math_t* input,
+                           int n_rows,
+                           int n_cols,
+                           const math_t* coef,
+                           math_t intercept,
+                           math_t* preds,
+                           ML::loss_funct loss,
+                           cudaStream_t stream)
+{
+  sgdPredict(handle, input, n_rows, n_cols, coef, intercept, preds, loss, stream);
+
+  math_t scalar = math_t(1);
+  if (loss == ML::loss_funct::SQRD_LOSS || loss == ML::loss_funct::LOG) {
+    raft::linalg::unaryOp(
+      preds,
+      preds,
+      n_rows,
+      [scalar] __device__(math_t in) {
+        if (in >= math_t(0.5))
+          return math_t(1);
+        else
+          return math_t(0);
+      },
+      stream);
+  } else if (loss == ML::loss_funct::HINGE) {
+    raft::linalg::unaryOp(
+      preds,
+      preds,
+      n_rows,
+      [scalar] __device__(math_t in) {
+        if (in >= math_t(0.0))
+          return math_t(1);
+        else
+          return math_t(0);
+      },
+      stream);
+  }
+}
+
+};  // namespace raft::solver::detail

--- a/cpp/include/raft/solver/detail/shuffle.h
+++ b/cpp/include/raft/solver/detail/shuffle.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2018-2021, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <random>
+
+namespace raft::solver::detail {
+
+template <typename math_t>
+void initShuffle(std::vector<math_t>& rand_indices, std::mt19937& g, math_t random_state = 0)
+{
+  g.seed((int)random_state);
+  for (std::size_t i = 0; i < rand_indices.size(); ++i)
+    rand_indices[i] = i;
+}
+
+template <typename math_t>
+void shuffle(std::vector<math_t>& rand_indices, std::mt19937& g)
+{
+  std::shuffle(rand_indices.begin(), rand_indices.end(), g);
+}
+
+};  // namespace raft::solver::detail

--- a/cpp/include/raft/solver/gradient_descent.cuh
+++ b/cpp/include/raft/solver/gradient_descent.cuh
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/solver/detail/sgd.cuh>
+
+namespace raft::solver::gradient_descent {
+
+}

--- a/cpp/include/raft/solver/least_angle_regression.cuh
+++ b/cpp/include/raft/solver/least_angle_regression.cuh
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/solver/detail/lars.cuh>
+
+namespace raft::solver::least_angle_regression {
+
+}

--- a/cpp/include/raft/solver/quasi_newton.cuh
+++ b/cpp/include/raft/solver/quasi_newton.cuh
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/solver/detail/qn/objectives/base.cuh>
+#include <raft/solver/detail/qn/objectives/hinge.cuh>
+#include <raft/solver/detail/qn/objectives/linear.cuh>
+#include <raft/solver/detail/qn/objectives/logistic.cuh>
+#include <raft/solver/detail/qn/objectives/regularizer.cuh>
+#include <raft/solver/detail/qn/objectives/softmax.cuh>
+
+#include <raft/solver/solver_types.hpp>
+#include <raft/solver/detail/qn/qn.cuh>
+
+namespace raft::solver::quasi_newton {
+
+    using raft::solver::quasi_newton::detail::objectives::AbsLoss;
+    using raft::solver::quasi_newton::detail::objectives::HingeLoss;
+    using raft::solver::quasi_newton::detail::objectives::LogisticLoss;
+    using raft::solver::quasi_newton::detail::objectives::LinearDims;
+    using raft::solver::quasi_newton::detail::objectives::SqHingeLoss;
+    using raft::solver::quasi_newton::detail::objectives::SqEpsInsHingeLoss;
+    using raft::solver::quasi_newton::detail::objectives::EpsInsHingeLoss;
+    using raft::solver::quasi_newton::detail::LBFGSParam
+
+    /**
+     *
+     * @tparam T
+     * @tparam Loss
+     * @tparam Reg
+     */
+    template <typename T, class Loss, class Reg>
+    class RegularizedQN : public detail::objectives::RegularizedQN<T, Loss, Reg> {
+        RegularizedQN(Loss* loss, Reg* reg): detail::objectives::RegularizedQN(loss, reg) {}
+    };
+
+    /**
+     *
+     * @tparam T
+     * @tparam Loss
+     */
+    template <typename T, class Loss>
+    struct QNLinearBase : detail::objectives::QNLinearBase<T, Loss> {
+        QNLinearBase(const raft::handle_t &handle, int D, int C, bool fit_intercept)
+                : detail::objectives::QNLinearBase<T, Loss>(C, D, fit_intercept) {}
+    }
+
+
+        using raft::solver::quasi_newton::detail::objectives::Softmax;
+
+    using raft::solver::quasi_newton::detail::objectives::QNWithData;
+    using raft::solver::quasi_newton::detail::objectives::QuasiNewtonBase;
+
+    template <typename T, typename LossFunction>
+    inline int qn_minimize(const raft::handle_t& handle,
+                           T *x,
+                           T* fx,
+                           int* num_iters,
+                           LossFunction& loss,
+                           const T l1,
+                           const detail::LBFGSParam<T>& opt_param) {
+
+    }
+
+}

--- a/cpp/include/raft/solver/solver_types.hpp
+++ b/cpp/include/raft/solver/solver_types.hpp
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+
+
+namespace raft::solver {
+
+    enum lr_type {
+        OPTIMAL,
+        CONSTANT,
+        INVSCALING,
+        ADAPTIVE,
+    };
+
+    enum loss_funct {
+        SQRD_LOSS,
+        HINGE,
+        LOG,
+    };
+
+    enum penalty { NONE, L1, L2, ELASTICNET };
+
+/** Loss function types supported by the Quasi-Newton solvers. */
+    enum qn_loss_type {
+        /** Logistic classification.
+         *  Expected target: {0, 1}.
+         */
+        QN_LOSS_LOGISTIC = 0,
+        /** L2 regression.
+         *  Expected target: R.
+         */
+        QN_LOSS_SQUARED = 1,
+        /** Softmax classification..
+         *  Expected target: {0, 1, ...}.
+         */
+        QN_LOSS_SOFTMAX = 2,
+        /** Hinge.
+         *  Expected target: {0, 1}.
+         */
+        QN_LOSS_HINGE = 3,
+        /** Squared-hinge.
+         *  Expected target: {0, 1}.
+         */
+        QN_LOSS_SQUARED_HINGE = 4,
+        /** Epsilon-insensitive.
+         *  Expected target: R.
+         */
+        QN_LOSS_EPS_INS_HINGE = 5,
+        /** Epsilon-insensitive-squared.
+         *  Expected target: R.
+         */
+        QN_LOSS_SQ_EPS_INS_HINGE = 6,
+        /** L1 regression.
+         *  Expected target: R.
+         */
+        QN_LOSS_ABS = 7,
+        /** Someone forgot to set the loss type! */
+        QN_LOSS_UNKNOWN = 99
+    };
+
+    struct qn_params {
+        /** Loss type. */
+        qn_loss_type loss;
+        /** Regularization: L1 component. */
+        double penalty_l1;
+        /** Regularization: L2 component. */
+        double penalty_l2;
+        /** Convergence criteria: the threshold on the gradient. */
+        double grad_tol;
+        /** Convergence criteria: the threshold on the function change. */
+        double change_tol;
+        /** Maximum number of iterations. */
+        int max_iter;
+        /** Maximum number of linesearch (inner loop) iterations. */
+        int linesearch_max_iter;
+        /** Number of vectors approximating the hessian (l-bfgs). */
+        int lbfgs_memory;
+        /** Triggers extra output when greater than zero. */
+        int verbose;
+        /** Whether to fit the bias term. */
+        bool fit_intercept;
+        /**
+         * Whether to divide the L1 and L2 regularization parameters by the sample size.
+         *
+         * Note, the defined QN loss functions normally are scaled for the sample size,
+         * e.g. the average across the data rows is calculated.
+         * Enabling `penalty_normalized` makes this solver's behavior compatible to those solvers,
+         * which do not scale the loss functions (like sklearn.LogisticRegression()).
+         */
+        bool penalty_normalized;
+
+qn_params()
+    : loss(QN_LOSS_UNKNOWN),
+      penalty_l1(0),
+      penalty_l2(0),
+      grad_tol(1e-4),
+      change_tol(1e-5),
+      max_iter(1000),
+      linesearch_max_iter(50),
+      lbfgs_memory(5),
+      verbose(0),
+      fit_intercept(true),
+      penalty_normalized(true) {}
+};
+
+
+    enum class LarsFitStatus { kOk, kCollinear, kError, kStop };
+
+
+    namespace quasi_newton {
+
+        enum LINE_SEARCH_ALGORITHM {
+            LBFGS_LS_BT_ARMIJO       = 1,
+            LBFGS_LS_BT              = 2,  // Default. Alias for Wolfe
+            LBFGS_LS_BT_WOLFE        = 2,
+            LBFGS_LS_BT_STRONG_WOLFE = 3
+        };
+
+        enum LINE_SEARCH_RETCODE {
+            LS_SUCCESS           = 0,
+            LS_INVALID_STEP_MIN  = 1,
+            LS_INVALID_STEP_MAX  = 2,
+            LS_MAX_ITERS_REACHED = 3,
+            LS_INVALID_DIR       = 4,
+            LS_INVALID_STEP      = 5
+        };
+
+        enum OPT_RETCODE {
+            OPT_SUCCESS           = 0,
+            OPT_NUMERIC_ERROR     = 1,
+            OPT_LS_FAILED         = 2,
+            OPT_MAX_ITERS_REACHED = 3,
+            OPT_INVALID_ARGS      = 4
+        };
+
+        template <typename T = double>
+        class LBFGSParam {
+        public:
+            int m;      // lbfgs memory limit
+            T epsilon;  // controls convergence
+            int past;   // lookback for function value based convergence test
+            T delta;    // controls fun val based conv test
+            int max_iterations;
+            int linesearch;  // see enum above
+            int max_linesearch;
+            T min_step;  // min. allowed step length
+            T max_step;  // max. allowed step length
+            T ftol;      // line  search tolerance
+            T wolfe;     // wolfe parameter
+            T ls_dec;    // line search decrease factor
+            T ls_inc;    // line search increase factor
+
+        public:
+            LBFGSParam()
+            {
+                m              = 6;
+                epsilon        = T(1e-5);
+                past           = 0;
+                delta          = T(0);
+                max_iterations = 0;
+                linesearch     = LBFGS_LS_BT_ARMIJO;
+                max_linesearch = 20;
+                min_step       = T(1e-20);
+                max_step       = T(1e+20);
+                ftol           = T(1e-4);
+                wolfe          = T(0.9);
+                ls_dec         = T(0.5);
+                ls_inc         = T(2.1);
+            }
+
+            explicit LBFGSParam(const qn_params& pams) : LBFGSParam()
+            {
+                m       = pams.lbfgs_memory;
+                epsilon = T(pams.grad_tol);
+                // sometimes even number works better - to detect zig-zags;
+                past           = pams.change_tol > 0 ? 10 : 0;
+                delta          = T(pams.change_tol);
+                max_iterations = pams.max_iter;
+                max_linesearch = pams.linesearch_max_iter;
+                ftol           = pams.change_tol > 0 ? T(pams.change_tol * 0.1) : T(1e-4);
+            }
+
+            inline int check_param() const
+            {  // TODO exceptions
+                int ret = 1;
+                if (m <= 0) return ret;
+                ret++;
+                if (epsilon <= 0) return ret;
+                ret++;
+                if (past < 0) return ret;
+                ret++;
+                if (delta < 0) return ret;
+                ret++;
+                if (max_iterations < 0) return ret;
+                ret++;
+                if (linesearch < LBFGS_LS_BT_ARMIJO || linesearch > LBFGS_LS_BT_STRONG_WOLFE) return ret;
+                ret++;
+                if (max_linesearch <= 0) return ret;
+                ret++;
+                if (min_step < 0) return ret;
+                ret++;
+                if (max_step < min_step) return ret;
+                ret++;
+                if (ftol <= 0 || ftol >= 0.5) return ret;
+                ret++;
+                if (wolfe <= ftol || wolfe >= 1) return ret;
+                ret++;
+                return 0;
+            }
+        };
+
+        struct LinearDims {
+            bool fit_intercept;
+            int C, D, dims, n_param;
+            LinearDims(int C, int D, bool fit_intercept) : C(C), D(D), fit_intercept(fit_intercept)
+            {
+                dims    = D + fit_intercept;
+                n_param = dims * C;
+            }
+        };
+    }
+
+}

--- a/cpp/include/raft/util/cache.cuh
+++ b/cpp/include/raft/util/cache.cuh
@@ -27,7 +27,7 @@
 
 #include <cstddef>
 
-namespace raft::util::cache
+namespace raft::util::cache {
 
   /**
    * @brief Associative cache with least recently used replacement policy.

--- a/cpp/include/raft/util/cache.cuh
+++ b/cpp/include/raft/util/cache.cuh
@@ -18,8 +18,8 @@
 
 #include <cub/cub.cuh>
 
-#include <raft/core/logger.hpp>
 #include <raft/core/interruptible.hpp>
+#include <raft/core/logger.hpp>
 #include <raft/util/cache_util.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
@@ -30,84 +30,84 @@
 
 namespace raft::cache {
 
-  /**
-   * @brief Associative cache with least recently used replacement policy.
-   *
-   * SW managed cache in device memory, for ML algos where we can trade memory
-   * access for computation. The two main functions of this class are the
-   * management of cache indices, and methods to retrieve/store data using the
-   * cache indices.
-   *
-   * The index management can be considered as a hash map<int, int>, where the int
-   * keys are the original vector indices that we want to store, and the values are
-   * the cache location of these vectors. The keys are hashed into a bucket
-   * whose size equals the associativity. These are the cache sets. If a cache
-   * set is full, then new indices are stored by replacing the oldest entries.
-   *
-   * Using this index mapping we implement methods to store and retrive data from
-   * the cache buffer, where a unit of data that we are storing is math_t[n_vec].
-   * For example in SVM we store full columns of the kernel matrix at each cache
-   * entry.
-   *
-   * Note: we should have a look if the index management could be simplified using
-   * concurrent_unordered_map.cuh from cudf. See Issue #914.
-   *
-   * Example usage:
-   * @code{.cpp}
-   *
-   * // An expensive calculation that we want to accelerate with caching:
-   * // we have n keys, and for each key we generate a vector with m elements.
-   * // The keys and the output values are stored in GPU memory.
-   * void calc(int *key, int n, int m, float *out, cudaStream_t stream) {
-   *   for (k=0; k<n; k++) {
-   *     // use key[k] to generate out[i + m*k],  where i=0..m-1
-   *   }
-   * }
-   *
-   * // We assume that our ML algo repeatedly calls calc, and the set of keys have
-   * // an overlap. We will use the cache to avoid repeated calculations.
-   *
-   * // Assume we have raft::handle_t& h, and cudaStream_t stream
-   * Cache<float> cache(h.get_device_allocator(), stream, m);
-   *
-   * // A buffer that we will reuse to store the cache indices.
-   * rmm::device_uvector<int> cache_idx(h.get_device_allocator(), stream, n);
-   *
-   * void cached_calc(int *key, int n, int m, float *out, stream) {
-   *   int n_cached = 0;
-   *
-   *   cache.GetCacheIdxPartitioned(key, n, cache_idx.data(), &n_cached,
-   *                                cudaStream_t stream);
-   *
-   *   // Note: GetCacheIdxPartitioned has reordered the keys so that
-   *   // key[0..n_cached-1] are the keys already in the cache.
-   *   // We collect the corresponding values
-   *   cache.GetVecs(cache_idx.data(), n_cached, out, stream);
-   *
-   *   // Calculate the elements not in the cache
-   *   int non_cached = n - n_cached;
-   *   if (non_cached > 0) {
-   *     int *key_new = key + n_cached;
-   *     int *cache_idx_new = cache_idx.data() + n_cached;
-   *     float *out_new = out + n_cached * m;
-   *     // AssignCacheIdx can permute the keys, therefore it has to come before
-   *     // we call calc.
-   *     // Note: a call to AssignCacheIdx should always be preceded with
-   *     // GetCacheIdxPartitioned, because that initializes the cache_idx_new array
-   *     // with the cache set (hash bucket) that correspond to the keys.
-   *     // The cache idx will be assigned from that cache set.
-   *     cache.AssignCacheIdx(key_new, non_cached, cache_idx_new, stream);
-   *
-   *     calc(key_new, non_cached, m, out_new, stream);
-   *
-   *     // Store the calculated vectors into the cache.
-   *     cache.StoreVecs(out_new, non_cached, non_cached, cache_idx_new, stream);
-   *    }
-   * }
-   * @endcode
-   */
-  template <typename math_t, int associativity = 32>
-  class Cache {
+/**
+ * @brief Associative cache with least recently used replacement policy.
+ *
+ * SW managed cache in device memory, for ML algos where we can trade memory
+ * access for computation. The two main functions of this class are the
+ * management of cache indices, and methods to retrieve/store data using the
+ * cache indices.
+ *
+ * The index management can be considered as a hash map<int, int>, where the int
+ * keys are the original vector indices that we want to store, and the values are
+ * the cache location of these vectors. The keys are hashed into a bucket
+ * whose size equals the associativity. These are the cache sets. If a cache
+ * set is full, then new indices are stored by replacing the oldest entries.
+ *
+ * Using this index mapping we implement methods to store and retrive data from
+ * the cache buffer, where a unit of data that we are storing is math_t[n_vec].
+ * For example in SVM we store full columns of the kernel matrix at each cache
+ * entry.
+ *
+ * Note: we should have a look if the index management could be simplified using
+ * concurrent_unordered_map.cuh from cudf. See Issue #914.
+ *
+ * Example usage:
+ * @code{.cpp}
+ *
+ * // An expensive calculation that we want to accelerate with caching:
+ * // we have n keys, and for each key we generate a vector with m elements.
+ * // The keys and the output values are stored in GPU memory.
+ * void calc(int *key, int n, int m, float *out, cudaStream_t stream) {
+ *   for (k=0; k<n; k++) {
+ *     // use key[k] to generate out[i + m*k],  where i=0..m-1
+ *   }
+ * }
+ *
+ * // We assume that our ML algo repeatedly calls calc, and the set of keys have
+ * // an overlap. We will use the cache to avoid repeated calculations.
+ *
+ * // Assume we have raft::handle_t& h, and cudaStream_t stream
+ * Cache<float> cache(h.get_device_allocator(), stream, m);
+ *
+ * // A buffer that we will reuse to store the cache indices.
+ * rmm::device_uvector<int> cache_idx(h.get_device_allocator(), stream, n);
+ *
+ * void cached_calc(int *key, int n, int m, float *out, stream) {
+ *   int n_cached = 0;
+ *
+ *   cache.GetCacheIdxPartitioned(key, n, cache_idx.data(), &n_cached,
+ *                                cudaStream_t stream);
+ *
+ *   // Note: GetCacheIdxPartitioned has reordered the keys so that
+ *   // key[0..n_cached-1] are the keys already in the cache.
+ *   // We collect the corresponding values
+ *   cache.GetVecs(cache_idx.data(), n_cached, out, stream);
+ *
+ *   // Calculate the elements not in the cache
+ *   int non_cached = n - n_cached;
+ *   if (non_cached > 0) {
+ *     int *key_new = key + n_cached;
+ *     int *cache_idx_new = cache_idx.data() + n_cached;
+ *     float *out_new = out + n_cached * m;
+ *     // AssignCacheIdx can permute the keys, therefore it has to come before
+ *     // we call calc.
+ *     // Note: a call to AssignCacheIdx should always be preceded with
+ *     // GetCacheIdxPartitioned, because that initializes the cache_idx_new array
+ *     // with the cache set (hash bucket) that correspond to the keys.
+ *     // The cache idx will be assigned from that cache set.
+ *     cache.AssignCacheIdx(key_new, non_cached, cache_idx_new, stream);
+ *
+ *     calc(key_new, non_cached, m, out_new, stream);
+ *
+ *     // Store the calculated vectors into the cache.
+ *     cache.StoreVecs(out_new, non_cached, non_cached, cache_idx_new, stream);
+ *    }
+ * }
+ * @endcode
+ */
+template <typename math_t, int associativity = 32>
+class Cache {
  public:
   /**
    * @brief Construct a Cache object
@@ -403,5 +403,4 @@ namespace raft::cache {
     }
   }
 };
-}
-;  // namespace raft::cache
+};  // namespace raft::cache

--- a/cpp/include/raft/util/cache.cuh
+++ b/cpp/include/raft/util/cache.cuh
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cub/cub.cuh>
+
+#include <raft/core/interruptible.hpp>
+#include <raft/util/cache_util.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+#include <rmm/device_scalar.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <cstddef>
+
+namespace raft::util::cache
+
+  /**
+   * @brief Associative cache with least recently used replacement policy.
+   *
+   * SW managed cache in device memory, for ML algos where we can trade memory
+   * access for computation. The two main functions of this class are the
+   * management of cache indices, and methods to retrieve/store data using the
+   * cache indices.
+   *
+   * The index management can be considered as a hash map<int, int>, where the int
+   * keys are the original vector indices that we want to store, and the values are
+   * the cache location of these vectors. The keys are hashed into a bucket
+   * whose size equals the associativity. These are the cache sets. If a cache
+   * set is full, then new indices are stored by replacing the oldest entries.
+   *
+   * Using this index mapping we implement methods to store and retrive data from
+   * the cache buffer, where a unit of data that we are storing is math_t[n_vec].
+   * For example in SVM we store full columns of the kernel matrix at each cache
+   * entry.
+   *
+   * Note: we should have a look if the index management could be simplified using
+   * concurrent_unordered_map.cuh from cudf. See Issue #914.
+   *
+   * Example usage:
+   * @code{.cpp}
+   *
+   * // An expensive calculation that we want to accelerate with caching:
+   * // we have n keys, and for each key we generate a vector with m elements.
+   * // The keys and the output values are stored in GPU memory.
+   * void calc(int *key, int n, int m, float *out, cudaStream_t stream) {
+   *   for (k=0; k<n; k++) {
+   *     // use key[k] to generate out[i + m*k],  where i=0..m-1
+   *   }
+   * }
+   *
+   * // We assume that our ML algo repeatedly calls calc, and the set of keys have
+   * // an overlap. We will use the cache to avoid repeated calculations.
+   *
+   * // Assume we have raft::handle_t& h, and cudaStream_t stream
+   * Cache<float> cache(h.get_device_allocator(), stream, m);
+   *
+   * // A buffer that we will reuse to store the cache indices.
+   * rmm::device_uvector<int> cache_idx(h.get_device_allocator(), stream, n);
+   *
+   * void cached_calc(int *key, int n, int m, float *out, stream) {
+   *   int n_cached = 0;
+   *
+   *   cache.GetCacheIdxPartitioned(key, n, cache_idx.data(), &n_cached,
+   *                                cudaStream_t stream);
+   *
+   *   // Note: GetCacheIdxPartitioned has reordered the keys so that
+   *   // key[0..n_cached-1] are the keys already in the cache.
+   *   // We collect the corresponding values
+   *   cache.GetVecs(cache_idx.data(), n_cached, out, stream);
+   *
+   *   // Calculate the elements not in the cache
+   *   int non_cached = n - n_cached;
+   *   if (non_cached > 0) {
+   *     int *key_new = key + n_cached;
+   *     int *cache_idx_new = cache_idx.data() + n_cached;
+   *     float *out_new = out + n_cached * m;
+   *     // AssignCacheIdx can permute the keys, therefore it has to come before
+   *     // we call calc.
+   *     // Note: a call to AssignCacheIdx should always be preceded with
+   *     // GetCacheIdxPartitioned, because that initializes the cache_idx_new array
+   *     // with the cache set (hash bucket) that correspond to the keys.
+   *     // The cache idx will be assigned from that cache set.
+   *     cache.AssignCacheIdx(key_new, non_cached, cache_idx_new, stream);
+   *
+   *     calc(key_new, non_cached, m, out_new, stream);
+   *
+   *     // Store the calculated vectors into the cache.
+   *     cache.StoreVecs(out_new, non_cached, non_cached, cache_idx_new, stream);
+   *    }
+   * }
+   * @endcode
+   */
+  template <typename math_t, int associativity = 32>
+  class Cache {
+ public:
+  /**
+   * @brief Construct a Cache object
+   *
+   * @tparam math_t type of elements to be cached
+   * @tparam associativity number of vectors in a cache set
+   *
+   * @param stream cuda stream
+   * @param n_vec number of elements in a single vector that is stored in a
+   *   cache entry
+   * @param cache_size in MiB
+   */
+  Cache(cudaStream_t stream, int n_vec, float cache_size = 200)
+    : n_vec(n_vec),
+      cache_size(cache_size),
+      cache(0, stream),
+      cached_keys(0, stream),
+      cache_time(0, stream),
+      is_cached(0, stream),
+      ws_tmp(0, stream),
+      idx_tmp(0, stream),
+      d_num_selected_out(stream),
+      d_temp_storage(0, stream)
+  {
+    ASSERT(n_vec > 0, "Parameter n_vec: shall be larger than zero");
+    ASSERT(associativity > 0, "Associativity shall be larger than zero");
+    ASSERT(cache_size >= 0, "Cache size should not be negative");
+
+    // Calculate how many vectors would fit the cache
+    int n_cache_vecs = (cache_size * 1024 * 1024) / (sizeof(math_t) * n_vec);
+
+    // The available memory shall be enough for at least one cache set
+    if (n_cache_vecs >= associativity) {
+      n_cache_sets = n_cache_vecs / associativity;
+      n_cache_vecs = n_cache_sets * associativity;
+      cache.resize(n_cache_vecs * n_vec, stream);
+      cached_keys.resize(n_cache_vecs, stream);
+      cache_time.resize(n_cache_vecs, stream);
+      RAFT_CUDA_TRY(
+        cudaMemsetAsync(cached_keys.data(), 0, cached_keys.size() * sizeof(int), stream));
+      RAFT_CUDA_TRY(cudaMemsetAsync(cache_time.data(), 0, cache_time.size() * sizeof(int), stream));
+    } else {
+      if (cache_size > 0) {
+        CUML_LOG_WARN(
+          "Warning: not enough memory to cache a single set of "
+          "rows, not using cache");
+      }
+      n_cache_sets = 0;
+      cache_size   = 0;
+    }
+    CUML_LOG_DEBUG(
+      "Creating cache with size=%f MiB, to store %d vectors, in "
+      "%d sets with associativity=%d",
+      cache_size,
+      n_cache_vecs,
+      n_cache_sets,
+      associativity);
+  }
+
+  Cache(const Cache& other) = delete;
+
+  Cache& operator=(const Cache& other) = delete;
+
+  /** @brief Collect cached data into contiguous memory space.
+   *
+   * On exit, the tile array is filled the following way:
+   * out[i + n_vec*k] = cache[i + n_vec * idx[k]]), where i=0..n_vec-1,
+   * k = 0..n-1
+   *
+   * Idx values less than 0 are ignored.
+   *
+   * @param [in] idx cache indices, size [n]
+   * @param [in] n the number of vectors that need to be collected
+   * @param [out] out vectors collected from cache, size [n_vec*n]
+   * @param [in] stream cuda stream
+   */
+  void GetVecs(const int* idx, int n, math_t* out, cudaStream_t stream)
+  {
+    if (n > 0) {
+      get_vecs<<<raft::ceildiv(n * n_vec, TPB), TPB, 0, stream>>>(cache.data(), n_vec, idx, n, out);
+      RAFT_CUDA_TRY(cudaPeekAtLastError());
+    }
+  }
+
+  /** @brief Store vectors of data into the cache.
+   *
+   * Roughly the opposite of GetVecs, but the input vectors can be scattered
+   * in memory. The cache is updated using the following formula:
+   *
+   * cache[i + cache_idx[k]*n_vec] = tile[i + tile_idx[k]*n_vec],
+   * for i=0..n_vec-1, k=0..n-1
+   *
+   * If tile_idx==nullptr, then we assume tile_idx[k] = k.
+   *
+   * Elements within a vector should be contiguous in memory (i.e. column vectors
+   * for column major data storage, or row vectors of row major data).
+   *
+   * @param [in] tile stores the data to be cashed cached, size [n_vec x n_tile]
+   * @param [in] n_tile number of vectors in tile (at least n)
+   * @param [in] n number of vectors that need to be stored in the cache (a subset
+   *   of all the vectors in the tile)
+   * @param [in] cache_idx cache indices for storing the vectors (negative values
+   *   are ignored), size [n]
+   * @param [in] stream cuda stream
+   * @param [in] tile_idx indices of vectors that need to be stored
+   */
+  void StoreVecs(const math_t* tile,
+                 int n_tile,
+                 int n,
+                 int* cache_idx,
+                 cudaStream_t stream,
+                 const int* tile_idx = nullptr)
+  {
+    if (n > 0) {
+      store_vecs<<<raft::ceildiv(n * n_vec, TPB), TPB, 0, stream>>>(
+        tile, n_tile, n_vec, tile_idx, n, cache_idx, cache.data(), cache.size() / n_vec);
+      RAFT_CUDA_TRY(cudaPeekAtLastError());
+    }
+  }
+
+  /** @brief Map a set of keys to cache indices.
+   *
+   * For each k in 0..n-1, if keys[k] is found in the cache, then cache_idx[k]
+   * will tell the corresponding cache idx, and is_cached[k] is set to true.
+   *
+   * If keys[k] is not found in the cache, then is_cached[k] is set to false.
+   * In this case we assign the cache set for keys[k], and cache_idx[k] will
+   * store the cache set.
+   *
+   * @note in order to retrieve the cached vector j=cache_idx[k] from the cache,
+   *  we have to access cache[i + j*n_vec], where i=0..n_vec-1.
+   *
+   * @note: do not use simultaneous GetCacheIdx and AssignCacheIdx
+   *
+   * @param [in] keys device array of keys, size [n]
+   * @param [in] n number of keys
+   * @param [out] cache_idx device array of cache indices corresponding to the
+   *   input keys, size [n]
+   * @param [out] is_cached whether the element is already available in the
+   *   cache, size [n]
+   * @param [in] stream
+   */
+  void GetCacheIdx(int* keys, int n, int* cache_idx, bool* is_cached, cudaStream_t stream)
+  {
+    n_iter++;  // we increase the iteration counter, that is used to time stamp
+    // accessing entries from the cache
+    get_cache_idx<<<raft::ceildiv(n, TPB), TPB, 0, stream>>>(keys,
+                                                             n,
+                                                             cached_keys.data(),
+                                                             n_cache_sets,
+                                                             associativity,
+                                                             cache_time.data(),
+                                                             cache_idx,
+                                                             is_cached,
+                                                             n_iter);
+    RAFT_CUDA_TRY(cudaPeekAtLastError());
+  }
+
+  /** @brief Map a set of keys to cache indices.
+   *
+   * Same as GetCacheIdx, but partitions the keys, and cache_idx arrays in a way
+   * that keys[0..n_cached-1] and cache_idx[0..n_cached-1] store the indices of
+   * vectors that are found in the cache, while keys[n_cached..n-1] are the
+   * indices of vectors that are not found in the cache. For the vectors not
+   * found in the cache, cache_idx[n_cached..n-1] stores the cache set, and this
+   * can be used to call AssignCacheIdx.
+   *
+   * @param [inout] keys device array of keys, size [n]
+   * @param [in] n number of indices
+   * @param [out] cache_idx device array of cache indices corresponding to
+   *   the input keys, size [n]
+   * @param [out] n_cached number of elements that are cached
+   * @param [in] stream cuda stream
+   */
+  void GetCacheIdxPartitioned(int* keys, int n, int* cache_idx, int* n_cached, cudaStream_t stream)
+  {
+    ResizeTmpBuffers(n, stream);
+
+    GetCacheIdx(keys, n, ws_tmp.data(), is_cached.data(), stream);
+
+    // Group cache indices as [already cached, non_cached]
+    cub::DevicePartition::Flagged(d_temp_storage.data(),
+                                  d_temp_storage_size,
+                                  ws_tmp.data(),
+                                  is_cached.data(),
+                                  cache_idx,
+                                  d_num_selected_out.data(),
+                                  n,
+                                  stream);
+
+    raft::update_host(n_cached, d_num_selected_out.data(), 1, stream);
+
+    // Similarily re-group the input indices
+    raft::copy(ws_tmp.data(), keys, n, stream);
+    cub::DevicePartition::Flagged(d_temp_storage.data(),
+                                  d_temp_storage_size,
+                                  ws_tmp.data(),
+                                  is_cached.data(),
+                                  keys,
+                                  d_num_selected_out.data(),
+                                  n,
+                                  stream);
+
+    raft::interruptible::synchronize(stream);
+  }
+
+  /**
+   * @brief Assign cache location to a set of keys.
+   *
+   * Note: call GetCacheIdx first, to get the cache_set assigned to the keys.
+   * Keys that cannot be cached are assigned to -1.
+   *
+   * @param [inout] keys device array of keys, size [n]
+   * @param [in] n number of elements that we want to cache
+   * @param [inout] cidx on entry: cache_set, on exit: assigned cache_idx or -1,
+   *   size[n]
+   * @param [in] stream cuda stream
+   */
+  void AssignCacheIdx(int* keys, int n, int* cidx, cudaStream_t stream)
+  {
+    if (n <= 0) return;
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    d_temp_storage_size,
+                                    cidx,
+                                    ws_tmp.data(),
+                                    keys,
+                                    idx_tmp.data(),
+                                    n,
+                                    0,
+                                    sizeof(int) * 8,
+                                    stream);
+
+    raft::copy(keys, idx_tmp.data(), n, stream);
+
+    // set it to -1
+    RAFT_CUDA_TRY(cudaMemsetAsync(cidx, 255, n * sizeof(int), stream));
+    const int nthreads = associativity <= 32 ? associativity : 32;
+
+    assign_cache_idx<nthreads, associativity><<<n_cache_sets, nthreads, 0, stream>>>(
+      keys, n, ws_tmp.data(), cached_keys.data(), n_cache_sets, cache_time.data(), n_iter, cidx);
+
+    RAFT_CUDA_TRY(cudaPeekAtLastError());
+    if (debug_mode) RAFT_CUDA_TRY(cudaDeviceSynchronize());
+  }
+
+  /** Return approximate cache size in MiB. */
+  float GetSizeInMiB() const { return cache_size; }
+
+  /**
+   * Returns the number of vectors that can be cached.
+   */
+  int GetSize() const { return cached_keys.size(); }
+
+ private:
+  int n_vec;         //!< Number of elements in a cached vector
+  float cache_size;  //!< in MiB
+  int n_cache_sets;  //!< number of cache sets
+
+  const int TPB = 256;  //!< threads per block for kernel launch
+  int n_iter    = 0;    //!< Counter for time stamping cache operation
+
+  bool debug_mode = false;
+
+  rmm::device_uvector<math_t> cache;     //!< The value of cached vectors
+  rmm::device_uvector<int> cached_keys;  //!< Keys stored at each cache loc
+  rmm::device_uvector<int> cache_time;   //!< Time stamp for LRU cache
+
+  // Helper arrays for GetCacheIdx
+  rmm::device_uvector<bool> is_cached;
+  rmm::device_uvector<int> ws_tmp;
+  rmm::device_uvector<int> idx_tmp;
+
+  // Helper arrays for cub
+  rmm::device_scalar<int> d_num_selected_out;
+  rmm::device_uvector<char> d_temp_storage;
+  size_t d_temp_storage_size = 0;
+
+  void ResizeTmpBuffers(int n, cudaStream_t stream)
+  {
+    if (ws_tmp.size() < static_cast<std::size_t>(n)) {
+      ws_tmp.resize(n, stream);
+      is_cached.resize(n, stream);
+      idx_tmp.resize(n, stream);
+      cub::DevicePartition::Flagged(NULL,
+                                    d_temp_storage_size,
+                                    cached_keys.data(),
+                                    is_cached.data(),
+                                    cached_keys.data(),
+                                    d_num_selected_out.data(),
+                                    n,
+                                    stream);
+      d_temp_storage.resize(d_temp_storage_size, stream);
+    }
+  }
+};
+}
+;  // namespace raft::util::cache

--- a/cpp/include/raft/util/cache.cuh
+++ b/cpp/include/raft/util/cache.cuh
@@ -18,6 +18,7 @@
 
 #include <cub/cub.cuh>
 
+#include <raft/core/logger.hpp>
 #include <raft/core/interruptible.hpp>
 #include <raft/util/cache_util.cuh>
 #include <raft/util/cuda_utils.cuh>
@@ -150,14 +151,14 @@ namespace raft::cache {
       RAFT_CUDA_TRY(cudaMemsetAsync(cache_time.data(), 0, cache_time.size() * sizeof(int), stream));
     } else {
       if (cache_size > 0) {
-        CUML_LOG_WARN(
+        RAFT_LOG_WARN(
           "Warning: not enough memory to cache a single set of "
           "rows, not using cache");
       }
       n_cache_sets = 0;
       cache_size   = 0;
     }
-    CUML_LOG_DEBUG(
+    RAFT_LOG_DEBUG(
       "Creating cache with size=%f MiB, to store %d vectors, in "
       "%d sets with associativity=%d",
       cache_size,

--- a/cpp/include/raft/util/cache.cuh
+++ b/cpp/include/raft/util/cache.cuh
@@ -27,7 +27,7 @@
 
 #include <cstddef>
 
-namespace raft::util::cache {
+namespace raft::cache {
 
   /**
    * @brief Associative cache with least recently used replacement policy.
@@ -403,4 +403,4 @@ namespace raft::util::cache {
   }
 };
 }
-;  // namespace raft::util::cache
+;  // namespace raft::cache

--- a/cpp/include/raft/util/fast_int_div.cuh
+++ b/cpp/include/raft/util/fast_int_div.cuh
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/util/cuda_utils.cuh>
+#include <stdint.h>
+
+namespace raft::util {
+
+/**
+ * @brief Perform fast integer division and modulo using a known divisor
+ *
+ * @note This currently only supports 32b signed integers
+ * @todo Extend support for signed divisors
+ * @ref Hacker's Delight, Second Edition, Chapter 10
+ */
+    struct FastIntDiv {
+        /**
+         * @defgroup HostMethods Ctor's that are accessible only from host
+         * @{
+         * @brief Host-only ctor's
+         * @param _d the divisor
+         */
+        FastIntDiv(int _d) : d(_d) { computeScalars(); }
+        FastIntDiv& operator=(int _d)
+        {
+            d = _d;
+            computeScalars();
+            return *this;
+        }
+        /** @} */
+
+        /**
+         * @defgroup DeviceMethods Ctor's which even the device-side can access
+         * @{
+         * @brief host and device ctor's
+         * @param other source object to be copied from
+         */
+        HDI FastIntDiv(const FastIntDiv& other) : d(other.d), m(other.m), p(other.p) {}
+        HDI FastIntDiv& operator=(const FastIntDiv& other)
+        {
+            d = other.d;
+            m = other.m;
+            p = other.p;
+            return *this;
+        }
+        /** @} */
+
+        /** divisor */
+        int d;
+        /** the term 'm' as found in the reference chapter */
+        unsigned m;
+        /** the term 'p' as found in the reference chapter */
+        int p;
+
+    private:
+        void computeScalars()
+        {
+            if (d == 1) {
+                m = 0;
+                p = 1;
+                return;
+            } else if (d < 0) {
+                ASSERT(false, "FastIntDiv: division by negative numbers not supported!");
+            } else if (d == 0) {
+                ASSERT(false, "FastIntDiv: got division by zero!");
+            }
+            int64_t nc = ((1LL << 31) / d) * d - 1;
+            p          = 31;
+            int64_t twoP, rhs;
+            do {
+                ++p;
+                twoP = 1LL << p;
+                rhs  = nc * (d - twoP % d);
+            } while (twoP <= rhs);
+            m = (twoP + d - twoP % d) / d;
+        }
+    };  // struct FastIntDiv
+
+/**
+ * @brief Division overload, so that FastIntDiv can be transparently switched
+ *        to even on device
+ * @param n numerator
+ * @param divisor the denominator
+ * @return the quotient
+ */
+    HDI int operator/(int n, const FastIntDiv& divisor)
+    {
+        if (divisor.d == 1) return n;
+        int ret = (int64_t(divisor.m) * int64_t(n)) >> divisor.p;
+        if (n < 0) ++ret;
+        return ret;
+    }
+
+/**
+ * @brief Modulo overload, so that FastIntDiv can be transparently switched
+ *        to even on device
+ * @param n numerator
+ * @param divisor the denominator
+ * @return the remainder
+ */
+    HDI int operator%(int n, const FastIntDiv& divisor)
+    {
+        int quotient  = n / divisor;
+        int remainder = n - quotient * divisor.d;
+        return remainder;
+    }
+
+};  // namespace raft::util

--- a/cpp/include/raft/util/fast_int_div.cuh
+++ b/cpp/include/raft/util/fast_int_div.cuh
@@ -28,68 +28,68 @@ namespace raft::util {
  * @todo Extend support for signed divisors
  * @ref Hacker's Delight, Second Edition, Chapter 10
  */
-    struct FastIntDiv {
-        /**
-         * @defgroup HostMethods Ctor's that are accessible only from host
-         * @{
-         * @brief Host-only ctor's
-         * @param _d the divisor
-         */
-        FastIntDiv(int _d) : d(_d) { computeScalars(); }
-        FastIntDiv& operator=(int _d)
-        {
-            d = _d;
-            computeScalars();
-            return *this;
-        }
-        /** @} */
+struct FastIntDiv {
+  /**
+   * @defgroup HostMethods Ctor's that are accessible only from host
+   * @{
+   * @brief Host-only ctor's
+   * @param _d the divisor
+   */
+  FastIntDiv(int _d) : d(_d) { computeScalars(); }
+  FastIntDiv& operator=(int _d)
+  {
+    d = _d;
+    computeScalars();
+    return *this;
+  }
+  /** @} */
 
-        /**
-         * @defgroup DeviceMethods Ctor's which even the device-side can access
-         * @{
-         * @brief host and device ctor's
-         * @param other source object to be copied from
-         */
-        HDI FastIntDiv(const FastIntDiv& other) : d(other.d), m(other.m), p(other.p) {}
-        HDI FastIntDiv& operator=(const FastIntDiv& other)
-        {
-            d = other.d;
-            m = other.m;
-            p = other.p;
-            return *this;
-        }
-        /** @} */
+  /**
+   * @defgroup DeviceMethods Ctor's which even the device-side can access
+   * @{
+   * @brief host and device ctor's
+   * @param other source object to be copied from
+   */
+  HDI FastIntDiv(const FastIntDiv& other) : d(other.d), m(other.m), p(other.p) {}
+  HDI FastIntDiv& operator=(const FastIntDiv& other)
+  {
+    d = other.d;
+    m = other.m;
+    p = other.p;
+    return *this;
+  }
+  /** @} */
 
-        /** divisor */
-        int d;
-        /** the term 'm' as found in the reference chapter */
-        unsigned m;
-        /** the term 'p' as found in the reference chapter */
-        int p;
+  /** divisor */
+  int d;
+  /** the term 'm' as found in the reference chapter */
+  unsigned m;
+  /** the term 'p' as found in the reference chapter */
+  int p;
 
-    private:
-        void computeScalars()
-        {
-            if (d == 1) {
-                m = 0;
-                p = 1;
-                return;
-            } else if (d < 0) {
-                ASSERT(false, "FastIntDiv: division by negative numbers not supported!");
-            } else if (d == 0) {
-                ASSERT(false, "FastIntDiv: got division by zero!");
-            }
-            int64_t nc = ((1LL << 31) / d) * d - 1;
-            p          = 31;
-            int64_t twoP, rhs;
-            do {
-                ++p;
-                twoP = 1LL << p;
-                rhs  = nc * (d - twoP % d);
-            } while (twoP <= rhs);
-            m = (twoP + d - twoP % d) / d;
-        }
-    };  // struct FastIntDiv
+ private:
+  void computeScalars()
+  {
+    if (d == 1) {
+      m = 0;
+      p = 1;
+      return;
+    } else if (d < 0) {
+      ASSERT(false, "FastIntDiv: division by negative numbers not supported!");
+    } else if (d == 0) {
+      ASSERT(false, "FastIntDiv: got division by zero!");
+    }
+    int64_t nc = ((1LL << 31) / d) * d - 1;
+    p          = 31;
+    int64_t twoP, rhs;
+    do {
+      ++p;
+      twoP = 1LL << p;
+      rhs  = nc * (d - twoP % d);
+    } while (twoP <= rhs);
+    m = (twoP + d - twoP % d) / d;
+  }
+};  // struct FastIntDiv
 
 /**
  * @brief Division overload, so that FastIntDiv can be transparently switched
@@ -98,13 +98,13 @@ namespace raft::util {
  * @param divisor the denominator
  * @return the quotient
  */
-    HDI int operator/(int n, const FastIntDiv& divisor)
-    {
-        if (divisor.d == 1) return n;
-        int ret = (int64_t(divisor.m) * int64_t(n)) >> divisor.p;
-        if (n < 0) ++ret;
-        return ret;
-    }
+HDI int operator/(int n, const FastIntDiv& divisor)
+{
+  if (divisor.d == 1) return n;
+  int ret = (int64_t(divisor.m) * int64_t(n)) >> divisor.p;
+  if (n < 0) ++ret;
+  return ret;
+}
 
 /**
  * @brief Modulo overload, so that FastIntDiv can be transparently switched
@@ -113,11 +113,11 @@ namespace raft::util {
  * @param divisor the denominator
  * @return the remainder
  */
-    HDI int operator%(int n, const FastIntDiv& divisor)
-    {
-        int quotient  = n / divisor;
-        int remainder = n - quotient * divisor.d;
-        return remainder;
-    }
+HDI int operator%(int n, const FastIntDiv& divisor)
+{
+  int quotient  = n / divisor;
+  int remainder = n - quotient * divisor.d;
+  return remainder;
+}
 
 };  // namespace raft::util

--- a/cpp/include/raft/util/fast_int_div.cuh
+++ b/cpp/include/raft/util/fast_int_div.cuh
@@ -23,10 +23,10 @@ namespace raft::util {
 
 /**
  * @brief Perform fast integer division and modulo using a known divisor
+ * From Hacker's Delight, Second Edition, Chapter 10
  *
  * @note This currently only supports 32b signed integers
  * @todo Extend support for signed divisors
- * @ref Hacker's Delight, Second Edition, Chapter 10
  */
 struct FastIntDiv {
   /**

--- a/cpp/src/distance/specializations/detail/kernels/gram_matrix_base_double.cu
+++ b/cpp/src/distance/specializations/detail/kernels/gram_matrix_base_double.cu
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/distance/detail/kernels/gram_matrix.cuh>
+
+template class raft::distance::kernels::detail::GramMatrixBase<double>;

--- a/cpp/src/distance/specializations/detail/kernels/gram_matrix_base_float.cu
+++ b/cpp/src/distance/specializations/detail/kernels/gram_matrix_base_float.cu
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/distance/detail/kernels/gram_matrix.cuh>
+
+template class raft::distance::kernels::detail::GramMatrixBase<float>;

--- a/cpp/src/distance/specializations/detail/kernels/polynomial_kernel_double_int.cu
+++ b/cpp/src/distance/specializations/detail/kernels/polynomial_kernel_double_int.cu
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/distance/detail/kernels/kernel_matrices.cuh>
+
+template class raft::distance::kernels::detail::PolynomalKernel<double, int>;

--- a/cpp/src/distance/specializations/detail/kernels/polynomial_kernel_double_int.cu
+++ b/cpp/src/distance/specializations/detail/kernels/polynomial_kernel_double_int.cu
@@ -16,4 +16,4 @@
 
 #include <raft/distance/detail/kernels/kernel_matrices.cuh>
 
-template class raft::distance::kernels::detail::PolynomalKernel<double, int>;
+template class raft::distance::kernels::detail::PolynomialKernel<double, int>;

--- a/cpp/src/distance/specializations/detail/kernels/polynomial_kernel_float_int.cu
+++ b/cpp/src/distance/specializations/detail/kernels/polynomial_kernel_float_int.cu
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/distance/detail/kernels/kernel_matrices.cuh>
+
+template class raft::distance::kernels::detail::PolynomalKernel<float, int>;

--- a/cpp/src/distance/specializations/detail/kernels/polynomial_kernel_float_int.cu
+++ b/cpp/src/distance/specializations/detail/kernels/polynomial_kernel_float_int.cu
@@ -16,4 +16,4 @@
 
 #include <raft/distance/detail/kernels/kernel_matrices.cuh>
 
-template class raft::distance::kernels::detail::PolynomalKernel<float, int>;
+template class raft::distance::kernels::detail::PolynomialKernel<float, int>;

--- a/cpp/src/distance/specializations/detail/kernels/rbf_kernel_double.cu
+++ b/cpp/src/distance/specializations/detail/kernels/rbf_kernel_double.cu
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/distance/detail/kernels/kernel_matrices.cuh>
+
+template class raft::distance::kernels::detail::RBFKernel<double>;

--- a/cpp/src/distance/specializations/detail/kernels/rbf_kernel_float.cu
+++ b/cpp/src/distance/specializations/detail/kernels/rbf_kernel_float.cu
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/distance/detail/kernels/kernel_matrices.cuh>
+
+template class raft::distance::kernels::detail::RBFKernel<float>;

--- a/cpp/src/distance/specializations/detail/kernels/tanh_kernel_double.cu
+++ b/cpp/src/distance/specializations/detail/kernels/tanh_kernel_double.cu
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/distance/detail/kernels/kernel_matrices.cuh>
+
+template class raft::distance::kernels::detail::TanhKernel<double>;

--- a/cpp/src/distance/specializations/detail/kernels/tanh_kernel_float.cu
+++ b/cpp/src/distance/specializations/detail/kernels/tanh_kernel_float.cu
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <raft/distance/detail/kernels/kernel_matrices.cuh>
+
+template class raft::distance::kernels::detail::TanhKernel<float>;

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -116,6 +116,7 @@ if(BUILD_TESTS)
             test/distance/dist_minkowski.cu
             test/distance/dist_russell_rao.cu
             test/distance/fused_l2_nn.cu
+            test/distance/gram.cu
             OPTIONAL DIST
     )
 

--- a/cpp/test/distance/gram.cu
+++ b/cpp/test/distance/gram.cu
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined RAFT_DISTANCE_COMPILED
+#include <raft/distance/specializations.hpp>
+#endif
+
+#include "test_utils.h"
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <raft/distance/distance_types.hpp>
+#include <raft/distance/kernels.cuh>
+#include <raft/random/rng.cuh>
+#include <raft/util/cuda_utils.cuh>
+#include <raft/util/cudart_utils.hpp>
+#include <rmm/device_uvector.hpp>
+
+namespace raft::distance::kernels {
+
+// Get the offset of element [i,k].
+HDI int get_offset(int i, int k, int ld, bool is_row_major)
+{
+  return is_row_major ? i * ld + k : i + k * ld;
+}
+
+struct GramMatrixInputs {
+  int n1;      // feature vectors in matrix 1
+  int n2;      // featuer vectors in matrix 2
+  int n_cols;  // number of elements in a feature vector
+  bool is_row_major;
+  KernelParams kernel;
+  int ld1;
+  int ld2;
+  int ld_out;
+  // We will generate random input using the dimensions given here.
+  // The reference output is calculated by a custom kernel.
+};
+
+std::ostream& operator<<(std::ostream& os, const GramMatrixInputs& p)
+{
+  std::vector<std::string> kernel_names{"linear", "poly", "rbf", "tanh"};
+  os << "/" << p.n1 << "x" << p.n2 << "x" << p.n_cols << "/"
+     << (p.is_row_major ? "RowMajor/" : "ColMajor/") << kernel_names[p.kernel.kernel] << "/ld_"
+     << p.ld1 << "x" << p.ld2 << "x" << p.ld_out;
+  return os;
+}
+
+const std::vector<GramMatrixInputs> inputs = {
+  {42, 137, 2, false, {KernelType::LINEAR}},
+  {42, 137, 2, true, {KernelType::LINEAR}},
+  {42, 137, 2, false, {KernelType::LINEAR}, 64, 179, 181},
+  {42, 137, 2, true, {KernelType::LINEAR}, 64, 179, 181},
+  {137, 42, 2, false, {KernelType::POLYNOMIAL, 2, 0.5, 2.4}},
+  {137, 42, 2, true, {KernelType::POLYNOMIAL, 2, 0.5, 2.4}},
+  {137, 42, 2, false, {KernelType::POLYNOMIAL, 2, 0.5, 2.4}, 159, 73, 144},
+  {137, 42, 2, true, {KernelType::POLYNOMIAL, 2, 0.5, 2.4}, 159, 73, 144},
+  {42, 137, 2, false, {KernelType::TANH, 0, 0.5, 2.4}},
+  {42, 137, 2, true, {KernelType::TANH, 0, 0.5, 2.4}},
+  {42, 137, 2, false, {KernelType::TANH, 0, 0.5, 2.4}, 64, 155, 49},
+  {42, 137, 2, true, {KernelType::TANH, 0, 0.5, 2.4}, 64, 155, 143},
+  {3, 4, 2, false, {KernelType::RBF, 0, 0.5}},
+  {42, 137, 2, false, {KernelType::RBF, 0, 0.5}},
+  {42, 137, 2, true, {KernelType::RBF, 0, 0.5}},
+  // Distance kernel does not support LD parameter yet.
+  //{42, 137, 2, false, {KernelType::RBF, 0, 0.5}, 64, 155, 49},
+  // {42, 137, 2, true, {KernelType::RBF, 0, 0.5}, 64, 155, 143},
+};
+
+template <typename math_t>
+class GramMatrixTest : public ::testing::TestWithParam<GramMatrixInputs> {
+ protected:
+  GramMatrixTest()
+    : params(GetParam()), stream(0), x1(0, stream), x2(0, stream), gram(0, stream), gram_host(0)
+  {
+    RAFT_CUDA_TRY(cudaStreamCreate(&stream));
+
+    if (params.ld1 == 0) { params.ld1 = params.is_row_major ? params.n_cols : params.n1; }
+    if (params.ld2 == 0) { params.ld2 = params.is_row_major ? params.n_cols : params.n2; }
+    if (params.ld_out == 0) { params.ld_out = params.is_row_major ? params.n2 : params.n1; }
+    // Derive the size of the ouptut from the offset of the last element.
+    size_t size = get_offset(params.n1 - 1, params.n_cols - 1, params.ld1, params.is_row_major) + 1;
+    x1.resize(size, stream);
+    size = get_offset(params.n2 - 1, params.n_cols - 1, params.ld2, params.is_row_major) + 1;
+    x2.resize(size, stream);
+    size = get_offset(params.n1 - 1, params.n2 - 1, params.ld_out, params.is_row_major) + 1;
+
+    gram.resize(size, stream);
+    RAFT_CUDA_TRY(cudaMemsetAsync(gram.data(), 0, gram.size() * sizeof(math_t), stream));
+    gram_host.resize(gram.size());
+    std::fill(gram_host.begin(), gram_host.end(), 0);
+
+    raft::random::Rng r(42137ULL);
+    r.uniform(x1.data(), x1.size(), math_t(0), math_t(1), stream);
+    r.uniform(x2.data(), x2.size(), math_t(0), math_t(1), stream);
+  }
+
+  ~GramMatrixTest() override { RAFT_CUDA_TRY_NO_THROW(cudaStreamDestroy(stream)); }
+
+  // Calculate the Gram matrix on the host.
+  void naiveKernel()
+  {
+    std::vector<math_t> x1_host(x1.size());
+    raft::update_host(x1_host.data(), x1.data(), x1.size(), stream);
+    std::vector<math_t> x2_host(x2.size());
+    raft::update_host(x2_host.data(), x2.data(), x2.size(), stream);
+    handle.sync_stream(stream);
+
+    for (int i = 0; i < params.n1; i++) {
+      for (int j = 0; j < params.n2; j++) {
+        float d = 0;
+        for (int k = 0; k < params.n_cols; k++) {
+          if (params.kernel.kernel == KernelType::RBF) {
+            math_t diff = x1_host[get_offset(i, k, params.ld1, params.is_row_major)] -
+                          x2_host[get_offset(j, k, params.ld2, params.is_row_major)];
+            d += diff * diff;
+          } else {
+            d += x1_host[get_offset(i, k, params.ld1, params.is_row_major)] *
+                 x2_host[get_offset(j, k, params.ld2, params.is_row_major)];
+          }
+        }
+        int idx  = get_offset(i, j, params.ld_out, params.is_row_major);
+        math_t v = 0;
+        switch (params.kernel.kernel) {
+          case (KernelType::LINEAR): gram_host[idx] = d; break;
+          case (KernelType::POLYNOMIAL):
+            v              = params.kernel.gamma * d + params.kernel.coef0;
+            gram_host[idx] = std::pow(v, params.kernel.degree);
+            break;
+          case (KernelType::TANH):
+            gram_host[idx] = std::tanh(params.kernel.gamma * d + params.kernel.coef0);
+            break;
+          case (KernelType::RBF): gram_host[idx] = exp(-params.kernel.gamma * d); break;
+        }
+      }
+    }
+  }
+
+  void runTest()
+  {
+    std::unique_ptr<GramMatrixBase<math_t>> kernel = std::unique_ptr<GramMatrixBase<math_t>>(
+      KernelFactory<math_t>::create(params.kernel, handle.get_cublas_handle()));
+
+    kernel->evaluate(x1.data(),
+                     params.n1,
+                     params.n_cols,
+                     x2.data(),
+                     params.n2,
+                     gram.data(),
+                     params.is_row_major,
+                     stream,
+                     params.ld1,
+                     params.ld2,
+                     params.ld_out);
+    naiveKernel();
+    ASSERT_TRUE(raft::devArrMatchHost(
+      gram_host.data(), gram.data(), gram.size(), raft::CompareApprox<math_t>(1e-6f)));
+  }
+
+  raft::handle_t handle;
+  cudaStream_t stream = 0;
+  GramMatrixInputs params;
+
+  rmm::device_uvector<math_t> x1;
+  rmm::device_uvector<math_t> x2;
+  rmm::device_uvector<math_t> gram;
+  std::vector<math_t> gram_host;
+};
+
+typedef GramMatrixTest<float> GramMatrixTestFloat;
+typedef GramMatrixTest<double> GramMatrixTestDouble;
+
+TEST_P(GramMatrixTestFloat, Gram) { runTest(); }
+
+INSTANTIATE_TEST_SUITE_P(GramMatrixTests, GramMatrixTestFloat, ::testing::ValuesIn(inputs));
+};  // end namespace raft::distance::kernels

--- a/cpp/test/distance/gram.cu
+++ b/cpp/test/distance/gram.cu
@@ -18,7 +18,7 @@
 #include <raft/distance/specializations.hpp>
 #endif
 
-#include "test_utils.h"
+#include "../test_utils.h"
 #include <gtest/gtest.h>
 #include <iostream>
 #include <memory>


### PR DESCRIPTION
We've planned to move these for quite awhile and the codebase has finally been organized in a way that can accep them. The goal here is not to move over entire end-to-end GLM algorithms, but rather just move the underlying solvers (e.g. lgbfs/owl, sgd, cd, smo, lars, etc...) and then continue to clean up and refactor, consolidate and unify their APIs to accept more generic objectives. 