### PR TITLE
Fix various build errors

### DIFF
--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/cpp/bench/CMakeLists.txt
+++ b/cpp/bench/CMakeLists.txt
@@ -32,6 +32,7 @@ function(ConfigureBench)
     PRIVATE raft::raft
             $<$<BOOL:${ConfigureBench_DIST}>:raft::distance>
             $<$<BOOL:${ConfigureBench_NN}>:raft::nn>
+            GTest::gtest
             benchmark::benchmark
             Threads::Threads
             $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX>

--- a/cpp/include/raft/core/device_mdspan.hpp
+++ b/cpp/include/raft/core/device_mdspan.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,8 +197,9 @@ auto make_device_aligned_matrix_view(ElementType* ptr, IndexType n_rows, IndexTy
                                                  detail::alignment::value>::data_handle_type;
   static_assert(std::is_same<LayoutPolicy, layout_left_padded<ElementType>>::value ||
                 std::is_same<LayoutPolicy, layout_right_padded<ElementType>>::value);
-  assert(reinterpret_cast<std::uintptr_t>(ptr)
-         == std::experimental::details::alignTo(reinterpret_cast<std::uintptr_t>(ptr), detail::alignment::value));
+  assert(reinterpret_cast<std::uintptr_t>(ptr) ==
+         std::experimental::details::alignTo(reinterpret_cast<std::uintptr_t>(ptr),
+                                             detail::alignment::value));
 
   data_handle_type aligned_pointer = ptr;
 

--- a/cpp/include/raft/core/device_mdspan.hpp
+++ b/cpp/include/raft/core/device_mdspan.hpp
@@ -197,7 +197,8 @@ auto make_device_aligned_matrix_view(ElementType* ptr, IndexType n_rows, IndexTy
                                                  detail::alignment::value>::data_handle_type;
   static_assert(std::is_same<LayoutPolicy, layout_left_padded<ElementType>>::value ||
                 std::is_same<LayoutPolicy, layout_right_padded<ElementType>>::value);
-  assert(ptr == alignTo(ptr, detail::alignment::value));
+  assert(reinterpret_cast<std::uintptr_t>(ptr)
+         == std::experimental::details::alignTo(reinterpret_cast<std::uintptr_t>(ptr), detail::alignment::value));
 
   data_handle_type aligned_pointer = ptr;
 

--- a/cpp/include/raft/core/host_mdspan.hpp
+++ b/cpp/include/raft/core/host_mdspan.hpp
@@ -144,7 +144,8 @@ auto make_host_aligned_matrix_view(ElementType* ptr, IndexType n_rows, IndexType
 
   static_assert(std::is_same<LayoutPolicy, layout_left_padded<ElementType>>::value ||
                 std::is_same<LayoutPolicy, layout_right_padded<ElementType>>::value);
-  assert(ptr == alignTo(ptr, detail::alignment::value));
+  assert(reinterpret_cast<std::uintptr_t>(ptr)
+         == std::experimental::details::alignTo(reinterpret_cast<std::uintptr_t>(ptr), detail::alignment::value));
   data_handle_type aligned_pointer = ptr;
 
   matrix_extent<IndexType> extents{n_rows, n_cols};

--- a/cpp/include/raft/core/host_mdspan.hpp
+++ b/cpp/include/raft/core/host_mdspan.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,8 +144,9 @@ auto make_host_aligned_matrix_view(ElementType* ptr, IndexType n_rows, IndexType
 
   static_assert(std::is_same<LayoutPolicy, layout_left_padded<ElementType>>::value ||
                 std::is_same<LayoutPolicy, layout_right_padded<ElementType>>::value);
-  assert(reinterpret_cast<std::uintptr_t>(ptr)
-         == std::experimental::details::alignTo(reinterpret_cast<std::uintptr_t>(ptr), detail::alignment::value));
+  assert(reinterpret_cast<std::uintptr_t>(ptr) ==
+         std::experimental::details::alignTo(reinterpret_cast<std::uintptr_t>(ptr),
+                                             detail::alignment::value));
   data_handle_type aligned_pointer = ptr;
 
   matrix_extent<IndexType> extents{n_rows, n_cols};

--- a/cpp/include/raft/matrix/detail/linewise_op.cuh
+++ b/cpp/include/raft/matrix/detail/linewise_op.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/include/raft/matrix/detail/linewise_op.cuh
+++ b/cpp/include/raft/matrix/detail/linewise_op.cuh
@@ -796,7 +796,7 @@ struct MatrixLinewiseOp {
                   "layout for in and out must be either padded row or col major");
 
     // also statically assert padded matrix alignment == 2^i*VecBytes
-    assert(raft::Pow2<VecBytes>::areSameAlignOffsets(in, out));
+    assert(raft::Pow2<VecBytes>::areSameAlignOffsets(in.data_handle(), out.data_handle()));
 
     if (alongLines)
       return matrixLinewiseVecRowsSpan<Type,

--- a/cpp/include/raft/matrix/detail/linewise_op.cuh
+++ b/cpp/include/raft/matrix/detail/linewise_op.cuh
@@ -796,7 +796,7 @@ struct MatrixLinewiseOp {
                   "layout for in and out must be either padded row or col major");
 
     // also statically assert padded matrix alignment == 2^i*VecBytes
-    assert(raft::Pow2<VecBytes>::areSameAlignOffsets(in.data_handle(), out.data_handle()));
+    RAFT_EXPECTS(raft::Pow2<VecBytes>::areSameAlignOffsets(in.data_handle(), out.data_handle()));
 
     if (alongLines)
       return matrixLinewiseVecRowsSpan<Type,

--- a/cpp/include/raft/matrix/detail/linewise_op.cuh
+++ b/cpp/include/raft/matrix/detail/linewise_op.cuh
@@ -796,7 +796,8 @@ struct MatrixLinewiseOp {
                   "layout for in and out must be either padded row or col major");
 
     // also statically assert padded matrix alignment == 2^i*VecBytes
-    RAFT_EXPECTS(raft::Pow2<VecBytes>::areSameAlignOffsets(in.data_handle(), out.data_handle()));
+    RAFT_EXPECTS(raft::Pow2<VecBytes>::areSameAlignOffsets(in.data_handle(), out.data_handle()),
+                 "The matrix views in and out does not have correct alignment");
 
     if (alongLines)
       return matrixLinewiseVecRowsSpan<Type,


### PR DESCRIPTION
Fix various build errors I encountered as I tried to build RAFT locally on my workstation. (Command used: `./build.sh -g raft-dask pylibraft libraft tests bench --compile-libs`)

* Add `gtest` as a link dependency of the C++ benchmark suite, to fix the error
```
[266/332] Building CUDA object CMakeFiles/NEIGHBORS_BENCH.dir/bench/neighbors/refine.cu.o
FAILED: CMakeFiles/NEIGHBORS_BENCH.dir/bench/neighbors/refine.cu.o
In file included from /home/phcho/Desktop/raft/cpp/bench/neighbors/../../test/neighbors/../test_utils.cuh:19,
from /home/phcho/Desktop/raft/cpp/bench/neighbors/../../test/neighbors/ann_utils.cuh:28,
from /home/phcho/Desktop/raft/cpp/bench/neighbors/../../test/neighbors/refine_helper.cuh:18,
from /home/phcho/Desktop/raft/cpp/bench/neighbors/refine.cu:39:
/home/phcho/Desktop/raft/cpp/bench/neighbors/../../test/neighbors/../test_utils.h:22:10: fatal error:
gtest/gtest.h: No such file or directory
22 | #include <gtest/gtest.h>
   |          ^~~~~~~~~~~~~~~
compilation terminated. 
```

* Explicitly specify the namespace for `alignTo`.
* Cast pointers into an integral type prior to passing it to `alignTo`.
* When calling `areSameAlignOffsets()`, pass the underlying pointers of the mdspan objects. Passing an mdspan to `areSameAlignOffsets()` is an error.