### PR TITLE
Fix docs upload path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -456,5 +456,5 @@ if hasArg docs; then
     cd ${DOXYGEN_BUILD_DIR}
     doxygen Doxyfile
     cd ${SPHINX_BUILD_DIR}
-    sphinx-build -b dirhtml source _html
+    sphinx-build -b html source _html
 fi

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -51,4 +51,4 @@ for PROJECT in ${PROJECTS[@]}; do
     rm -rf "$DOCS_WORKSPACE/api/$PROJECT/$BRANCH_VERSION/"*
 done
 
-mv "$PROJECT_WORKSPACE/docs/build/html/"* "$DOCS_WORKSPACE/api/raft/$BRANCH_VERSION"
+mv "$PROJECT_WORKSPACE/docs/_html/"* "$DOCS_WORKSPACE/api/raft/$BRANCH_VERSION"


### PR DESCRIPTION
This updates the s3 docs build to copy the generated html files from the correct folder. PR also updates the sphinx buildername flag.