### PR TITLE
Provide memory_type enum

### DIFF
--- a/cpp/include/raft/core/memory_type.hpp
+++ b/cpp/include/raft/core/memory_type.hpp
@@ -16,20 +16,19 @@
 #pragma once
 
 namespace raft {
-enum class memory_type {
-  host,
-  device,
-  managed,
-  pinned
-};
+enum class memory_type { host, device, managed, pinned };
 
-auto constexpr is_device_accessible(memory_type mem_type) {
+auto constexpr is_device_accessible(memory_type mem_type)
+{
   return (mem_type == memory_type::device || mem_type == memory_type::managed);
 }
-auto constexpr is_host_accessible(memory_type mem_type) {
-  return (mem_type == memory_type::host || mem_type == memory_type::managed || mem_type == memory_type::pinned);
+auto constexpr is_host_accessible(memory_type mem_type)
+{
+  return (mem_type == memory_type::host || mem_type == memory_type::managed ||
+          mem_type == memory_type::pinned);
 }
-auto constexpr is_host_device_accessible(memory_type mem_type) {
+auto constexpr is_host_device_accessible(memory_type mem_type)
+{
   return mem_type == memory_type::managed;
 }
 

--- a/cpp/include/raft/core/memory_type.hpp
+++ b/cpp/include/raft/core/memory_type.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace raft {
+enum class memory_type {
+  host,
+  device,
+  managed,
+  pinned
+};
+
+auto constexpr is_device_accessible(memory_type mem_type) {
+  return (mem_type == memory_type::device || mem_type == memory_type::managed);
+}
+auto constexpr is_host_accessible(memory_type mem_type) {
+  return (mem_type == memory_type::host || mem_type == memory_type::managed || mem_type == memory_type::pinned);
+}
+auto constexpr is_host_device_accessible(memory_type mem_type) {
+  return mem_type == memory_type::managed;
+}
+
+}  // end namespace raft

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -98,6 +98,7 @@ if(BUILD_TESTS)
             test/nvtx.cpp
             test/mdarray.cu
             test/mdspan_utils.cu
+            test/memory_type.cpp
             test/span.cpp
             test/span.cu
             test/test.cpp

--- a/cpp/test/memory_type.cpp
+++ b/cpp/test/memory_type.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <raft/core/memory_type.hpp>
+
+namespace raft {
+TEST(MemoryType, IsDeviceAccessible)
+{
+  static_assert(!is_device_accessible(memory_type::host));
+  static_assert(is_device_accessible(memory_type::device));
+  static_assert(is_device_accessible(memory_type::managed));
+  static_assert(!is_device_accessible(memory_type::pinned));
+}
+
+TEST(MemoryType, IsHostAccessible)
+{
+  static_assert(is_host_accessible(memory_type::host));
+  static_assert(!is_host_accessible(memory_type::device));
+  static_assert(is_host_accessible(memory_type::managed));
+  static_assert(is_host_accessible(memory_type::pinned));
+}
+
+TEST(MemoryType, IsHostDeviceAccessible)
+{
+  static_assert(!is_host_device_accessible(memory_type::host));
+  static_assert(!is_host_device_accessible(memory_type::device));
+  static_assert(is_host_device_accessible(memory_type::managed));
+  static_assert(!is_host_device_accessible(memory_type::pinned));
+}
+}  // namespace raft


### PR DESCRIPTION
This PR introduces an enum to specify a memory type (e.g. host, device, managed...). This allows us to provide a template parameter which always indicates a valid memory type, which is extensible for possible future memory types, and which is less verbose than alternatives.

The most serious shortcoming of existing alternatives is the possibility of indicating invalid memory states. E.g. by templating on `is_device` and `is_host`, we introduce the possible state `is_host=false, is_device=false`.