### PR TITLE
Pass `AWS_SESSION_TOKEN` and `SCCACHE_S3_USE_SSL` vars to conda build

### DIFF
--- a/conda/recipes/libraft/meta.yaml
+++ b/conda/recipes/libraft/meta.yaml
@@ -23,6 +23,7 @@ outputs:
       script_env: &script_env
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
+        - AWS_SESSION_TOKEN
         - CMAKE_C_COMPILER_LAUNCHER
         - CMAKE_CUDA_COMPILER_LAUNCHER
         - CMAKE_CXX_COMPILER_LAUNCHER
@@ -33,6 +34,7 @@ outputs:
         - SCCACHE_REGION
         - SCCACHE_S3_KEY_PREFIX=libraft-aarch64 # [aarch64]
         - SCCACHE_S3_KEY_PREFIX=libraft-linux64 # [linux64]
+        - SCCACHE_S3_USE_SSL
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:


### PR DESCRIPTION
This PR ensures that the `AWS_SESSION_TOKEN` and `SCCACHE_S3_USE_SSL` environment variables are passed to our conda build process.

`AWS_SESSION_TOKEN` is necessary in order to support using temporary credentials via AWS STS (we recently adopted this method in CI).

`SCCACHE_S3_USE_SSL` has been reported to increase cache performance for S3.
