### PR TITLE
Fix serialize documentation of ivf_flat

### DIFF
--- a/cpp/include/raft/neighbors/ivf_flat_serialize.cuh
+++ b/cpp/include/raft/neighbors/ivf_flat_serialize.cuh
@@ -48,7 +48,6 @@ namespace raft::neighbors::ivf_flat {
  * @param[in] os output stream
  * @param[in] index IVF-Flat index
  *
- * @return raft::neighbors::ivf_flat::index<T, IdxT>
  */
 template <typename T, typename IdxT>
 void serialize(raft::device_resources const& handle, std::ostream& os, const index<T, IdxT>& index)
@@ -79,7 +78,6 @@ void serialize(raft::device_resources const& handle, std::ostream& os, const ind
  * @param[in] filename the file name for saving the index
  * @param[in] index IVF-Flat index
  *
- * @return raft::neighbors::ivf_flat::index<T, IdxT>
  */
 template <typename T, typename IdxT>
 void serialize(raft::device_resources const& handle,

--- a/docs/source/cpp_api/neighbors_ivf_flat.rst
+++ b/docs/source/cpp_api/neighbors_ivf_flat.rst
@@ -14,5 +14,13 @@ namespace *raft::neighbors::ivf_flat*
     :members:
     :content-only:
 
+Serializer Methods
+------------------
+``#include <raft/neighbors/ivf_flat_serialize.cuh>``
 
+namespace *raft::neighbors::ivf_flat*
 
+.. doxygengroup:: ivf_flat_serialize
+    :project: RAFT
+    :members:
+    :content-only:

--- a/docs/source/cpp_api/neighbors_ivf_pq.rst
+++ b/docs/source/cpp_api/neighbors_ivf_pq.rst
@@ -18,14 +18,9 @@ Serializer Methods
 ------------------
 ``#include <raft/neighbors/ivf_pq_serialize.cuh>``
 
-.. doxygenfunction:: serialize(raft::device_resources const& handle, std::ostream& os, const index<IdxT>& index)
-    :project: RAFT
+namespace *raft::neighbors::ivf_pq*
 
-.. doxygenfunction:: serialize(raft::device_resources const& handle, const std::string& filename, const index<IdxT>& index)
+.. doxygengroup:: ivf_pq_serialize
     :project: RAFT
-
-.. doxygenfunction:: deserialize(raft::device_resources const& handle, std::istream& is)
-    :project: RAFT
-
-.. doxygenfunction:: deserialize(raft::device_resources const& handle, const std::string& filename)
-    :project: RAFT
+    :members:
+    :content-only:


### PR DESCRIPTION
I switched the doxygen documentation from `doxygenfunction` to `doxygengroup` because there was an issue resolving the `deserialize` methods on both ivf-flat and ivf-pq.