### PR TITLE
Remove MANIFEST.in use auto-generated one for sdists and package_data for wheels

### DIFF
--- a/python/pylibraft/MANIFEST.in
+++ b/python/pylibraft/MANIFEST.in
@@ -1,7 +1,0 @@
-# Cython files
-recursive-include pylibraft *.pxd
-recursive-include pylibraft *.pyx
-
-# Build files. Don't use a recursive include on '.' in case the repo is dirty
-include . CMakeLists.txt
-recursive-include pylibraft CMakeLists.txt

--- a/python/pylibraft/setup.py
+++ b/python/pylibraft/setup.py
@@ -27,10 +27,11 @@ def exclude_libcxx_symlink(cmake_manifest):
     )
 
 
+packages = find_packages(include=["pylibraft*"])
 setup(
-    include_package_data=True,
     # Don't want libcxx getting pulled into wheel builds.
     cmake_process_manifest_hook=exclude_libcxx_symlink,
-    packages=find_packages(include=["pylibraft", "pylibraft.*"]),
+    packages=packages,
+    package_data={key: ["*.pxd"] for key in packages},
     zip_safe=False,
 )

--- a/python/raft-dask/MANIFEST.in
+++ b/python/raft-dask/MANIFEST.in
@@ -1,7 +1,0 @@
-# Cython files
-recursive-include raft-dask *.pxd
-recursive-include raft-dask *.pyx
-
-# Build files. Don't use a recursive include on '.' in case the repo is dirty
-include . CMakeLists.txt
-recursive-include raft-dask CMakeLists.txt

--- a/python/raft-dask/setup.py
+++ b/python/raft-dask/setup.py
@@ -27,9 +27,10 @@ def exclude_libcxx_symlink(cmake_manifest):
     )
 
 
+packages = find_packages(include=["raft_dask*"])
 setup(
-    include_package_data=True,
     cmake_process_manifest_hook=exclude_libcxx_symlink,
-    packages=find_packages(include=["raft_dask", "raft_dask.*"]),
+    packages=packages,
+    package_data={key: ["*.pxd"] for key in packages},
     zip_safe=False,
 )


### PR DESCRIPTION
<!--

Thank you for contributing to RAFT :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->
Using MANIFEST.in currently runs into a pretty nasty scikit-build bug (https://github.com/scikit-build/scikit-build/issues/886) that results in any file included by the manifest being copied from the install tree back into the source tree whenever an in place build occurs after an install, overwriting any local changes. We need an alternative approach to ensure that all necessary files are included in built packages. There are two types:
- sdists: scikit-build automatically generates a manifest during sdist generation if we don't provide one, and that manifest is reliably complete. It contains all files needed for a source build up to the raft C++ code (which has always been true and is something we can come back to improving later if desired).
- wheels: The autogenerated manifest is not used during wheel generation because the manifest generation hook is not invoked during wheel builds, so to include data in the wheels we must provide the `package_data` argument to `setup`. In this case we do not need to include CMake or pyx files because the result does not need to be possible to build from, it just needs pxd files for other packages to cimport if desired.
