### PR TITLE
Fix `ucx-py` version

### DIFF
--- a/conda/recipes/raft-dask/conda_build_config.yaml
+++ b/conda/recipes/raft-dask/conda_build_config.yaml
@@ -14,7 +14,7 @@ ucx_version:
   - "1.13.0"
 
 ucx_py_version:
-  - "0.30.*"
+  - "0.31.*"
 
 cmake_version:
   - ">=3.23.1,!=3.25.0"


### PR DESCRIPTION
This change should've occurred in the commit below when the [update-version.sh](https://github.com/rapidsai/raft/blob/branch-23.02/ci/release/update-version.sh) script was run.

This file is listed in `update-version.sh`, so I'm not sure why it wasn't updated

- https://github.com/rapidsai/raft/commit/9963c12187d5b73710fa98d0fe0f94f84ce5e669

