### PR TITLE
IVF-Flat: make adaptive-centers behavior optional

### DIFF
--- a/cpp/include/raft/neighbors/ivf_flat_types.hpp
+++ b/cpp/include/raft/neighbors/ivf_flat_types.hpp
@@ -86,7 +86,7 @@ struct index : ann::index {
   {
     return metric_;
   }
-  /** Whethe `centers()` change upon extending the index (ivf_pq::extend). */
+  /** Whether `centers()` change upon extending the index (ivf_pq::extend). */
   [[nodiscard]] constexpr inline auto adaptive_centers() const noexcept -> bool
   {
     return adaptive_centers_;

--- a/cpp/include/raft/neighbors/ivf_flat_types.hpp
+++ b/cpp/include/raft/neighbors/ivf_flat_types.hpp
@@ -41,13 +41,13 @@ struct index_params : ann::index_params {
   /**
    * By default (adaptive_centers = false), the cluster centers are trained in `ivf_flat::build`,
    * and never modified in `ivf_flat::extend`. As a result, you may need to retrain the index
-   * from scratch after invoking (`ivf_flat::extend`) a few times with new data, the distribution of which
-   * is no longer representative of the original training set.
+   * from scratch after invoking (`ivf_flat::extend`) a few times with new data, the distribution of
+   * which is no longer representative of the original training set.
    *
-   * The alternative behavior (adaptive_centers = true) is to update the cluster centers for new data when
-   * it is added. In this case, `index.centers()` are always exactly the centroids of
-   * the data in the corresponding clusters. The drawback of this behavior is that the centroids
-   * depend on the order of adding new data (through the classification of the added data); that is,
+   * The alternative behavior (adaptive_centers = true) is to update the cluster centers for new
+   * data when it is added. In this case, `index.centers()` are always exactly the centroids of the
+   * data in the corresponding clusters. The drawback of this behavior is that the centroids depend
+   * on the order of adding new data (through the classification of the added data); that is,
    * `index.centers()` "drift" together with the changing distribution of the newly added data.
    */
   bool adaptive_centers = false;

--- a/cpp/include/raft/neighbors/ivf_flat_types.hpp
+++ b/cpp/include/raft/neighbors/ivf_flat_types.hpp
@@ -41,11 +41,11 @@ struct index_params : ann::index_params {
   /**
    * By default (adaptive_centers = false), the cluster centers are trained in `ivf_flat::build`,
    * and never modified in `ivf_flat::extend`. As a result, you may need to retrain the index
-   * from scratch after adding (`ivf_flat::extend`) a few times new data, distribution of which
-   * is not well-represented by the original training set.
+   * from scratch after invoking (`ivf_flat::extend`) a few times with new data, the distribution of which
+   * is no longer representative of the original training set.
    *
-   * The alternative behavior (adaptive_centers = true) is to update cluster centers every time
-   * the new data is added. In this case, `index.centers()` are always exactly the centroids of
+   * The alternative behavior (adaptive_centers = true) is to update the cluster centers for new data when
+   * it is added. In this case, `index.centers()` are always exactly the centroids of
    * the data in the corresponding clusters. The drawback of this behavior is that the centroids
    * depend on the order of adding new data (through the classification of the added data); that is,
    * `index.centers()` "drift" together with the changing distribution of the newly added data.

--- a/cpp/test/neighbors/ann_ivf_flat.cu
+++ b/cpp/test/neighbors/ann_ivf_flat.cu
@@ -24,6 +24,7 @@
 #include <raft/spatial/knn/ann.cuh>
 #include <raft/spatial/knn/ivf_flat.cuh>
 #include <raft/spatial/knn/knn.cuh>
+#include <raft/stats/mean.cuh>
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -53,6 +54,7 @@ struct AnnIvfFlatInputs {
   IdxT nprobe;
   IdxT nlist;
   raft::distance::DistanceType metric;
+  bool adaptive_centers;
 };
 
 template <typename T, typename DataT, typename IdxT>
@@ -198,6 +200,45 @@ class AnnIVFFlatTest : public ::testing::TestWithParam<AnnIvfFlatInputs<IdxT>> {
         update_host(distances_ivfflat.data(), distances_ivfflat_dev.data(), queries_size, stream_);
         update_host(indices_ivfflat.data(), indices_ivfflat_dev.data(), queries_size, stream_);
         handle_.sync_stream(stream_);
+
+        // Test the centroid invariants
+        if (index_2.adaptive_centers()) {
+          // The centers must be up-to-date with the corresponding data
+          std::vector<uint32_t> list_sizes(index_2.n_lists());
+          std::vector<IdxT> list_offsets(index_2.n_lists());
+          rmm::device_uvector<float> centroid(ps.dim, stream_);
+          raft::copy(
+            list_sizes.data(), index_2.list_sizes().data_handle(), index_2.n_lists(), stream_);
+          raft::copy(
+            list_offsets.data(), index_2.list_offsets().data_handle(), index_2.n_lists(), stream_);
+          handle_.sync_stream(stream_);
+          for (uint32_t l = 0; l < index_2.n_lists(); l++) {
+            rmm::device_uvector<float> cluster_data(list_sizes[l] * ps.dim, stream_);
+            raft::spatial::knn::detail::utils::copy_selected<float>(
+              (IdxT)list_sizes[l],
+              (IdxT)ps.dim,
+              database.data(),
+              index_2.indices().data_handle() + list_offsets[l],
+              (IdxT)ps.dim,
+              cluster_data.data(),
+              (IdxT)ps.dim,
+              stream_);
+            raft::stats::mean<float, uint32_t>(
+              centroid.data(), cluster_data.data(), ps.dim, list_sizes[l], false, true, stream_);
+            ASSERT_TRUE(raft::devArrMatch(index_2.centers().data_handle() + ps.dim * l,
+                                          centroid.data(),
+                                          ps.dim,
+                                          raft::CompareApprox<float>(0.001),
+                                          stream_));
+          }
+        } else {
+          // The centers must be immutable
+          ASSERT_TRUE(raft::devArrMatch(index_2.centers().data_handle(),
+                                        index.centers().data_handle(),
+                                        index_2.centers().size(),
+                                        raft::Compare<float>(),
+                                        stream_));
+        }
       }
       ASSERT_TRUE(eval_neighbours(indices_naive,
                                   indices_ivfflat,
@@ -243,44 +284,44 @@ class AnnIVFFlatTest : public ::testing::TestWithParam<AnnIvfFlatInputs<IdxT>> {
 
 const std::vector<AnnIvfFlatInputs<int64_t>> inputs = {
   // test various dims (aligned and not aligned to vector sizes)
-  {1000, 10000, 1, 16, 40, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 10000, 2, 16, 40, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 10000, 3, 16, 40, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 10000, 4, 16, 40, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 10000, 5, 16, 40, 1024, raft::distance::DistanceType::InnerProduct},
-  {1000, 10000, 8, 16, 40, 1024, raft::distance::DistanceType::InnerProduct},
+  {1000, 10000, 1, 16, 40, 1024, raft::distance::DistanceType::L2Expanded, true},
+  {1000, 10000, 2, 16, 40, 1024, raft::distance::DistanceType::L2Expanded, false},
+  {1000, 10000, 3, 16, 40, 1024, raft::distance::DistanceType::L2Expanded, true},
+  {1000, 10000, 4, 16, 40, 1024, raft::distance::DistanceType::L2Expanded, false},
+  {1000, 10000, 5, 16, 40, 1024, raft::distance::DistanceType::InnerProduct, false},
+  {1000, 10000, 8, 16, 40, 1024, raft::distance::DistanceType::InnerProduct, true},
 
   // test dims that do not fit into kernel shared memory limits
-  {1000, 10000, 2048, 16, 40, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 10000, 2049, 16, 40, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 10000, 2050, 16, 40, 1024, raft::distance::DistanceType::InnerProduct},
-  {1000, 10000, 2051, 16, 40, 1024, raft::distance::DistanceType::InnerProduct},
-  {1000, 10000, 2052, 16, 40, 1024, raft::distance::DistanceType::InnerProduct},
-  {1000, 10000, 2053, 16, 40, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 10000, 2056, 16, 40, 1024, raft::distance::DistanceType::L2Expanded},
+  {1000, 10000, 2048, 16, 40, 1024, raft::distance::DistanceType::L2Expanded, false},
+  {1000, 10000, 2049, 16, 40, 1024, raft::distance::DistanceType::L2Expanded, false},
+  {1000, 10000, 2050, 16, 40, 1024, raft::distance::DistanceType::InnerProduct, false},
+  {1000, 10000, 2051, 16, 40, 1024, raft::distance::DistanceType::InnerProduct, true},
+  {1000, 10000, 2052, 16, 40, 1024, raft::distance::DistanceType::InnerProduct, false},
+  {1000, 10000, 2053, 16, 40, 1024, raft::distance::DistanceType::L2Expanded, true},
+  {1000, 10000, 2056, 16, 40, 1024, raft::distance::DistanceType::L2Expanded, true},
 
   // various random combinations
-  {1000, 10000, 16, 10, 40, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 10000, 16, 10, 50, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 10000, 16, 10, 70, 1024, raft::distance::DistanceType::L2Expanded},
-  {100, 10000, 16, 10, 20, 512, raft::distance::DistanceType::L2Expanded},
-  {20, 100000, 16, 10, 20, 1024, raft::distance::DistanceType::L2Expanded},
-  {1000, 100000, 16, 10, 20, 1024, raft::distance::DistanceType::L2Expanded},
-  {10000, 131072, 8, 10, 20, 1024, raft::distance::DistanceType::L2Expanded},
+  {1000, 10000, 16, 10, 40, 1024, raft::distance::DistanceType::L2Expanded, false},
+  {1000, 10000, 16, 10, 50, 1024, raft::distance::DistanceType::L2Expanded, false},
+  {1000, 10000, 16, 10, 70, 1024, raft::distance::DistanceType::L2Expanded, false},
+  {100, 10000, 16, 10, 20, 512, raft::distance::DistanceType::L2Expanded, false},
+  {20, 100000, 16, 10, 20, 1024, raft::distance::DistanceType::L2Expanded, true},
+  {1000, 100000, 16, 10, 20, 1024, raft::distance::DistanceType::L2Expanded, true},
+  {10000, 131072, 8, 10, 20, 1024, raft::distance::DistanceType::L2Expanded, false},
 
-  {1000, 10000, 16, 10, 40, 1024, raft::distance::DistanceType::InnerProduct},
-  {1000, 10000, 16, 10, 50, 1024, raft::distance::DistanceType::InnerProduct},
-  {1000, 10000, 16, 10, 70, 1024, raft::distance::DistanceType::InnerProduct},
-  {100, 10000, 16, 10, 20, 512, raft::distance::DistanceType::InnerProduct},
-  {20, 100000, 16, 10, 20, 1024, raft::distance::DistanceType::InnerProduct},
-  {1000, 100000, 16, 10, 20, 1024, raft::distance::DistanceType::InnerProduct},
-  {10000, 131072, 8, 10, 50, 1024, raft::distance::DistanceType::InnerProduct},
+  {1000, 10000, 16, 10, 40, 1024, raft::distance::DistanceType::InnerProduct, true},
+  {1000, 10000, 16, 10, 50, 1024, raft::distance::DistanceType::InnerProduct, true},
+  {1000, 10000, 16, 10, 70, 1024, raft::distance::DistanceType::InnerProduct, false},
+  {100, 10000, 16, 10, 20, 512, raft::distance::DistanceType::InnerProduct, true},
+  {20, 100000, 16, 10, 20, 1024, raft::distance::DistanceType::InnerProduct, true},
+  {1000, 100000, 16, 10, 20, 1024, raft::distance::DistanceType::InnerProduct, false},
+  {10000, 131072, 8, 10, 50, 1024, raft::distance::DistanceType::InnerProduct, true},
 
-  {1000, 10000, 4096, 20, 50, 1024, raft::distance::DistanceType::InnerProduct},
+  {1000, 10000, 4096, 20, 50, 1024, raft::distance::DistanceType::InnerProduct, false},
 
   // test splitting the big query batches  (> max gridDim.y) into smaller batches
-  {100000, 1024, 32, 10, 64, 64, raft::distance::DistanceType::InnerProduct},
-  {98306, 1024, 32, 10, 64, 64, raft::distance::DistanceType::InnerProduct},
+  {100000, 1024, 32, 10, 64, 64, raft::distance::DistanceType::InnerProduct, false},
+  {98306, 1024, 32, 10, 64, 64, raft::distance::DistanceType::InnerProduct, true},
 
   // test radix_sort for getting the cluster selection
   {1000,
@@ -289,14 +330,16 @@ const std::vector<AnnIvfFlatInputs<int64_t>> inputs = {
    10,
    raft::spatial::knn::detail::topk::kMaxCapacity * 2,
    raft::spatial::knn::detail::topk::kMaxCapacity * 4,
-   raft::distance::DistanceType::L2Expanded},
+   raft::distance::DistanceType::L2Expanded,
+   false},
   {1000,
    10000,
    16,
    10,
    raft::spatial::knn::detail::topk::kMaxCapacity * 4,
    raft::spatial::knn::detail::topk::kMaxCapacity * 4,
-   raft::distance::DistanceType::InnerProduct}};
+   raft::distance::DistanceType::InnerProduct,
+   false}};
 
 typedef AnnIVFFlatTest<float, float, std::int64_t> AnnIVFFlatTestF;
 TEST_P(AnnIVFFlatTestF, AnnIVFFlat) { this->testIVFFlat(); }


### PR DESCRIPTION
Add an indexing parameter `adaptive_centers` (false by default) to control whether `index.centers()` should be kept up-to-date with the cluster data or remain immutable.