### PR TITLE
Forward-merge branch-23.02 to branch-23.04

### DIFF
--- a/cpp/include/raft/core/device_resources.hpp
+++ b/cpp/include/raft/core/device_resources.hpp
@@ -59,11 +59,18 @@ namespace raft {
  */
 class device_resources : public resources {
  public:
-  // delete copy/move constructors and assignment operators as
-  // copying and moving underlying resources is unsafe
-  device_resources(const device_resources&) = delete;
-  device_resources& operator=(const device_resources&) = delete;
-  device_resources(device_resources&&)                 = delete;
+  device_resources(const device_resources& handle,
+                   rmm::mr::device_memory_resource* workspace_resource)
+    : resources{handle}
+  {
+    // replace the resource factory for the workspace_resources
+    resources::add_resource_factory(
+      std::make_shared<resource::workspace_resource_factory>(workspace_resource));
+  }
+
+  device_resources(const device_resources& handle) : resources{handle} {}
+
+  device_resources(device_resources&&) = delete;
   device_resources& operator=(device_resources&&) = delete;
 
   /**
@@ -210,7 +217,7 @@ class device_resources : public resources {
     return resource::get_subcomm(*this, key);
   }
 
-  const rmm::mr::device_memory_resource* get_workspace_resource() const
+  rmm::mr::device_memory_resource* get_workspace_resource() const
   {
     return resource::get_workspace_resource(*this);
   }

--- a/cpp/include/raft/core/handle.hpp
+++ b/cpp/include/raft/core/handle.hpp
@@ -32,11 +32,14 @@ namespace raft {
  */
 class handle_t : public raft::device_resources {
  public:
-  // delete copy/move constructors and assignment operators as
-  // copying and moving underlying resources is unsafe
-  handle_t(const handle_t&) = delete;
-  handle_t& operator=(const handle_t&) = delete;
-  handle_t(handle_t&&)                 = delete;
+  handle_t(const handle_t& handle, rmm::mr::device_memory_resource* workspace_resource)
+    : device_resources(handle, workspace_resource)
+  {
+  }
+
+  handle_t(const handle_t& handle) : device_resources{handle} {}
+
+  handle_t(handle_t&&) = delete;
   handle_t& operator=(handle_t&&) = delete;
 
   /**

--- a/cpp/include/raft/core/resources.hpp
+++ b/cpp/include/raft/core/resources.hpp
@@ -62,9 +62,12 @@ class resources {
     }
   }
 
-  resources(const resources&) = delete;
-  resources& operator=(const resources&) = delete;
-  resources(resources&&)                 = delete;
+  /**
+   * @brief Shallow copy of underlying resources instance.
+   * Note that this does not create any new resources.
+   */
+  resources(const resources& res) : factories_(res.factories_), resources_(res.resources_) {}
+  resources(resources&&) = delete;
   resources& operator=(resources&&) = delete;
 
   /**
@@ -120,7 +123,7 @@ class resources {
     return reinterpret_cast<res_t*>(res->get_resource());
   }
 
- private:
+ protected:
   mutable std::mutex mutex_;
   mutable std::vector<pair_res_factory> factories_;
   mutable std::vector<pair_resource> resources_;


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.02` that creates a PR to keep `branch-23.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.