### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/conda/recipes/libraft/conda_build_config.yaml
+++ b/conda/recipes/libraft/conda_build_config.yaml
@@ -20,10 +20,10 @@ gtest_version:
   - "=1.10.0"
 
 libcusolver_version:
-  - ">=11.2.1"
+  - ">=11.2.1,<=11.4.1.48"
 
 libcusparse_version:
-  - ">=11.5.0"
+  - ">=11.5.0,<12.0"
 
 libfaiss_version:
   - "1.7.0 *_cuda"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.