### PR TITLE
Squared norm fix follow-up (change was lost in merge conflict)

### DIFF
--- a/cpp/include/raft/spatial/knn/detail/ivf_flat_search.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ivf_flat_search.cuh
@@ -1133,8 +1133,7 @@ void search_impl(const handle_t& handle,
                             static_cast<IdxT>(n_queries),
                             raft::linalg::L2Norm,
                             true,
-                            stream,
-                            raft::sqrt_op());
+                            stream);
       utils::outer_add(query_norm_dev.data(),
                        (IdxT)n_queries,
                        index.center_norms()->data_handle(),


### PR DESCRIPTION
This change was part of #1141 but was accidentally lost while merging conflicts with #1133