### PR TITLE
[REVIEW] Pin `dask` and `distributed` for release

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,5 @@
 name: pr
 
-
 on:
   push:
     branches:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,6 @@
 name: pr
 
+
 on:
   push:
     branches:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -105,7 +105,7 @@ jobs:
       build_type: pull-request
       package-name: raft_dask
       # Always want to test against latest dask/distributed.
-      test-before-amd64: "RAPIDS_PY_WHEEL_NAME=pylibraft_cu11 rapids-download-wheels-from-s3 ./local-pylibraft-dep && pip install --no-deps ./local-pylibraft-dep/pylibraft*.whl && pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
-      test-before-arm64: "RAPIDS_PY_WHEEL_NAME=pylibraft_cu11 rapids-download-wheels-from-s3 ./local-pylibraft-dep && pip install --no-deps ./local-pylibraft-dep/pylibraft*.whl && pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
+      test-before-amd64: "RAPIDS_PY_WHEEL_NAME=pylibraft_cu11 rapids-download-wheels-from-s3 ./local-pylibraft-dep && pip install --no-deps ./local-pylibraft-dep/pylibraft*.whl && pip install git+https://github.com/dask/dask.git@2023.3.2 git+https://github.com/dask/distributed.git@2023.3.2.1 git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
+      test-before-arm64: "RAPIDS_PY_WHEEL_NAME=pylibraft_cu11 rapids-download-wheels-from-s3 ./local-pylibraft-dep && pip install --no-deps ./local-pylibraft-dep/pylibraft*.whl && pip install git+https://github.com/dask/dask.git@2023.3.2 git+https://github.com/dask/distributed.git@2023.3.2.1 git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
       test-unittest: "python -m pytest -v ./python/raft-dask/raft_dask/test"
       test-smoketest: "python ./ci/wheel_smoke_test_raft_dask.py"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,6 +51,6 @@ jobs:
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
       package-name: raft_dask
-      test-before-amd64: "pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
-      test-before-arm64: "pip install git+https://github.com/dask/dask.git@main git+https://github.com/dask/distributed.git@main git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
+      test-before-amd64: "pip install git+https://github.com/dask/dask.git@2023.3.2 git+https://github.com/dask/distributed.git@2023.3.2.1 git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
+      test-before-arm64: "pip install git+https://github.com/dask/dask.git@2023.3.2 git+https://github.com/dask/distributed.git@2023.3.2.1 git+https://github.com/rapidsai/dask-cuda.git@branch-23.04"
       test-unittest: "python -m pytest -v ./python/raft-dask/raft_dask/test"

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -20,6 +20,7 @@ dependencies:
 - cython>=0.29,<0.30
 - dask-cuda==23.4.*
 - dask==2023.3.2
+- dask-core==2023.3.2
 - distributed==2023.3.2.1
 - doxygen>=1.8.20
 - gcc_linux-64=11.*

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -19,8 +19,8 @@ dependencies:
 - cxx-compiler
 - cython>=0.29,<0.30
 - dask-cuda==23.4.*
-- dask>=2023.1.1
-- distributed>=2023.1.1
+- dask==2023.3.2
+- distributed==2023.3.2.1
 - doxygen>=1.8.20
 - gcc_linux-64=11.*
 - graphviz

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -18,9 +18,9 @@ dependencies:
 - cupy
 - cxx-compiler
 - cython>=0.29,<0.30
+- dask-core==2023.3.2
 - dask-cuda==23.4.*
 - dask==2023.3.2
-- dask-core==2023.3.2
 - distributed==2023.3.2.1
 - doxygen>=1.8.20
 - gcc_linux-64=11.*

--- a/conda/recipes/raft-dask/meta.yaml
+++ b/conda/recipes/raft-dask/meta.yaml
@@ -46,9 +46,9 @@ requirements:
   run:
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - cuda-python >=11.7.1,<12.0
-    - dask >=2023.1.1
+    - dask ==2023.3.2
     - dask-cuda ={{ minor_version }}
