### PR TITLE
Fix ivf flat specialization header IdxT from uint64_t -> int64_t

### DIFF
--- a/cpp/include/raft/neighbors/specializations/ivf_flat.cuh
+++ b/cpp/include/raft/neighbors/specializations/ivf_flat.cuh
@@ -46,9 +46,9 @@ namespace raft::neighbors::ivf_flat {
                               raft::device_matrix_view<IdxT, IdxT, row_major>,               \
                               raft::device_matrix_view<float, IdxT, row_major>);
 
-RAFT_INST(float, uint64_t);
-RAFT_INST(int8_t, uint64_t);
-RAFT_INST(uint8_t, uint64_t);
+RAFT_INST(float, int64_t);
+RAFT_INST(int8_t, int64_t);
+RAFT_INST(uint8_t, int64_t);
 
 #undef RAFT_INST
 }  // namespace raft::neighbors::ivf_flat

--- a/cpp/include/raft/neighbors/specializations/ivf_flat.cuh
+++ b/cpp/include/raft/neighbors/specializations/ivf_flat.cuh
@@ -20,30 +20,30 @@
 
 namespace raft::neighbors::ivf_flat {
 
-#define RAFT_INST(T, IdxT)                                                                   \
-  extern template auto build(raft::device_resources const& handle,                           \
-                             const index_params& params,                                     \
-                             raft::device_matrix_view<const T, uint64_t, row_major> dataset) \
-    ->index<T, IdxT>;                                                                        \
-                                                                                             \
-  extern template auto extend(                                                               \
-    raft::device_resources const& handle,                                                    \
-    raft::device_matrix_view<const T, IdxT, row_major> new_vectors,                          \
-    std::optional<raft::device_vector_view<const IdxT, IdxT>> new_indices,                   \
-    const index<T, IdxT>& orig_index)                                                        \
-    ->index<T, IdxT>;                                                                        \
-                                                                                             \
-  extern template void extend(                                                               \
-    raft::device_resources const& handle,                                                    \
-    raft::device_matrix_view<const T, IdxT, row_major> new_vectors,                          \
-    std::optional<raft::device_vector_view<const IdxT, IdxT>> new_indices,                   \
-    raft::neighbors::ivf_flat::index<T, IdxT>* idx);                                         \
-                                                                                             \
-  extern template void search(raft::device_resources const&,                                 \
-                              raft::neighbors::ivf_flat::search_params const&,               \
-                              const raft::neighbors::ivf_flat::index<T, IdxT>&,              \
-                              raft::device_matrix_view<const T, IdxT, row_major>,            \
-                              raft::device_matrix_view<IdxT, IdxT, row_major>,               \
+#define RAFT_INST(T, IdxT)                                                               \
+  extern template auto build(raft::device_resources const& handle,                       \
+                             const index_params& params,                                 \
+                             raft::device_matrix_view<const T, IdxT, row_major> dataset) \
+    ->index<T, IdxT>;                                                                    \
+                                                                                         \
+  extern template auto extend(                                                           \
+    raft::device_resources const& handle,                                                \
+    raft::device_matrix_view<const T, IdxT, row_major> new_vectors,                      \
+    std::optional<raft::device_vector_view<const IdxT, IdxT>> new_indices,               \
+    const index<T, IdxT>& orig_index)                                                    \
+    ->index<T, IdxT>;                                                                    \
+                                                                                         \
+  extern template void extend(                                                           \
+    raft::device_resources const& handle,                                                \
+    raft::device_matrix_view<const T, IdxT, row_major> new_vectors,                      \
+    std::optional<raft::device_vector_view<const IdxT, IdxT>> new_indices,               \
+    raft::neighbors::ivf_flat::index<T, IdxT>* idx);                                     \
+                                                                                         \
+  extern template void search(raft::device_resources const&,                             \
+                              raft::neighbors::ivf_flat::search_params const&,           \
+                              const raft::neighbors::ivf_flat::index<T, IdxT>&,          \
+                              raft::device_matrix_view<const T, IdxT, row_major>,        \
+                              raft::device_matrix_view<IdxT, IdxT, row_major>,           \
                               raft::device_matrix_view<float, IdxT, row_major>);
 
 RAFT_INST(float, int64_t);


### PR DESCRIPTION
The ivf_flat specialization header declarations used a wrong index type. 

The specializations for ivf flat are defined for int64_t. The raft_runtime interface also uses the int64_t instances. The ivf_flat specialization header, however, declared an interface using uint64_t.

This is fixed with this PR. Should also reduce compile times for `src/distance/neighbors/ivf_flat_search.cu.o`