### PR TITLE
Protect balanced k-means out-of-memory in some cases

### DIFF
--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -839,6 +839,10 @@ inline auto arrange_fine_clusters(uint32_t n_clusters,
  *  As a result, the fine clusters are what is returned by `build_hierarchical`;
  *  this function returns the total number of fine clusters, which can be checked to be
  *  the same as the requested number of clusters.
+ *
+ *  Note: this function uses at most `fine_clusters_nums_max` points per mesocluster for training;
+ *  if one of the clusters is larger than that (as given by `mesocluster_sizes`), the extra data
+ *  is ignored and a warning is reported.
  */
 template <typename T, typename IdxT, typename LabelT>
 auto build_fine_clusters(const handle_t& handle,

--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -1034,8 +1034,8 @@ void build_hierarchical(const handle_t& handle,
   auto [mesocluster_size_max, fine_clusters_nums_max, fine_clusters_nums, fine_clusters_csum] =
     arrange_fine_clusters(n_clusters, n_mesoclusters, n_rows, mesocluster_sizes);
 
-  const auto mesocluster_size_max_balanced =
-    uint32_t(size_t{n_rows * 2lu} / std::max<size_t>(n_mesoclusters, 1lu));
+  const auto mesocluster_size_max_balanced = uint32_t(
+    div_rounding_up_safe<size_t>(2lu * size_t{n_rows}, std::max<size_t>(n_mesoclusters, 1lu)));
   if (mesocluster_size_max > mesocluster_size_max_balanced) {
     RAFT_LOG_WARN(
       "build_hierarchical: built unbalanced mesoclusters (max_mesocluster_size == %u > %u). "

--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -1034,8 +1034,8 @@ void build_hierarchical(const handle_t& handle,
   auto [mesocluster_size_max, fine_clusters_nums_max, fine_clusters_nums, fine_clusters_csum] =
     arrange_fine_clusters(n_clusters, n_mesoclusters, n_rows, mesocluster_sizes);
 
-  const auto mesocluster_size_max_balanced = uint32_t(
-    div_rounding_up_safe<size_t>(2lu * size_t{n_rows}, std::max<size_t>(n_mesoclusters, 1lu)));
+  const auto mesocluster_size_max_balanced = uint32_t(div_rounding_up_safe<size_t>(
+    2lu * size_t{n_rows}, std::max<size_t>(size_t{n_mesoclusters}, 1lu)));
   if (mesocluster_size_max > mesocluster_size_max_balanced) {
     RAFT_LOG_WARN(
       "build_hierarchical: built unbalanced mesoclusters (max_mesocluster_size == %u > %u). "

--- a/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_kmeans_balanced.cuh
@@ -1035,7 +1035,7 @@ void build_hierarchical(const handle_t& handle,
     arrange_fine_clusters(n_clusters, n_mesoclusters, n_rows, mesocluster_sizes);
 
   const auto mesocluster_size_max_balanced = uint32_t(div_rounding_up_safe<size_t>(
-    2lu * size_t{n_rows}, std::max<size_t>(size_t{n_mesoclusters}, 1lu)));
+    2lu * size_t(n_rows), std::max<size_t>(size_t(n_mesoclusters), 1lu)));
   if (mesocluster_size_max > mesocluster_size_max_balanced) {
     RAFT_LOG_WARN(
       "build_hierarchical: built unbalanced mesoclusters (max_mesocluster_size == %u > %u). "


### PR DESCRIPTION
There's no guarantee that our balanced k-means implementation always produces balanced clusters. In the first stage, when mesoclusters are trained, the biggest cluster can grow larger than half of all input data. This becomes a problem at the second stage, when in `build_fine_clusters`, the mesocluster data is copied in a temporary buffer. If size is too big, there may be not enough memory on the device. A quick workaround:

 1. Expand the error reporting (RAFT_LOG_WARN)
 2. Artificially limit the mesocluster size in the event of highly unbalanced clustering