### PR TITLE
Revert `raft-dask` import change

### DIFF
--- a/python/raft-dask/raft_dask/__init__.py
+++ b/python/raft-dask/raft_dask/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022, NVIDIA CORPORATION.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,5 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from .include_test import raft_include_test
 
 __version__ = "23.04.00"


### PR DESCRIPTION
This PR reverts an import change that was made in #1301 ([here](https://github.com/rapidsai/raft/pull/1301/files#diff-54583248030e6e3a9d869829df3b01abcb5a06909dada2d1052589f3c4dc2271L18)).

I'm assuming (though not certain) that this line was inadvertently deleted.

It's causing issues when running `import cugraph` (see screenshot below).

![image](https://user-images.githubusercontent.com/7400326/221968490-1b2c033c-8797-4c64-b0c6-f0ed471ba933.png)


This PR reverts that import change.