### PR TITLE
Fix pylibraft docstring example code

### DIFF
--- a/python/pylibraft/pylibraft/cluster/kmeans.pyx
+++ b/python/pylibraft/pylibraft/cluster/kmeans.pyx
@@ -129,7 +129,9 @@ def compute_new_centroids(X,
 
         new_centroids = cp.empty((n_clusters, n_features), dtype=cp.float32)
 
-        compute_new_centroids(X, centroids, labels, new_centroids, handle=handle)
+        compute_new_centroids(
+            X, centroids, labels, new_centroids, handle=handle
+        )
 
         # pylibraft functions are often asynchronous so the
         # handle needs to be explicitly synchronized

--- a/python/pylibraft/pylibraft/cluster/kmeans.pyx
+++ b/python/pylibraft/pylibraft/cluster/kmeans.pyx
@@ -107,7 +107,7 @@ def compute_new_centroids(X,
         import cupy as cp
 
         from pylibraft.common import Handle
-        from pylibaft.cluster.kmeans import update_centroids
+        from pylibraft.cluster.kmeans import compute_new_centroids
         from pylibraft.distance import fused_l2_nn_argmin
 
         # A single RAFT handle can optionally be reused across
@@ -129,7 +129,7 @@ def compute_new_centroids(X,
 
         new_centroids = cp.empty((n_clusters, n_features), dtype=cp.float32)
 
-        compute_new_centroids(X, centroids, new_centroids, handle=handle)
+        compute_new_centroids(X, centroids, labels, new_centroids, handle=handle)
 
         # pylibraft functions are often asynchronous so the
         # handle needs to be explicitly synchronized

--- a/python/pylibraft/pylibraft/common/cuda.pyx
+++ b/python/pylibraft/pylibraft/common/cuda.pyx
@@ -52,7 +52,7 @@ cdef class Stream:
 
     .. code-block:: python
 
-        from raft.common.cuda import Stream
+        from pylibraft.common.cuda import Stream
         stream = Stream()
         stream.sync()
         del stream  # optional!

--- a/python/pylibraft/pylibraft/distance/fused_l2_nn.pyx
+++ b/python/pylibraft/pylibraft/distance/fused_l2_nn.pyx
@@ -79,7 +79,7 @@ def fused_l2_nn_argmin(X, Y, output, sqrt=True, handle=None):
         import cupy as cp
 
         from pylibraft.common import Handle
-        from pylibraft.distance import fused_l2_nn
+        from pylibraft.distance import fused_l2_nn_argmin
 
         n_samples = 5000
         n_clusters = 5


### PR DESCRIPTION
Fix the pylibraft example code given in the docstrings so that they run without exceptions.