### PR TITLE
Re-enable copy_prs ops-bot plugin

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -5,4 +5,4 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
-copy_prs: false
+copy_prs: true


### PR DESCRIPTION
We need to re-enable this to run self-hosted GitHub Actions from PRs to build pip wheels.