### PR TITLE
Remove make_mdspan template for memory_type enum

### DIFF
--- a/cpp/include/raft/core/mdspan.hpp
+++ b/cpp/include/raft/core/mdspan.hpp
@@ -193,7 +193,6 @@ auto make_mdspan(ElementType* ptr, extents<IndexType, Extents...> exts)
   return mdspan<ElementType, decltype(exts), LayoutPolicy, accessor_type>{ptr, exts};
 }
 
-
 /**
  * @brief Create raft::extents to specify dimensionality
  *

--- a/cpp/include/raft/core/mdspan.hpp
+++ b/cpp/include/raft/core/mdspan.hpp
@@ -193,28 +193,6 @@ auto make_mdspan(ElementType* ptr, extents<IndexType, Extents...> exts)
   return mdspan<ElementType, decltype(exts), LayoutPolicy, accessor_type>{ptr, exts};
 }
 
-/**
- * @brief Create a raft::mdspan
- * @tparam ElementType the data type of the matrix elements
- * @tparam IndexType the index type of the extents
- * @tparam LayoutPolicy policy for strides and layout ordering
- * @tparam MemType the raft::memory_type for where the data are stored
- * @param ptr Pointer to the data
- * @param exts dimensionality of the array (series of integers)
- * @return raft::mdspan
- */
-template <typename ElementType,
-          typename IndexType    = std::uint32_t,
-          typename LayoutPolicy = layout_c_contiguous,
-          memory_type MemType   = memory_type::device,
-          size_t... Extents>
-auto make_mdspan(ElementType* ptr, extents<IndexType, Extents...> exts)
-{
-  using accessor_type =
-    host_device_accessor<std::experimental::default_accessor<ElementType>, MemType>;
-
-  return mdspan<ElementType, decltype(exts), LayoutPolicy, accessor_type>{ptr, exts};
-}
 
 /**
  * @brief Create raft::extents to specify dimensionality


### PR DESCRIPTION
This prevents requiring full specification for all template parameters in downstream `make_mdspan` usage. A more complete discussion of how we want to use `memory_type` in the public API can be deferred to a later PR.