### PR TITLE
Add `except +` to cython extern cdef declarations

### DIFF
--- a/python/pylibraft/pylibraft/cluster/kmeans.pyx
+++ b/python/pylibraft/pylibraft/cluster/kmeans.pyx
@@ -52,7 +52,7 @@ cdef extern from "raft_distance/kmeans.hpp" \
         const double *centroids,
         const int* labels,
         double *new_centroids,
-        double *weight_per_cluster)
+        double *weight_per_cluster) except +
 
     cdef void update_centroids(
         const handle_t& handle,
@@ -64,7 +64,7 @@ cdef extern from "raft_distance/kmeans.hpp" \
         const float *centroids,
         const int* labels,
         float *new_centroids,
-        float *weight_per_cluster)
+        float *weight_per_cluster) except +
 
 
 @auto_sync_handle

--- a/python/pylibraft/pylibraft/distance/fused_l2_nn.pyx
+++ b/python/pylibraft/pylibraft/distance/fused_l2_nn.pyx
@@ -47,7 +47,7 @@ cdef extern from "raft_distance/fused_l2_min_arg.hpp" \
         int m,
         int n,
         int k,
-        bool sqrt)
+        bool sqrt) except +
 
     void fused_l2_nn_min_arg(
         const handle_t &handle,
@@ -57,7 +57,7 @@ cdef extern from "raft_distance/fused_l2_min_arg.hpp" \
         int m,
         int n,
         int k,
-        bool sqrt)
+        bool sqrt) except +
 
 
 @auto_sync_handle

--- a/python/pylibraft/pylibraft/distance/pairwise_distance.pyx
+++ b/python/pylibraft/pylibraft/distance/pairwise_distance.pyx
@@ -49,7 +49,7 @@ cdef extern from "raft_distance/pairwise_distance.hpp" \
                                 int k,
                                 DistanceType metric,
                                 bool isRowMajor,
-                                float metric_arg)
+                                float metric_arg) except +
 
     cdef void pairwise_distance(const handle_t &handle,
                                 double *x,
@@ -60,7 +60,7 @@ cdef extern from "raft_distance/pairwise_distance.hpp" \
                                 int k,
                                 DistanceType metric,
                                 bool isRowMajor,
-                                float metric_arg)
+                                float metric_arg) except +
 
 DISTANCE_TYPES = {
     "l2": DistanceType.L2SqrtUnexpanded,

--- a/python/pylibraft/pylibraft/random/rmat_rectangular_generator.pyx
+++ b/python/pylibraft/pylibraft/random/rmat_rectangular_generator.pyx
@@ -41,7 +41,7 @@ cdef extern from "raft_distance/random/rmat_rectangular_generator.hpp" \
                                    int r_scale,
                                    int c_scale,
                                    int n_edges,
-                                   RngState& r)
+                                   RngState& r) except +
 
     cdef void rmat_rectangular_gen(const handle_t &handle,
                                    int64_t* out,
@@ -51,7 +51,7 @@ cdef extern from "raft_distance/random/rmat_rectangular_generator.hpp" \
                                    int64_t r_scale,
                                    int64_t c_scale,
                                    int64_t n_edges,
-                                   RngState& r)
+                                   RngState& r) except +
 
     cdef void rmat_rectangular_gen(const handle_t &handle,
                                    int* out,

--- a/python/pylibraft/pylibraft/random/rmat_rectangular_generator.pyx
+++ b/python/pylibraft/pylibraft/random/rmat_rectangular_generator.pyx
@@ -61,7 +61,7 @@ cdef extern from "raft_distance/random/rmat_rectangular_generator.hpp" \
                                    int r_scale,
                                    int c_scale,
                                    int n_edges,
-                                   RngState& r)
+                                   RngState& r) except +
 
     cdef void rmat_rectangular_gen(const handle_t &handle,
                                    int64_t* out,
@@ -71,7 +71,7 @@ cdef extern from "raft_distance/random/rmat_rectangular_generator.hpp" \
                                    int64_t r_scale,
                                    int64_t c_scale,
                                    int64_t n_edges,
-                                   RngState& r)
+                                   RngState& r) except +
 
 
 @auto_sync_handle


### PR DESCRIPTION
RAFT is using exceptions for error's, but these weren't always being declared to cython in the `cdef extern` blocks. This means that if the function were to throw an exception, the python program would core dump on an uncaught c++ exception - instead of translating the exception into a python exception.
