### PR TITLE
Bump pinned pip wheel deps to 23.4

### DIFF
--- a/python/pylibraft/_custom_build/backend.py
+++ b/python/pylibraft/_custom_build/backend.py
@@ -19,7 +19,7 @@ def replace_requirements(func):
     def wrapper(config_settings=None):
         orig_list = getattr(_orig, func.__name__)(config_settings)
         cuda_suffix = os.getenv("RAPIDS_PY_WHEEL_CUDA_SUFFIX", default="")
-        append_list = [f"rmm{cuda_suffix}==23.2.*"]
+        append_list = [f"rmm{cuda_suffix}==23.4.*"]
         return orig_list + append_list
 
     return wrapper

--- a/python/pylibraft/setup.py
+++ b/python/pylibraft/setup.py
@@ -25,7 +25,7 @@ cuda_suffix = os.getenv("RAPIDS_PY_WHEEL_CUDA_SUFFIX", default="")
 install_requires = [
     "numpy",
     "cuda-python>=11.7.1,<12.0",
-    f"rmm{cuda_suffix}==23.2.*",
+    f"rmm{cuda_suffix}==23.4.*",
 ]
 
 extras_require = {

--- a/python/raft-dask/setup.py
+++ b/python/raft-dask/setup.py
@@ -26,11 +26,11 @@ install_requires = [
     "numpy",
     "numba>=0.49",
     "joblib>=0.11",
-    "dask-cuda==23.2.*",
+    "dask-cuda==23.4.*",
     "dask==2023.1.1",
-    f"ucx-py{cuda_suffix}==0.30.*",
+    f"ucx-py{cuda_suffix}==0.31.*",
     "distributed==2023.1.1",
-    f"pylibraft{cuda_suffix}==23.2.*",
+    f"pylibraft{cuda_suffix}==23.4.*",
 ]
 
 extras_require = {


### PR DESCRIPTION
We introduced a change to pin RAPIDS wheel dependencies to the same release version. However, branch 23.04 was created before that last PR was merged, so as of now raft's 23.4 wheels are installing 23.2 RAPIDS dependencies. This PR updates those pins to the current release.