### PR TITLE
Update raft tests to compile with C++17 features enabled

### DIFF
--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -51,6 +51,10 @@ function(ConfigureTest)
             PROPERTIES
             # set target compile options
             INSTALL_RPATH "\$ORIGIN/../../../lib"
+            CXX_STANDARD                        17
+            CXX_STANDARD_REQUIRED               ON
+            CUDA_STANDARD                       17
+            CUDA_STANDARD_REQUIRED              ON
             )
 
     target_compile_options(${TEST_NAME}


### PR DESCRIPTION
The raft tests require C++17 features but doesn't request this compiler mode, so compilation will fail with compilers that default to 11 or 14.

