### PR TITLE
CI: Remove specification of manual stage for check_style.sh script.

### DIFF
--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -15,4 +15,4 @@ rapids-mamba-retry env create --force -f env.yaml -n checks
 conda activate checks
 
 # Run pre-commit checks
-pre-commit run --hook-stage manual --all-files --show-diff-on-failure
+pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
Do not explicitly specify to run the "manual" stage when running pre-commits as part of the ci/check_style.sh script.