### PR TITLE
Remove uses-setup-env-vars

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,6 @@ jobs:
       package-name: pylibraft
       package-dir: python/pylibraft
       skbuild-configure-options: "-DRAFT_BUILD_WHEELS=ON -DDETECT_CONDA_ENV=OFF -DFIND_RAFT_CPP=OFF"
-      uses-setup-env-vars: false
   wheel-publish-pylibraft:
     needs: wheel-build-pylibraft
     secrets: inherit
@@ -98,7 +97,6 @@ jobs:
       package-name: raft_dask
       package-dir: python/raft-dask
       skbuild-configure-options: "-DRAFT_BUILD_WHEELS=ON -DDETECT_CONDA_ENV=OFF -DFIND_RAFT_CPP=OFF"
-      uses-setup-env-vars: false
   wheel-publish-raft-dask:
     needs: wheel-build-raft-dask
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -73,7 +73,6 @@ jobs:
       package-name: pylibraft
       package-dir: python/pylibraft
       skbuild-configure-options: "-DRAFT_BUILD_WHEELS=ON -DDETECT_CONDA_ENV=OFF -DFIND_RAFT_CPP=OFF"
-      uses-setup-env-vars: false
   wheel-tests-pylibraft:
     needs: wheel-build-pylibraft
     secrets: inherit
@@ -96,7 +95,6 @@ jobs:
       package-dir: python/raft-dask
       before-wheel: "RAPIDS_PY_WHEEL_NAME=pylibraft_cu11 rapids-download-wheels-from-s3 ./local-wheelhouse"
       skbuild-configure-options: "-DRAFT_BUILD_WHEELS=ON -DDETECT_CONDA_ENV=OFF -DFIND_RAFT_CPP=OFF"
-      uses-setup-env-vars: false
   wheel-tests-raft-dask:
     needs: wheel-build-raft-dask
     secrets: inherit


### PR DESCRIPTION
This setting now matches the default behavior of the shared-action-workflows repo
