### PR TITLE
Use new rapids-cmake functionality for rpath handling.

### DIFF
--- a/python/pylibraft/CMakeLists.txt
+++ b/python/pylibraft/CMakeLists.txt
@@ -41,6 +41,8 @@ else()
   set(raft_FOUND OFF)
 endif()
 
+include(rapids-cython)
+
 if(NOT raft_FOUND)
   # TODO: This will not be necessary once we upgrade to CMake 3.22, which will
   # pull in the required languages for the C++ project even if this project
@@ -61,14 +63,17 @@ if(NOT raft_FOUND)
   # When building the C++ libraries from source we must copy
   # libraft_distance.so alongside the pairwise_distance and random Cython libraries
   # TODO: when we have a single 'compiled' raft library, we shouldn't need this
-  install(TARGETS raft_distance_lib DESTINATION pylibraft/distance)
-  install(TARGETS raft_distance_lib DESTINATION pylibraft/random)
+  set(cython_lib_dir pylibraft)
+  install(TARGETS raft_distance_lib DESTINATION ${cython_lib_dir})
 endif()
 
-include(rapids-cython)
 rapids_cython_init()
 
 add_subdirectory(pylibraft/common)
 add_subdirectory(pylibraft/distance)
 add_subdirectory(pylibraft/random)
 add_subdirectory(pylibraft/cluster)
+
+if(DEFINED cython_lib_dir)
+  rapids_cython_add_rpath_entries(TARGET raft PATHS "${cython_lib_dir}")
+endif()

--- a/python/pylibraft/pylibraft/common/CMakeLists.txt
+++ b/python/pylibraft/pylibraft/common/CMakeLists.txt
@@ -21,8 +21,5 @@ rapids_cython_create_modules(
         CXX
         SOURCE_FILES "${cython_sources}"
         LINKED_LIBRARIES "${linked_libraries}"
+        ASSOCIATED_TARGETS raft
         MODULE_PREFIX common_)
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-    set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/pylibraft/pylibraft/distance/CMakeLists.txt
+++ b/python/pylibraft/pylibraft/distance/CMakeLists.txt
@@ -22,8 +22,5 @@ rapids_cython_create_modules(
     CXX
     SOURCE_FILES "${cython_sources}"
     LINKED_LIBRARIES "${linked_libraries}"
+    ASSOCIATED_TARGETS cuml
     MODULE_PREFIX distance_)
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-    set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()

--- a/python/pylibraft/pylibraft/distance/CMakeLists.txt
+++ b/python/pylibraft/pylibraft/distance/CMakeLists.txt
@@ -22,5 +22,5 @@ rapids_cython_create_modules(
     CXX
     SOURCE_FILES "${cython_sources}"
     LINKED_LIBRARIES "${linked_libraries}"
-    ASSOCIATED_TARGETS cuml
+    ASSOCIATED_TARGETS raft
     MODULE_PREFIX distance_)

--- a/python/pylibraft/pylibraft/random/CMakeLists.txt
+++ b/python/pylibraft/pylibraft/random/CMakeLists.txt
@@ -23,5 +23,5 @@ rapids_cython_create_modules(
     CXX
     SOURCE_FILES "${cython_sources}"
     LINKED_LIBRARIES "${linked_libraries}"
-    ASSOCIATED_TARGETS cuml
+    ASSOCIATED_TARGETS raft
     MODULE_PREFIX random_)

--- a/python/pylibraft/pylibraft/random/CMakeLists.txt
+++ b/python/pylibraft/pylibraft/random/CMakeLists.txt
@@ -23,8 +23,5 @@ rapids_cython_create_modules(
     CXX
     SOURCE_FILES "${cython_sources}"
     LINKED_LIBRARIES "${linked_libraries}"
+    ASSOCIATED_TARGETS cuml
     MODULE_PREFIX random_)
-
-foreach(cython_module IN LISTS RAPIDS_CYTHON_CREATED_TARGETS)
-    set_target_properties(${cython_module} PROPERTIES INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../library")
-endforeach()


### PR DESCRIPTION
<!--

Thank you for contributing to RAFT :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
The new functionality creates a single source of truth defining the location at which a library will be, allowing rapids-cmake to handle the necessary relative paths in the RPATH and avoiding the current error-prone approach that requires each CMakeLists.txt to correctly assign the relative path.