### PR TITLE
Specify correct global targets names to raft_export

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -663,25 +663,8 @@ raft_export(
 # ##################################################################################################
 # * build export -------------------------------------------------------------
 raft_export(
-  BUILD
-  raft
-  EXPORT_SET
-  raft-exports
-  COMPONENTS
-  nn
-  distance
-  distributed
-  GLOBAL_TARGETS
-  raft
-  distance
-  distributed
-  nn
-  DOCUMENTATION
-  doc_string
-  NAMESPACE
-  raft::
-  FINAL_CODE_BLOCK
-  code_string
+  BUILD raft EXPORT_SET raft-exports COMPONENTS nn distance distributed GLOBAL_TARGETS raft
+  distance distributed nn DOCUMENTATION doc_string NAMESPACE raft:: FINAL_CODE_BLOCK code_string
 )
 
 # ##################################################################################################

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -673,9 +673,9 @@ raft_export(
   distributed
   GLOBAL_TARGETS
   raft
-  raft_distance
+  distance
   distributed
-  raft_nn
+  nn
   DOCUMENTATION
   doc_string
   NAMESPACE


### PR DESCRIPTION
The raft_nn and raft_distance targets are exported with the names nn and distance, therefore those are the names that need to be marked as GLOBAL.
