### PR TITLE
Enable shallow copy of `handle_t`'s resource pointers with different workspace_resource 

### DIFF
--- a/cpp/include/raft/core/device_resources.hpp
+++ b/cpp/include/raft/core/device_resources.hpp
@@ -59,9 +59,14 @@ namespace raft {
  */
 class device_resources : public resources {
  public:
-  // delete copy/move constructors and assignment operators as
-  // copying and moving underlying resources is unsafe
-  device_resources(const device_resources&) = delete;
+  device_resources(const device_resources& handle,
+                   rmm::mr::device_memory_resource* workspace_resource)
+    : resources{handle}
+  {
+    // replace the resource factory for the workspace_resources
+    resources::add_resource_factory(
+      std::make_shared<resource::workspace_resource_factory>(workspace_resource));
+  }
   device_resources& operator=(const device_resources&) = delete;
   device_resources(device_resources&&)                 = delete;
   device_resources& operator=(device_resources&&) = delete;

--- a/cpp/include/raft/core/handle.hpp
+++ b/cpp/include/raft/core/handle.hpp
@@ -32,9 +32,10 @@ namespace raft {
  */
 class handle_t : public raft::device_resources {
  public:
-  // delete copy/move constructors and assignment operators as
-  // copying and moving underlying resources is unsafe
-  handle_t(const handle_t&) = delete;
+  handle_t(const handle_t& handle, rmm::mr::device_memory_resource* workspace_resource)
+    : device_resources(handle, workspace_resource)
+  {
+  }
   handle_t& operator=(const handle_t&) = delete;
   handle_t(handle_t&&)                 = delete;
   handle_t& operator=(handle_t&&) = delete;

--- a/cpp/include/raft/core/resources.hpp
+++ b/cpp/include/raft/core/resources.hpp
@@ -66,10 +66,7 @@ class resources {
    * @brief Shallow copy of underlying resources instance.
    * Note that this does not create any new resources.
    */
-  resources(const resources&)
-    : factories_(resources.factories_.copy()), resources_(resources.resources_.copy())
-  {
-  }
+  resources(const resources& res) : factories_(res.factories_), resources_(res.resources_) {}
   resources& operator=(const resources&) = delete;
   resources(resources&&)                 = delete;
   resources& operator=(resources&&) = delete;

--- a/cpp/include/raft/core/resources.hpp
+++ b/cpp/include/raft/core/resources.hpp
@@ -62,7 +62,14 @@ class resources {
     }
   }
 
-  resources(const resources&) = delete;
+  /**
+   * @brief Shallow copy of underlying resources instance.
+   * Note that this does not create any new resources.
+   */
+  resources(const resources&)
+    : factories_(resources.factories_.copy()), resources_(resources.resources_.copy())
+  {
+  }
   resources& operator=(const resources&) = delete;
   resources(resources&&)                 = delete;
   resources& operator=(resources&&) = delete;
@@ -120,7 +127,7 @@ class resources {
     return reinterpret_cast<res_t*>(res->get_resource());
   }
 
- private:
+ protected:
   mutable std::mutex mutex_;
   mutable std::vector<pair_res_factory> factories_;
   mutable std::vector<pair_resource> resources_;


### PR DESCRIPTION
This effectively affords users the flexibility to shallow copy a handle and it's underlying vectors and change out only the `workspace_resource` so that they can, for example, configure multiple different pools or managed pools for workspace resources. 

cc @Nyrio RE: hierarchical k-means API. 