### PR TITLE
Add dispatch based on compute architecture

### DIFF
--- a/cpp/include/raft/distance/detail/distance.cuh
+++ b/cpp/include/raft/distance/detail/distance.cuh
@@ -45,8 +45,8 @@
 
 #include <raft/distance/distance_types.hpp>
 #include <raft/linalg/gemm.cuh>
-#include <raft/util/cuda_utils.cuh>
 #include <raft/util/arch.cuh>
+#include <raft/util/cuda_utils.cuh>
 #include <rmm/device_uvector.hpp>
 
 namespace raft {
@@ -262,9 +262,9 @@ void distance_impl(raft::resources const& handle,
     distance_matrix_dispatch<decltype(distance_op), DataT, AccT, OutT, FinOpT, IdxT>(
       distance_op, m, n, k, x, y, norm_A, norm_B, out, fin_op, stream, is_row_major);
   } else {
-    auto runtime_arch = raft::arch::kernel_runtime_arch();
+    auto runtime_arch  = raft::arch::kernel_runtime_arch();
     auto cutlass_range = raft::arch::SM_range(raft::arch::SM_80(), raft::arch::SM_future());
-    auto legacy_range = raft::arch::SM_range(raft::arch::SM_min(), raft::arch::SM_80());
+    auto legacy_range  = raft::arch::SM_range(raft::arch::SM_min(), raft::arch::SM_80());
 
     if (cutlass_range.contains(runtime_arch)) {
       // If device is SM_80 or later, use CUTLASS-based kernel.
@@ -276,8 +276,25 @@ void distance_impl(raft::resources const& handle,
     } else {
       // Else use "legacy" L2
       ops::cosine_distance_op<DataT, AccT, IdxT> distance_op{};
-      distance_matrix_dispatch<decltype(distance_op), DataT, AccT, OutT, FinOpT, IdxT, decltype(legacy_range)>(
-        distance_op, m, n, k, x, y, norm_A, norm_B, out, fin_op, stream, is_row_major, legacy_range);
+      distance_matrix_dispatch<decltype(distance_op),
+                               DataT,
+                               AccT,
+                               OutT,
+                               FinOpT,
+                               IdxT,
+                               decltype(legacy_range)>(distance_op,
+                                                       m,
+                                                       n,
+                                                       k,
+                                                       x,
+                                                       y,
+                                                       norm_A,
+                                                       norm_B,
+                                                       out,
+                                                       fin_op,
+                                                       stream,
+                                                       is_row_major,
+                                                       legacy_range);
     }
   }
 }
@@ -531,9 +548,9 @@ void distance_impl_l2_expanded(  // NOTE: different name
     distance_matrix_dispatch<decltype(l2_op), DataT, AccT, OutT, FinOpT, IdxT>(
       l2_op, m, n, k, x, y, norm_A, norm_B, out, fin_op, stream, is_row_major);
   } else {
-    auto runtime_arch = raft::arch::kernel_runtime_arch();
+    auto runtime_arch  = raft::arch::kernel_runtime_arch();
     auto cutlass_range = raft::arch::SM_range(raft::arch::SM_80(), raft::arch::SM_future());
-    auto legacy_range = raft::arch::SM_range(raft::arch::SM_min(), raft::arch::SM_80());
+    auto legacy_range  = raft::arch::SM_range(raft::arch::SM_min(), raft::arch::SM_80());
 
     if (cutlass_range.contains(runtime_arch)) {
       // If device is SM_80 or later, use CUTLASS-based kernel.
@@ -546,7 +563,13 @@ void distance_impl_l2_expanded(  // NOTE: different name
       // Else use "legacy" L2. Compile *only* for architectures in the legacy
       // range. For newer architectures, compile empty kernels.
       ops::l2_exp_distance_op<DataT, AccT, IdxT> l2_op(perform_sqrt);
-      distance_matrix_dispatch<decltype(l2_op), DataT, AccT, OutT, FinOpT, IdxT, decltype(legacy_range)>(
+      distance_matrix_dispatch<decltype(l2_op),
+                               DataT,
+                               AccT,
+                               OutT,
+                               FinOpT,
+                               IdxT,
+                               decltype(legacy_range)>(
         l2_op, m, n, k, x, y, norm_A, norm_B, out, fin_op, stream, is_row_major, legacy_range);
     }
   }

--- a/cpp/include/raft/distance/detail/pairwise_matrix/dispatch.cuh
+++ b/cpp/include/raft/distance/detail/pairwise_matrix/dispatch.cuh
@@ -17,9 +17,9 @@
 
 #include "kernel_sm60.cuh"
 #include <cstdio>
-#include <raft/util/arch.cuh>
 #include <raft/distance/detail/pairwise_distance_cutlass_base.cuh>
 #include <raft/linalg/contractions.cuh>
+#include <raft/util/arch.cuh>
 #include <utility>
 
 namespace raft::distance::detail {
@@ -90,21 +90,22 @@ template <typename OpT,
           typename AccT,
           typename OutT,
           typename FinOpT,
-          typename IdxT = int,
+          typename IdxT        = int,
           typename SM_compat_t = raft::arch::SM_range<raft::arch::SM_min, raft::arch::SM_future>>
-void distance_matrix_dispatch(OpT distance_op,
-                              IdxT m,
-                              IdxT n,
-                              IdxT k,
-                              const DataT* x,
-                              const DataT* y,
-                              const DataT* x_norm,
-                              const DataT* y_norm,
-                              OutT* out,
-                              FinOpT fin_op,
-                              cudaStream_t stream,
-                              bool is_row_major,
-                              SM_compat_t sm_compat_range = raft::arch::SM_range(raft::arch::SM_min(), raft::arch::SM_future()))
+void distance_matrix_dispatch(
+  OpT distance_op,
+  IdxT m,
+  IdxT n,
+  IdxT k,
+  const DataT* x,
+  const DataT* y,
+  const DataT* x_norm,
+  const DataT* y_norm,
+  OutT* out,
+  FinOpT fin_op,
+  cudaStream_t stream,
+  bool is_row_major,
+  SM_compat_t sm_compat_range = raft::arch::SM_range(raft::arch::SM_min(), raft::arch::SM_future()))
 {
   // Determine leading dimensions and, if column-major, flip order of passing x
   // and y.
@@ -148,7 +149,21 @@ void distance_matrix_dispatch(OpT distance_op,
     typedef typename std::conditional<row_major(), RowPolicy, ColPolicy>::type Policy;
 
     return pairwise_matrix<Policy, row_major(), DataT, AccT, OutT, IdxT, OpT, FinOpT>(
-      distance_op, fin_op, x, y, x_norm, y_norm, m, n, k, ldx, ldy, ld_out, out, stream, sm_compat_range);
+      distance_op,
+      fin_op,
+      x,
+      y,
+      x_norm,
+      y_norm,
+      m,
+      n,
+      k,
+      ldx,
+      ldy,
+      ld_out,
+      out,
+      stream,
+      sm_compat_range);
   });
 }
 

--- a/cpp/include/raft/util/arch.cuh
+++ b/cpp/include/raft/util/arch.cuh
@@ -47,7 +47,7 @@ struct SM_generic {
   __host__ __device__ constexpr int value() const { return n; }
 };
 
-// A
+// A dummy kernel that is used to determine the runtime architecture.
 __global__ inline void dummy_runtime_kernel() {}
 }  // namespace inner
 
@@ -102,7 +102,7 @@ struct SM_runtime {
 // Computes which compute architecture of a kernel will run
 //
 // Semantics are described above in the documentation of SM_runtime.
-SM_runtime kernel_runtime_arch()
+inline SM_runtime kernel_runtime_arch()
 {
   auto kernel = inner::dummy_runtime_kernel;
   cudaFuncAttributes attributes;

--- a/cpp/include/raft/util/arch.cuh
+++ b/cpp/include/raft/util/arch.cuh
@@ -43,26 +43,24 @@ namespace raft::arch {
 namespace inner {
 template <int n>
 struct SM_generic {
-public:
-  __host__ __device__ constexpr int value() const {
-    return n;
-  }
+ public:
+  __host__ __device__ constexpr int value() const { return n; }
 };
 
 // A
 __global__ inline void dummy_runtime_kernel() {}
-}
+}  // namespace inner
 
 // A list of architectures that RAPIDS explicitly builds for (SM60, ..., SM90)
 // and SM_MIN and SM_FUTURE, that allow specifying an open interval of
 // compatible compute architectures.
-using SM_min = inner::SM_generic<350>;
-using SM_60 = inner::SM_generic<600>;
-using SM_70 = inner::SM_generic<700>;
-using SM_75 = inner::SM_generic<750>;
-using SM_80 = inner::SM_generic<800>;
-using SM_86 = inner::SM_generic<860>;
-using SM_90 = inner::SM_generic<900>;
+using SM_min    = inner::SM_generic<350>;
+using SM_60     = inner::SM_generic<600>;
+using SM_70     = inner::SM_generic<700>;
+using SM_75     = inner::SM_generic<750>;
+using SM_80     = inner::SM_generic<800>;
+using SM_86     = inner::SM_generic<860>;
+using SM_90     = inner::SM_generic<900>;
 using SM_future = inner::SM_generic<99999>;
 
 // This is a type that uses the __CUDA_ARCH__ macro to obtain the compile-time
@@ -70,7 +68,8 @@ using SM_future = inner::SM_generic<99999>;
 // i.e., inside a __global__ function template.
 struct SM_compute_arch {
   template <int dummy = 0>
-  __host__ __device__ constexpr int value() const {
+  __host__ __device__ constexpr int value() const
+  {
 #ifdef __CUDA_ARCH__
     return __CUDA_ARCH__;
 #else
@@ -91,21 +90,20 @@ struct SM_compute_arch {
 // the kernel runs.
 struct SM_runtime {
   friend SM_runtime kernel_runtime_arch();
-private:
-  const int _version;
-  SM_runtime(int version)
-    : _version (version) {}
 
-public:
-  __host__ __device__ int value() const  {
-    return _version;
-  }
+ private:
+  const int _version;
+  SM_runtime(int version) : _version(version) {}
+
+ public:
+  __host__ __device__ int value() const { return _version; }
 };
 
 // Computes which compute architecture of a kernel will run
 //
 // Semantics are described above in the documentation of SM_runtime.
-SM_runtime kernel_runtime_arch() {
+SM_runtime kernel_runtime_arch()
+{
   auto kernel = inner::dummy_runtime_kernel;
   cudaFuncAttributes attributes;
   cudaFuncGetAttributes(&attributes, kernel);
@@ -117,17 +115,18 @@ SM_runtime kernel_runtime_arch() {
 // conditionally compile a kernel.
 template <typename SM_MIN, typename SM_MAX>
 struct SM_range {
-private:
+ private:
   const SM_MIN _min;
   const SM_MAX _max;
-public:
-  __host__ __device__ constexpr SM_range(SM_MIN min, SM_MAX max)
-    : _min(min), _max(max) {}
+
+ public:
+  __host__ __device__ constexpr SM_range(SM_MIN min, SM_MAX max) : _min(min), _max(max) {}
 
   template <typename SM_t>
-  __host__ __device__ constexpr bool contains(SM_t current) const {
+  __host__ __device__ constexpr bool contains(SM_t current) const
+  {
     return _min.value() <= current.value() && current.value() < _max.value();
   }
 };
 
-} // namespace raft::arch
+}  // namespace raft::arch

--- a/cpp/include/raft/util/arch.cuh
+++ b/cpp/include/raft/util/arch.cuh
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace raft::arch {
+
+/* raft::arch provides the following facilities:
+ *
+ * - raft::arch::SM_XX : hardcoded compile-time constants for various compute
+ *   architectures. The values raft::arch::SM_min and raft::arch::SM_future
+ *   represent architectures that are always smaller and larger (respectively)
+ *   than any architecture that can be encountered in practice.
+ *
+ * - raft::arch::SM_compute_arch : a compile-time value for the *current*
+ *   compute architecture that a kernel is compiled with. It can only be used
+ *   inside kernels with a template argument.
+ *
+ * - raft::arch::kernel_runtime_arch : a function that computes at *run-time*
+ *   which version of a kernel will launch (i.e., it will return the compute
+ *   architecture of the version of the kernel that will be launched by the
+ *   driver).
+ *
+ * - raft::arch::SM_range : a compile-time value to represent an open interval
+ *   of compute architectures. This can be used to check if the current
+ *   compile-time architecture is in a specified compatibility range.
+ */
+
+// inner::SM_generic is a template to create a generic compile-time SM
+// architecture constant.
+namespace inner {
+template <int n>
+struct SM_generic {
+public:
+  __host__ __device__ constexpr int value() const {
+    return n;
+  }
+};
+
+// A
+__global__ inline void dummy_runtime_kernel() {}
+}
+
+// A list of architectures that RAPIDS explicitly builds for (SM60, ..., SM90)
+// and SM_MIN and SM_FUTURE, that allow specifying an open interval of
+// compatible compute architectures.
+using SM_min = inner::SM_generic<350>;
+using SM_60 = inner::SM_generic<600>;
+using SM_70 = inner::SM_generic<700>;
+using SM_75 = inner::SM_generic<750>;
+using SM_80 = inner::SM_generic<800>;
+using SM_86 = inner::SM_generic<860>;
+using SM_90 = inner::SM_generic<900>;
+using SM_future = inner::SM_generic<99999>;
+
+// This is a type that uses the __CUDA_ARCH__ macro to obtain the compile-time
+// compute architecture. It can only be used where __CUDA_ARCH__ is defined,
+// i.e., inside a __global__ function template.
+struct SM_compute_arch {
+  template <int dummy = 0>
+  __host__ __device__ constexpr int value() const {
+#ifdef __CUDA_ARCH__
+    return __CUDA_ARCH__;
+#else
+    static_assert(dummy != 0,
+                  "SM_compute_arch.value() is only callable from a __global__ function template. "
+                  "A way to create a function template is by adding 'template <int dummy = 0>'.");
+    return -1;
+#endif
+  }
+};
+
+// A runtime value for the actual compute architecture of a kernel.
+//
+// A single kernel can be compiled for several "virtual" compute architectures.
+// When a program runs, the driver picks the version of the kernel that most
+// closely matches the current hardware. This struct reflects the virtual
+// compute architecture of the version of the kernel that the driver picks when
+// the kernel runs.
+struct SM_runtime {
+  friend SM_runtime kernel_runtime_arch();
+private:
+  const int _version;
+  SM_runtime(int version)
+    : _version (version) {}
+
+public:
+  __host__ __device__ int value() const  {
+    return _version;
+  }
+};
+
+// Computes which compute architecture of a kernel will run
+//
+// Semantics are described above in the documentation of SM_runtime.
+SM_runtime kernel_runtime_arch() {
+  auto kernel = inner::dummy_runtime_kernel;
+  cudaFuncAttributes attributes;
+  cudaFuncGetAttributes(&attributes, kernel);
+
+  return SM_runtime(10 * attributes.ptxVersion);
+}
+
+// SM_range represents a range of SM architectures. It can be used to
+// conditionally compile a kernel.
+template <typename SM_MIN, typename SM_MAX>
+struct SM_range {
+private:
+  const SM_MIN _min;
+  const SM_MAX _max;
+public:
+  __host__ __device__ constexpr SM_range(SM_MIN min, SM_MAX max)
+    : _min(min), _max(max) {}
+
+  template <typename SM_t>
+  __host__ __device__ constexpr bool contains(SM_t current) const {
+    return _min.value() <= current.value() && current.value() < _max.value();
+  }
+};
+
+} // namespace raft::arch


### PR DESCRIPTION
This PR improves the ability to do dispatch based on compute architecture. It is a follow up to #1142.

It has two goals: 

1. Make it easier to specify which compute architectures a kernel is compatible with / should be compiled for.
2. Make it easier to compile a kernel only for the architectures for which it is used (if it is unused, the kernel should be empty).

We have a specific use case in RAFT for this feature. For the L2 pairwise distance kernel we have a CUTLASS based implementation that works om SM80+ and a fallback kernel. Preferably, each kernel is only compiled for the architectures on which it is actually used.

The previous approach can be described as follows (using psuedo code):
``` c++
template <typename DistanceOpT>
__global__ void generic_kernel(DistanceOpT op, other arguments .. ) { .. implementation .. }

__global__ void cutlass_kernel_l2(args.. ) {.. implementation }

template <typename DistanceOpT>
__global__ void generic_kernel_prior_to_sm80(DistanceOpT op, args..) {
#if __CUDA_ARCH__ < 800
  .. copy and paste generic_kernel implementation
#endif
}

template <typename DistanceOpT>
void dispatch(DistanceOpT op, args..) {
  if (! op == l2_distance_op) {
    // run normal generic kernel
    generic_kernel(op, args..);
  } else {
    if (device_capability() >= 800) {
      cutlass_kernel_l2(args...);
    } else {
      generic_kernel_prior_to_sm80(op, args...);
    }
  }
}
```
The main issue is that the generic kernel is copy pasted. In the new approach, the compute architectures for which the generic kernel has to be compiled (the "compatibility range") is given as an argument (using a compile-time tag type). This allows comparing to the compatibility range inside the kernel and early exiting if the architecture for which it is currently compiling is not supported. Therefore, we do not need to copy and paste generic kernel.

``` c++
template <typename DistanceOpT, typename SM_compat_t>
__global__ void generic_kernel(DistanceOpT op, SM_compat_t sm_compat_range, args .. ) {
  // Early exit to minimize the size of the kernel when it is not supposed to be compiled.
  if constexpr(! sm_compat_range.contains(raft::arch::SM_compute_arch())) {
    assert(false);
    return;
  }
  .. rest of implementation ..
}

__global__ void cutlass_kernel_l2(args.. ) {.. implementation }

template <typename DistanceOpT>
void dispatch(DistanceOpT op, args..) {
  if (! op == l2_distance_op) {
    // run normal generic kernel and compile for all architectures:
    auto full_range = raft::arch::SM_range(raft::arch::SM_min(), raft::arch::SM_future());
    generic_kernel(op, full_range, args..);
  } else {
    // Get current architecture of device at runtime
    auto runtime_arch = raft::arch::kernel_runtime_arch();
    // Define compatibility ranges for the cutlass and generic kernel
    auto cutlass_range = raft::arch::SM_range(raft::arch::SM_80(), raft::arch::SM_future());
    auto legacy_range = raft::arch::SM_range(raft::arch::SM_min(), raft::arch::SM_80());

    if (cutlass_range.contains(runtime_arch)) {
      // On SM80+: run cutlass kernel. (this might actually also compile a non-trivial kernel
      // for SM70 but that is unfortunately outside our control)
      cutlass_kernel_l2(args...);
    } else {
      // This will run on architectures < SM80. Also, the compiled kernels from
      // SM80 and higher will be empty (< 10 instructions).
      generic_kernel(op, legacy_range, args...);
    }
  }
}
```
