### PR TITLE
Forward-merge branch-23.02 to branch-23.04

### DIFF
--- a/cpp/include/raft/core/resource/cuda_stream.hpp
+++ b/cpp/include/raft/core/resource/cuda_stream.hpp
@@ -91,7 +91,10 @@ inline void set_cuda_stream(resources const& res, rmm::cuda_stream_view stream_v
  */
 inline void sync_stream(const resources& res, rmm::cuda_stream_view stream)
 {
-  interruptible::synchronize(stream);
+  // TODO: Fix interruptible segfault:
+  // https://github.com/rapidsai/raft/issues/1225
+  // interruptible::synchronize(stream);
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
 }
 
 /**


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.02` that creates a PR to keep `branch-23.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.