-    - distributed >=2023.1.1
+    - distributed ==2023.3.2.1
     - joblib >=0.11
     - nccl >=2.9.9
     - pylibraft {{ version }}

--- a/conda/recipes/raft-dask/meta.yaml
+++ b/conda/recipes/raft-dask/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - {{ pin_compatible('cudatoolkit', max_pin='x', min_pin='x') }}
     - cuda-python >=11.7.1,<12.0
     - dask ==2023.3.2
+    - dask-core ==2023.3.2
     - dask-cuda ={{ minor_version }}
     - distributed ==2023.3.2.1
     - joblib >=0.11

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -266,7 +266,6 @@ dependencies:
       - output_types: [conda, pyproject]
         packages:
           - dask==2023.3.2
-          - dask-core==2023.3.2
           - dask-cuda==23.4.*
           - distributed==2023.3.2.1
           - joblib>=0.11
@@ -275,6 +274,7 @@ dependencies:
           - ucx-py==0.31.*
       - output_types: conda
         packages:
+          - dask-core==2023.3.2
           - ucx>=1.13.0
           - ucx-proc=*=gpu
       - output_types: pyproject

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -265,9 +265,9 @@ dependencies:
     common:
       - output_types: [conda, pyproject]
         packages:
-          - dask>=2023.1.1
+          - dask==2023.3.2
           - dask-cuda==23.4.*
-          - distributed>=2023.1.1
+          - distributed==2023.3.2.1
           - joblib>=0.11
           - numba>=0.49
           - *numpy

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -266,6 +266,7 @@ dependencies:
       - output_types: [conda, pyproject]
         packages:
           - dask==2023.3.2
+          - dask-core==2023.3.2
           - dask-cuda==23.4.*
           - distributed==2023.3.2.1
           - joblib>=0.11

--- a/python/raft-dask/pyproject.toml
+++ b/python/raft-dask/pyproject.toml
@@ -35,8 +35,8 @@ license = { text = "Apache 2.0" }
 requires-python = ">=3.8"
 dependencies = [
     "dask-cuda==23.4.*",
-    "dask>=2023.1.1",
-    "distributed>=2023.1.1",
+    "dask==2023.3.2",
+    "distributed==2023.3.2.1",
     "joblib>=0.11",
     "numba>=0.49",
     "numpy>=1.21",

--- a/python/raft-dask/pyproject.toml
+++ b/python/raft-dask/pyproject.toml
@@ -35,6 +35,7 @@ license = { text = "Apache 2.0" }
 requires-python = ">=3.8"
 dependencies = [
     "dask-cuda==23.4.*",
+    "dask-core==2023.3.2",
     "dask==2023.3.2",
     "distributed==2023.3.2.1",
     "joblib>=0.11",

--- a/python/raft-dask/pyproject.toml
+++ b/python/raft-dask/pyproject.toml
@@ -34,7 +34,6 @@ authors = [
 license = { text = "Apache 2.0" }
 requires-python = ">=3.8"
 dependencies = [
-    "dask-core==2023.3.2",
     "dask-cuda==23.4.*",
     "dask==2023.3.2",
     "distributed==2023.3.2.1",

--- a/python/raft-dask/pyproject.toml
+++ b/python/raft-dask/pyproject.toml
@@ -34,8 +34,8 @@ authors = [
 license = { text = "Apache 2.0" }
 requires-python = ">=3.8"
 dependencies = [
-    "dask-cuda==23.4.*",
     "dask-core==2023.3.2",
+    "dask-cuda==23.4.*",
     "dask==2023.3.2",
     "distributed==2023.3.2.1",
     "joblib>=0.11",


### PR DESCRIPTION
This PR pins `dask` and `distributed` to `2023.3.2` and `2023.3.2.1` respectively for `23.04` release.

xref: https://github.com/rapidsai/cudf/pull/13070