### PR TITLE
balanced-k-means: fix a too large initial memory pool size

### DIFF
--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -974,7 +974,9 @@ void build_hierarchical(const handle_t& handle,
   rmm::mr::device_memory_resource* device_memory = nullptr;
   IdxT max_minibatch_size =
     calc_minibatch_size(n_clusters, n_rows, dim, metric, std::is_same_v<T, float>);
-  auto pool_guard = raft::get_pool_memory_resource(device_memory, max_minibatch_size * dim * 4);
+  auto pool_guard = raft::get_pool_memory_resource(
+    device_memory,
+    std::min<size_t>(size_t(dim * 4) * max_minibatch_size, 1000lu * 1000lu * 1000lu));
   if (pool_guard) {
     RAFT_LOG_DEBUG(
       "kmeans::build_hierarchical: using pool memory resource with initial size %zu bytes",


### PR DESCRIPTION
`calc_minibatch_size` decides on the batch size under assumption that the workspace shouldn't exceed 1GB. It takes into account that fewer extra buffers are needed when the data type `T` is float. However, we don't take this into account when setting the initial memory pool size immediately after calculating `max_minibatch_size`. As a result, under some conditions, the algorithm attempts to allocate more memory than available. This PR sets the limit of the initial pool size to 1GB to fix the issue.