### PR TITLE
Exclude changelog from pre-commit spellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,8 @@ repos:
         rev: v2.1.0
         hooks:
               - id: codespell
+                exclude: (?x)^(^CHANGELOG.md$)
+
 
 default_language_version:
       python: python3

--- a/python/pylibraft/pylibraft/__init__.py
+++ b/python/pylibraft/pylibraft/__init__.py
@@ -12,3 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from pylibraft._version import get_versions
+
+__version__ = get_versions()["version"]
+del get_versions

--- a/python/raft-dask/raft_dask/__init__.py
+++ b/python/raft-dask/raft_dask/__init__.py
@@ -13,4 +13,9 @@
 # limitations under the License.
 #
 
+from raft_dask._version import get_versions
+
 from .include_test import raft_include_test
+
+__version__ = get_versions()["version"]
+del get_versions


### PR DESCRIPTION
Exclude the changelog from the pre-commit codespell check- this is to prevent CI failures after release when the changelog is updated, as suggested here https://github.com/rapidsai/cudf/pull/12097#pullrequestreview-1180342650

This also exports the `__version__` for pylibraft / raft_dask, which was missing previously