### PR TITLE
Make cutlass use static ctk

### DIFF
--- a/cpp/cmake/thirdparty/get_cutlass.cmake
+++ b/cpp/cmake/thirdparty/get_cutlass.cmake
@@ -30,6 +30,10 @@ function(find_and_configure_cutlass)
       CACHE BOOL "Disable CUTLASS to build with cuBLAS library."
   )
 
+  if (CUDA_STATIC_RUNTIME)
+    set(CUDART_LIBRARY "${CUDA_cudart_static_LIBRARY}" CACHE FILEPATH "fixing cutlass cmake code" FORCE)
+  endif()
+
   rapids_cpm_find(
     NvidiaCutlass ${PKG_VERSION}
     GLOBAL_TARGETS nvidia::cutlass::cutlass


### PR DESCRIPTION
Cutlass links to the CTK in ways that cause problems for downstream pip wheel builds (especially in cugraph).

This might help.