### PR TITLE
Using `raft::resources` across `raft::random`

### DIFF
--- a/cpp/include/raft/linalg/detail/qr.cuh
+++ b/cpp/include/raft/linalg/detail/qr.cuh
@@ -18,6 +18,8 @@
 
 #include "cublas_wrappers.hpp"
 #include "cusolver_wrappers.hpp"
+#include <raft/core/resource/cusolver_dn_handle.hpp>
+#include <raft/core/resources.hpp>
 #include <raft/matrix/matrix.cuh>
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
@@ -42,10 +44,10 @@ namespace detail {
  */
 template <typename math_t>
 void qrGetQ_inplace(
-  raft::device_resources const& handle, math_t* Q, int n_rows, int n_cols, cudaStream_t stream)
+  raft::resources const& handle, math_t* Q, int n_rows, int n_cols, cudaStream_t stream)
 {
   RAFT_EXPECTS(n_rows >= n_cols, "QR decomposition expects n_rows >= n_cols.");
-  cusolverDnHandle_t cusolver = handle.get_cusolver_dn_handle();
+  cusolverDnHandle_t cusolver = resource::get_cusolver_dn_handle(handle);
 
   rmm::device_uvector<math_t> tau(n_cols, stream);
   RAFT_CUDA_TRY(cudaMemsetAsync(tau.data(), 0, sizeof(math_t) * n_cols, stream));
@@ -83,7 +85,7 @@ void qrGetQ_inplace(
 }
 
 template <typename math_t>
-void qrGetQ(raft::device_resources const& handle,
+void qrGetQ(raft::resources const& handle,
             const math_t* M,
             math_t* Q,
             int n_rows,
@@ -95,7 +97,7 @@ void qrGetQ(raft::device_resources const& handle,
 }
 
 template <typename math_t>
-void qrGetQR(raft::device_resources const& handle,
+void qrGetQR(raft::resources const& handle,
              math_t* M,
              math_t* Q,
              math_t* R,
@@ -103,7 +105,7 @@ void qrGetQR(raft::device_resources const& handle,
              int n_cols,
              cudaStream_t stream)
 {
-  cusolverDnHandle_t cusolverH = handle.get_cusolver_dn_handle();
+  cusolverDnHandle_t cusolverH = resource::get_cusolver_dn_handle(handle);
 
   int m = n_rows, n = n_cols;
   rmm::device_uvector<math_t> R_full(m * n, stream);

--- a/cpp/include/raft/linalg/qr.cuh
+++ b/cpp/include/raft/linalg/qr.cuh
@@ -19,6 +19,8 @@
 #pragma once
 
 #include "detail/qr.cuh"
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resources.hpp>
 
 namespace raft {
 namespace linalg {
@@ -33,7 +35,7 @@ namespace linalg {
  * @param stream cuda stream
  */
 template <typename math_t>
-void qrGetQ(raft::device_resources const& handle,
+void qrGetQ(raft::resources const& handle,
             const math_t* M,
             math_t* Q,
             int n_rows,
@@ -54,7 +56,7 @@ void qrGetQ(raft::device_resources const& handle,
  * @param stream cuda stream
  */
 template <typename math_t>
-void qrGetQR(raft::device_resources const& handle,
+void qrGetQR(raft::resources const& handle,
              math_t* M,
              math_t* Q,
              math_t* R,
@@ -77,13 +79,18 @@ void qrGetQR(raft::device_resources const& handle,
  * @param[out] Q Output raft::device_matrix_view
  */
 template <typename ElementType, typename IndexType>
-void qr_get_q(raft::device_resources const& handle,
+void qr_get_q(raft::resources const& handle,
               raft::device_matrix_view<const ElementType, IndexType, raft::col_major> M,
               raft::device_matrix_view<ElementType, IndexType, raft::col_major> Q)
 {
   RAFT_EXPECTS(Q.size() == M.size(), "Size mismatch between Output and Input");
 
-  qrGetQ(handle, M.data_handle(), Q.data_handle(), M.extent(0), M.extent(1), handle.get_stream());
+  qrGetQ(handle,
+         M.data_handle(),
+         Q.data_handle(),
+         M.extent(0),
+         M.extent(1),
+         resource::get_cuda_stream(handle));
 }
 
 /**
@@ -94,7 +101,7 @@ void qr_get_q(raft::device_resources const& handle,
  * @param[out] R Output raft::device_matrix_view
  */
 template <typename ElementType, typename IndexType>
-void qr_get_qr(raft::device_resources const& handle,
+void qr_get_qr(raft::resources const& handle,
                raft::device_matrix_view<const ElementType, IndexType, raft::col_major> M,
                raft::device_matrix_view<ElementType, IndexType, raft::col_major> Q,
                raft::device_matrix_view<ElementType, IndexType, raft::col_major> R)
@@ -107,7 +114,7 @@ void qr_get_qr(raft::device_resources const& handle,
           R.data_handle(),
           M.extent(0),
           M.extent(1),
-          handle.get_stream());
+          resource::get_cuda_stream(handle));
 }
 
 /** @} */

--- a/cpp/include/raft/linalg/transpose.cuh
+++ b/cpp/include/raft/linalg/transpose.cuh
@@ -20,6 +20,7 @@
 
 #include "detail/transpose.cuh"
 #include <raft/core/device_mdarray.hpp>
+#include <raft/core/resources.hpp>
 
 namespace raft {
 namespace linalg {
@@ -34,7 +35,7 @@ namespace linalg {
  * @param stream: cuda stream
  */
 template <typename math_t>
-void transpose(raft::device_resources const& handle,
+void transpose(raft::resources const& handle,
                math_t* in,
                math_t* out,
                int n_rows,
@@ -76,7 +77,7 @@ void transpose(math_t* inout, int n, cudaStream_t stream)
  * @param[out] out    Output matirx, storage is pre-allocated by caller.
  */
 template <typename T, typename IndexType, typename LayoutPolicy, typename AccessorPolicy>
-auto transpose(raft::device_resources const& handle,
+auto transpose(raft::resources const& handle,
                raft::mdspan<T, raft::matrix_extent<IndexType>, LayoutPolicy, AccessorPolicy> in,
                raft::mdspan<T, raft::matrix_extent<IndexType>, LayoutPolicy, AccessorPolicy> out)
   -> std::enable_if_t<std::is_floating_point_v<T>, void>

--- a/cpp/include/raft/random/detail/make_regression.cuh
+++ b/cpp/include/raft/random/detail/make_regression.cuh
@@ -22,7 +22,8 @@
 
 #include <algorithm>
 
-#include <raft/core/device_resources.hpp>
+#include <raft/core/resource/cublas_handle.hpp>
+#include <raft/core/resources.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/detail/cublas_wrappers.hpp>
 #include <raft/linalg/init.cuh>
@@ -52,7 +53,7 @@ static __global__ void _singular_profile_kernel(DataT* out, IdxT n, DataT tail_s
 
 /* Internal auxiliary function to generate a low-rank matrix */
 template <typename DataT, typename IdxT>
-static void _make_low_rank_matrix(raft::device_resources const& handle,
+static void _make_low_rank_matrix(raft::resources const& handle,
                                   DataT* out,
                                   IdxT n_rows,
                                   IdxT n_cols,
@@ -61,8 +62,7 @@ static void _make_low_rank_matrix(raft::device_resources const& handle,
                                   raft::random::RngState& r,
                                   cudaStream_t stream)
 {
-  cusolverDnHandle_t cusolver_handle = handle.get_cusolver_dn_handle();
-  cublasHandle_t cublas_handle       = handle.get_cublas_handle();
+  cublasHandle_t cublas_handle = resource::get_cublas_handle(handle);
 
   IdxT n = std::min(n_rows, n_cols);
 
@@ -143,7 +143,7 @@ static __global__ void _gather2d_kernel(
 }
 
 template <typename DataT, typename IdxT>
-void make_regression_caller(raft::device_resources const& handle,
+void make_regression_caller(raft::resources const& handle,
                             DataT* out,
                             DataT* values,
                             IdxT n_rows,
@@ -162,8 +162,7 @@ void make_regression_caller(raft::device_resources const& handle,
 {
   n_informative = std::min(n_informative, n_cols);
 
-  cusolverDnHandle_t cusolver_handle = handle.get_cusolver_dn_handle();
-  cublasHandle_t cublas_handle       = handle.get_cublas_handle();
+  cublasHandle_t cublas_handle = resource::get_cublas_handle(handle);
 
   cublasSetPointerMode(cublas_handle, CUBLAS_POINTER_MODE_HOST);
   raft::random::RngState r(seed, type);

--- a/cpp/include/raft/random/detail/rmat_rectangular_generator.cuh
+++ b/cpp/include/raft/random/detail/rmat_rectangular_generator.cuh
@@ -18,7 +18,8 @@
 
 #include "rmat_rectangular_generator_types.cuh"
 
-#include <raft/core/device_resources.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resources.hpp>
 #include <raft/random/rng_device.cuh>
 #include <raft/random/rng_state.hpp>
 #include <raft/util/cuda_utils.cuh>
@@ -206,7 +207,7 @@ void rmat_rectangular_gen_caller(IdxT* out,
  * @param[in]  c_scale 2^c_scale represents the number of destination nodes
  */
 template <typename IdxT, typename ProbT>
-void rmat_rectangular_gen_impl(raft::device_resources const& handle,
+void rmat_rectangular_gen_impl(raft::resources const& handle,
                                raft::random::RngState& r,
                                raft::device_vector_view<const ProbT, IdxT> theta,
                                raft::random::detail::rmat_rectangular_gen_output<IdxT> output,
@@ -247,7 +248,7 @@ void rmat_rectangular_gen_impl(raft::device_resources const& handle,
                               r_scale,
                               c_scale,
                               n_edges,
-                              handle.get_stream(),
+                              resource::get_cuda_stream(handle),
                               r);
 }
 
@@ -259,7 +260,7 @@ void rmat_rectangular_gen_impl(raft::device_resources const& handle,
  * `theta` parameter.
  */
 template <typename IdxT, typename ProbT>
-void rmat_rectangular_gen_impl(raft::device_resources const& handle,
+void rmat_rectangular_gen_impl(raft::resources const& handle,
                                raft::random::RngState& r,
                                raft::random::detail::rmat_rectangular_gen_output<IdxT> output,
                                ProbT a,
@@ -286,8 +287,17 @@ void rmat_rectangular_gen_impl(raft::device_resources const& handle,
   IdxT* out_dst_ptr            = out_dst_has_value ? (*out_dst).data_handle() : nullptr;
   const IdxT n_edges           = output.number_of_edges();
 
-  detail::rmat_rectangular_gen_caller(
-    out_ptr, out_src_ptr, out_dst_ptr, a, b, c, r_scale, c_scale, n_edges, handle.get_stream(), r);
+  detail::rmat_rectangular_gen_caller(out_ptr,
+                                      out_src_ptr,
+                                      out_dst_ptr,
+                                      a,
+                                      b,
+                                      c,
+                                      r_scale,
+                                      c_scale,
+                                      n_edges,
+                                      resource::get_cuda_stream(handle),
+                                      r);
 }
 
 }  // end namespace detail

--- a/cpp/include/raft/random/detail/rng_impl_deprecated.cuh
+++ b/cpp/include/raft/random/detail/rng_impl_deprecated.cuh
@@ -23,7 +23,7 @@
 #include "rng_device.cuh"
 
 #include <curand_kernel.h>
-#include <raft/core/device_resources.hpp>
+#include <raft/core/resources.hpp>
 #include <raft/random/rng_state.hpp>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/detail/cub_wrappers.cuh>
@@ -259,7 +259,7 @@ class RngImpl {
 
   template <typename DataT, typename WeightsT, typename IdxT = int>
   METHOD_DEPR(sampleWithoutReplacement)
-  void sampleWithoutReplacement(raft::device_resources const& handle,
+  void sampleWithoutReplacement(raft::resources const& handle,
                                 DataT* out,
                                 IdxT* outIdx,
                                 const DataT* in,

--- a/cpp/include/raft/random/make_blobs.cuh
+++ b/cpp/include/raft/random/make_blobs.cuh
@@ -22,6 +22,8 @@
 #include "detail/make_blobs.cuh"
 #include <optional>
 #include <raft/core/device_mdspan.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resources.hpp>
 
 namespace raft::random {
 
@@ -129,7 +131,7 @@ void make_blobs(DataT* out,
  */
 template <typename DataT, typename IdxT, typename layout>
 void make_blobs(
-  raft::device_resources const& handle,
+  raft::resources const& handle,
   raft::device_matrix_view<DataT, IdxT, layout> out,
   raft::device_vector_view<IdxT, IdxT> labels,
   IdxT n_clusters                                                        = 5,
@@ -167,7 +169,7 @@ void make_blobs(
                             (IdxT)out.extent(0),
                             (IdxT)out.extent(1),
                             n_clusters,
-                            handle.get_stream(),
+                            resource::get_cuda_stream(handle),
                             row_major,
                             prm_centers,
                             prm_cluster_std,

--- a/cpp/include/raft/random/make_regression.cuh
+++ b/cpp/include/raft/random/make_regression.cuh
@@ -26,6 +26,8 @@
 #include <algorithm>
 #include <optional>
 #include <raft/core/mdarray.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resources.hpp>
 
 #include "detail/make_regression.cuh"
 
@@ -67,7 +69,7 @@ namespace raft::random {
  * @param[in]   type            Random generator type
  */
 template <typename DataT, typename IdxT>
-void make_regression(raft::device_resources const& handle,
+void make_regression(raft::resources const& handle,
                      DataT* out,
                      DataT* values,
                      IdxT n_rows,
@@ -138,7 +140,7 @@ void make_regression(raft::device_resources const& handle,
  * @param[in]   type            Random generator type
  */
 template <typename DataT, typename IdxT>
-void make_regression(raft::device_resources const& handle,
+void make_regression(raft::resources const& handle,
                      raft::device_matrix_view<DataT, IdxT, raft::row_major> out,
                      raft::device_matrix_view<DataT, IdxT, raft::row_major> values,
                      IdxT n_informative,
@@ -170,7 +172,7 @@ void make_regression(raft::device_resources const& handle,
                                  n_samples,
                                  n_features,
                                  n_informative,
-                                 handle.get_stream(),
+                                 resource::get_cuda_stream(handle),
                                  coef_ptr,
                                  n_targets,
                                  bias,

--- a/cpp/include/raft/random/multi_variable_gaussian.cuh
+++ b/cpp/include/raft/random/multi_variable_gaussian.cuh
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "detail/multi_variable_gaussian.cuh"
+#include <raft/core/resources.hpp>
 #include <raft/random/random_types.hpp>
 
 namespace raft::random {
@@ -30,7 +31,7 @@ namespace raft::random {
  */
 
 template <typename ValueType>
-void multi_variable_gaussian(raft::device_resources const& handle,
+void multi_variable_gaussian(raft::resources const& handle,
                              rmm::mr::device_memory_resource& mem_resource,
                              std::optional<raft::device_vector_view<const ValueType, int>> x,
                              raft::device_matrix_view<ValueType, int, raft::col_major> P,
@@ -41,7 +42,7 @@ void multi_variable_gaussian(raft::device_resources const& handle,
 }
 
 template <typename ValueType>
-void multi_variable_gaussian(raft::device_resources const& handle,
+void multi_variable_gaussian(raft::resources const& handle,
                              std::optional<raft::device_vector_view<const ValueType, int>> x,
                              raft::device_matrix_view<ValueType, int, raft::col_major> P,
                              raft::device_matrix_view<ValueType, int, raft::col_major> X,

--- a/cpp/include/raft/random/permute.cuh
+++ b/cpp/include/raft/random/permute.cuh
@@ -23,7 +23,8 @@
 
 #include <optional>
 #include <raft/core/device_mdspan.hpp>
-#include <raft/core/device_resources.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resources.hpp>
 #include <type_traits>
 
 namespace raft::random {
@@ -95,7 +96,7 @@ using perms_out_view_t = typename perms_out_view<T, InputOutputValueType, IdxTyp
  *   then we recommend Knuth Shuffle.
  */
 template <typename InputOutputValueType, typename IntType, typename IdxType, typename Layout>
-void permute(raft::device_resources const& handle,
+void permute(raft::resources const& handle,
              raft::device_matrix_view<const InputOutputValueType, IdxType, Layout> in,
              std::optional<raft::device_vector_view<IntType, IdxType>> permsOut,
              std::optional<raft::device_matrix_view<InputOutputValueType, IdxType, Layout>> out)
@@ -128,8 +129,13 @@ void permute(raft::device_resources const& handle,
   if (permsOut_ptr != nullptr || out_ptr != nullptr) {
     const IdxType N = in.extent(0);
     const IdxType D = in.extent(1);
-    detail::permute<InputOutputValueType, IntType, IdxType>(
-      permsOut_ptr, out_ptr, in.data_handle(), D, N, is_row_major, handle.get_stream());
+    detail::permute<InputOutputValueType, IntType, IdxType>(permsOut_ptr,
+                                                            out_ptr,
+                                                            in.data_handle(),
+                                                            D,
+                                                            N,
+                                                            is_row_major,
+                                                            resource::get_cuda_stream(handle));
   }
 }
 
@@ -142,7 +148,7 @@ template <typename InputOutputValueType,
           typename Layout,
           typename PermsOutType,
           typename OutType>
-void permute(raft::device_resources const& handle,
+void permute(raft::resources const& handle,
              raft::device_matrix_view<const InputOutputValueType, IdxType, Layout> in,
              PermsOutType&& permsOut,
              OutType&& out)

--- a/cpp/include/raft/random/rmat_rectangular_generator.cuh
+++ b/cpp/include/raft/random/rmat_rectangular_generator.cuh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "detail/rmat_rectangular_generator.cuh"
+#include <raft/core/resources.hpp>
 
 namespace raft::random {
 
@@ -78,7 +79,7 @@ namespace raft::random {
  */
 template <typename IdxT, typename ProbT>
 void rmat_rectangular_gen(
-  raft::device_resources const& handle,
+  raft::resources const& handle,
   raft::random::RngState& r,
   raft::device_vector_view<const ProbT, IdxT> theta,
   raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major> out,
@@ -102,7 +103,7 @@ void rmat_rectangular_gen(
  * @pre `out_src.extent(0) == out_dst.extent(0)` is `true`
  */
 template <typename IdxT, typename ProbT>
-void rmat_rectangular_gen(raft::device_resources const& handle,
+void rmat_rectangular_gen(raft::resources const& handle,
                           raft::random::RngState& r,
                           raft::device_vector_view<const ProbT, IdxT> theta,
                           raft::device_vector_view<IdxT, IdxT> out_src,
@@ -125,7 +126,7 @@ void rmat_rectangular_gen(raft::device_resources const& handle,
  */
 template <typename IdxT, typename ProbT>
 void rmat_rectangular_gen(
-  raft::device_resources const& handle,
+  raft::resources const& handle,
   raft::random::RngState& r,
   raft::device_vector_view<const ProbT, IdxT> theta,
   raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major> out,
@@ -152,7 +153,7 @@ void rmat_rectangular_gen(
  */
 template <typename IdxT, typename ProbT>
 void rmat_rectangular_gen(
-  raft::device_resources const& handle,
+  raft::resources const& handle,
   raft::random::RngState& r,
   raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major> out,
   raft::device_vector_view<IdxT, IdxT> out_src,
@@ -179,7 +180,7 @@ void rmat_rectangular_gen(
  * @pre `out_src.extent(0) == out_dst.extent(0)` is `true`
  */
 template <typename IdxT, typename ProbT>
-void rmat_rectangular_gen(raft::device_resources const& handle,
+void rmat_rectangular_gen(raft::resources const& handle,
                           raft::random::RngState& r,
                           raft::device_vector_view<IdxT, IdxT> out_src,
                           raft::device_vector_view<IdxT, IdxT> out_dst,
@@ -204,7 +205,7 @@ void rmat_rectangular_gen(raft::device_resources const& handle,
  */
 template <typename IdxT, typename ProbT>
 void rmat_rectangular_gen(
-  raft::device_resources const& handle,
+  raft::resources const& handle,
   raft::random::RngState& r,
   raft::device_mdspan<IdxT, raft::extents<IdxT, raft::dynamic_extent, 2>, raft::row_major> out,
   ProbT a,

--- a/cpp/include/raft/random/rng.cuh
+++ b/cpp/include/raft/random/rng.cuh
@@ -22,7 +22,8 @@
 #include <cassert>
 #include <optional>
 #include <raft/core/device_mdspan.hpp>
-#include <raft/core/device_resources.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resources.hpp>
 #include <type_traits>
 #include <variant>
 
@@ -41,13 +42,14 @@ namespace raft::random {
  * @param[in] end end of the range
  */
 template <typename OutputValueType, typename IndexType>
-void uniform(raft::device_resources const& handle,
+void uniform(raft::resources const& handle,
              RngState& rng_state,
              raft::device_vector_view<OutputValueType, IndexType> out,
              OutputValueType start,
              OutputValueType end)
 {
-  detail::uniform(rng_state, out.data_handle(), out.extent(0), start, end, handle.get_stream());
+  detail::uniform(
+    rng_state, out.data_handle(), out.extent(0), start, end, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -63,14 +65,14 @@ void uniform(raft::device_resources const& handle,
  * @param[in] end end of the range
  */
 template <typename OutType, typename LenType = int>
-void uniform(raft::device_resources const& handle,
+void uniform(raft::resources const& handle,
              RngState& rng_state,
              OutType* ptr,
              LenType len,
              OutType start,
              OutType end)
 {
-  detail::uniform(rng_state, ptr, len, start, end, handle.get_stream());
+  detail::uniform(rng_state, ptr, len, start, end, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -86,7 +88,7 @@ void uniform(raft::device_resources const& handle,
  * @param[in] end end of the range
  */
 template <typename OutputValueType, typename IndexType>
-void uniformInt(raft::device_resources const& handle,
+void uniformInt(raft::resources const& handle,
                 RngState& rng_state,
                 raft::device_vector_view<OutputValueType, IndexType> out,
                 OutputValueType start,
@@ -98,7 +100,8 @@ void uniformInt(raft::device_resources const& handle,
     "so that we can write to it.");
   static_assert(std::is_integral<OutputValueType>::value,
                 "uniformInt: The elements of the output vector must have integral type.");
-  detail::uniformInt(rng_state, out.data_handle(), out.extent(0), start, end, handle.get_stream());
+  detail::uniformInt(
+    rng_state, out.data_handle(), out.extent(0), start, end, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -114,14 +117,14 @@ void uniformInt(raft::device_resources const& handle,
  * @param[in] end end of the range
  */
 template <typename OutType, typename LenType = int>
-void uniformInt(raft::device_resources const& handle,
+void uniformInt(raft::resources const& handle,
                 RngState& rng_state,
                 OutType* ptr,
                 LenType len,
                 OutType start,
                 OutType end)
 {
-  detail::uniformInt(rng_state, ptr, len, start, end, handle.get_stream());
+  detail::uniformInt(rng_state, ptr, len, start, end, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -138,13 +141,14 @@ void uniformInt(raft::device_resources const& handle,
  * @param[in] sigma std-dev of the distribution
  */
 template <typename OutputValueType, typename IndexType>
-void normal(raft::device_resources const& handle,
+void normal(raft::resources const& handle,
             RngState& rng_state,
             raft::device_vector_view<OutputValueType, IndexType> out,
             OutputValueType mu,
             OutputValueType sigma)
 {
-  detail::normal(rng_state, out.data_handle(), out.extent(0), mu, sigma, handle.get_stream());
+  detail::normal(
+    rng_state, out.data_handle(), out.extent(0), mu, sigma, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -160,14 +164,14 @@ void normal(raft::device_resources const& handle,
  * @param[in] sigma std-dev of the distribution
  */
 template <typename OutType, typename LenType = int>
-void normal(raft::device_resources const& handle,
+void normal(raft::resources const& handle,
             RngState& rng_state,
             OutType* ptr,
             LenType len,
             OutType mu,
             OutType sigma)
 {
-  detail::normal(rng_state, ptr, len, mu, sigma, handle.get_stream());
+  detail::normal(rng_state, ptr, len, mu, sigma, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -183,7 +187,7 @@ void normal(raft::device_resources const& handle,
  * @param[in] sigma standard deviation of the distribution
  */
 template <typename OutputValueType, typename IndexType>
-void normalInt(raft::device_resources const& handle,
+void normalInt(raft::resources const& handle,
                RngState& rng_state,
                raft::device_vector_view<OutputValueType, IndexType> out,
                OutputValueType mu,
@@ -196,7 +200,8 @@ void normalInt(raft::device_resources const& handle,
   static_assert(std::is_integral<OutputValueType>::value,
                 "normalInt: The output vector's value type must be an integer.");
 
-  detail::normalInt(rng_state, out.data_handle(), out.extent(0), mu, sigma, handle.get_stream());
+  detail::normalInt(
+    rng_state, out.data_handle(), out.extent(0), mu, sigma, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -212,14 +217,14 @@ void normalInt(raft::device_resources const& handle,
  * @param[in] sigma std-dev of the distribution
  */
 template <typename IntType, typename LenType = int>
-void normalInt(raft::device_resources const& handle,
+void normalInt(raft::resources const& handle,
                RngState& rng_state,
                IntType* ptr,
                LenType len,
                IntType mu,
                IntType sigma)
 {
-  detail::normalInt(rng_state, ptr, len, mu, sigma, handle.get_stream());
+  detail::normalInt(rng_state, ptr, len, mu, sigma, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -244,7 +249,7 @@ void normalInt(raft::device_resources const& handle,
  */
 template <typename OutputValueType, typename IndexType>
 void normalTable(
-  raft::device_resources const& handle,
+  raft::resources const& handle,
   RngState& rng_state,
   raft::device_vector_view<const OutputValueType, IndexType> mu_vec,
   std::variant<raft::device_vector_view<const OutputValueType, IndexType>, OutputValueType> sigma,
@@ -283,7 +288,7 @@ void normalTable(
                       mu_vec.data_handle(),
                       sigma_vec_ptr,
                       sigma_value,
-                      handle.get_stream());
+                      resource::get_cuda_stream(handle));
 }
 
 /**
@@ -307,7 +312,7 @@ void normalTable(
  * @param[in] sigma scalar sigma to be used if 'sigma_vec' is nullptr
  */
 template <typename OutType, typename LenType = int>
-void normalTable(raft::device_resources const& handle,
+void normalTable(raft::resources const& handle,
                  RngState& rng_state,
                  OutType* ptr,
                  LenType n_rows,
@@ -317,7 +322,7 @@ void normalTable(raft::device_resources const& handle,
                  OutType sigma)
 {
   detail::normalTable(
-    rng_state, ptr, n_rows, n_cols, mu_vec, sigma_vec, sigma, handle.get_stream());
+    rng_state, ptr, n_rows, n_cols, mu_vec, sigma_vec, sigma, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -332,12 +337,12 @@ void normalTable(raft::device_resources const& handle,
  * @param[out] out the output vector
  */
 template <typename OutputValueType, typename IndexType>
-void fill(raft::device_resources const& handle,
+void fill(raft::resources const& handle,
           RngState& rng_state,
           OutputValueType val,
           raft::device_vector_view<OutputValueType, IndexType> out)
 {
-  detail::fill(rng_state, out.data_handle(), out.extent(0), val, handle.get_stream());
+  detail::fill(rng_state, out.data_handle(), out.extent(0), val, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -353,9 +358,9 @@ void fill(raft::device_resources const& handle,
  */
 template <typename OutType, typename LenType = int>
 void fill(
-  raft::device_resources const& handle, RngState& rng_state, OutType* ptr, LenType len, OutType val)
+  raft::resources const& handle, RngState& rng_state, OutType* ptr, LenType len, OutType val)
 {
-  detail::fill(rng_state, ptr, len, val, handle.get_stream());
+  detail::fill(rng_state, ptr, len, val, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -372,12 +377,13 @@ void fill(
  * @param[in] prob coin-toss probability for heads
  */
 template <typename OutputValueType, typename IndexType, typename Type>
-void bernoulli(raft::device_resources const& handle,
+void bernoulli(raft::resources const& handle,
                RngState& rng_state,
                raft::device_vector_view<OutputValueType, IndexType> out,
                Type prob)
 {
-  detail::bernoulli(rng_state, out.data_handle(), out.extent(0), prob, handle.get_stream());
+  detail::bernoulli(
+    rng_state, out.data_handle(), out.extent(0), prob, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -395,9 +401,9 @@ void bernoulli(raft::device_resources const& handle,
  */
 template <typename Type, typename OutType = bool, typename LenType = int>
 void bernoulli(
-  raft::device_resources const& handle, RngState& rng_state, OutType* ptr, LenType len, Type prob)
+  raft::resources const& handle, RngState& rng_state, OutType* ptr, LenType len, Type prob)
 {
-  detail::bernoulli(rng_state, ptr, len, prob, handle.get_stream());
+  detail::bernoulli(rng_state, ptr, len, prob, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -413,14 +419,14 @@ void bernoulli(
  * @param[in] scale scaling factor
  */
 template <typename OutputValueType, typename IndexType>
-void scaled_bernoulli(raft::device_resources const& handle,
+void scaled_bernoulli(raft::resources const& handle,
                       RngState& rng_state,
                       raft::device_vector_view<OutputValueType, IndexType> out,
                       OutputValueType prob,
                       OutputValueType scale)
 {
   detail::scaled_bernoulli(
-    rng_state, out.data_handle(), out.extent(0), prob, scale, handle.get_stream());
+    rng_state, out.data_handle(), out.extent(0), prob, scale, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -436,14 +442,14 @@ void scaled_bernoulli(raft::device_resources const& handle,
  * @param[in] scale scaling factor
  */
 template <typename OutType, typename LenType = int>
-void scaled_bernoulli(raft::device_resources const& handle,
+void scaled_bernoulli(raft::resources const& handle,
                       RngState& rng_state,
                       OutType* ptr,
                       LenType len,
                       OutType prob,
                       OutType scale)
 {
-  detail::scaled_bernoulli(rng_state, ptr, len, prob, scale, handle.get_stream());
+  detail::scaled_bernoulli(rng_state, ptr, len, prob, scale, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -460,13 +466,14 @@ void scaled_bernoulli(raft::device_resources const& handle,
  * @note https://en.wikipedia.org/wiki/Gumbel_distribution
  */
 template <typename OutputValueType, typename IndexType = int>
-void gumbel(raft::device_resources const& handle,
+void gumbel(raft::resources const& handle,
             RngState& rng_state,
             raft::device_vector_view<OutputValueType, IndexType> out,
             OutputValueType mu,
             OutputValueType beta)
 {
-  detail::gumbel(rng_state, out.data_handle(), out.extent(0), mu, beta, handle.get_stream());
+  detail::gumbel(
+    rng_state, out.data_handle(), out.extent(0), mu, beta, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -483,14 +490,14 @@ void gumbel(raft::device_resources const& handle,
  * @note https://en.wikipedia.org/wiki/Gumbel_distribution
  */
 template <typename OutType, typename LenType = int>
-void gumbel(raft::device_resources const& handle,
+void gumbel(raft::resources const& handle,
             RngState& rng_state,
             OutType* ptr,
             LenType len,
             OutType mu,
             OutType beta)
 {
-  detail::gumbel(rng_state, ptr, len, mu, beta, handle.get_stream());
+  detail::gumbel(rng_state, ptr, len, mu, beta, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -506,13 +513,14 @@ void gumbel(raft::device_resources const& handle,
  * @param[in] sigma standard deviation of the distribution
  */
 template <typename OutputValueType, typename IndexType>
-void lognormal(raft::device_resources const& handle,
+void lognormal(raft::resources const& handle,
                RngState& rng_state,
                raft::device_vector_view<OutputValueType, IndexType> out,
                OutputValueType mu,
                OutputValueType sigma)
 {
-  detail::lognormal(rng_state, out.data_handle(), out.extent(0), mu, sigma, handle.get_stream());
+  detail::lognormal(
+    rng_state, out.data_handle(), out.extent(0), mu, sigma, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -528,14 +536,14 @@ void lognormal(raft::device_resources const& handle,
  * @param[in] sigma standard deviation of the distribution
  */
 template <typename OutType, typename LenType = int>
-void lognormal(raft::device_resources const& handle,
+void lognormal(raft::resources const& handle,
                RngState& rng_state,
                OutType* ptr,
                LenType len,
                OutType mu,
                OutType sigma)
 {
-  detail::lognormal(rng_state, ptr, len, mu, sigma, handle.get_stream());
+  detail::lognormal(rng_state, ptr, len, mu, sigma, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -551,13 +559,14 @@ void lognormal(raft::device_resources const& handle,
  * @param[in] scale scale value
  */
 template <typename OutputValueType, typename IndexType = int>
-void logistic(raft::device_resources const& handle,
+void logistic(raft::resources const& handle,
               RngState& rng_state,
               raft::device_vector_view<OutputValueType, IndexType> out,
               OutputValueType mu,
               OutputValueType scale)
 {
-  detail::logistic(rng_state, out.data_handle(), out.extent(0), mu, scale, handle.get_stream());
+  detail::logistic(
+    rng_state, out.data_handle(), out.extent(0), mu, scale, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -573,14 +582,14 @@ void logistic(raft::device_resources const& handle,
  * @param[in] scale scale value
  */
 template <typename OutType, typename LenType = int>
-void logistic(raft::device_resources const& handle,
+void logistic(raft::resources const& handle,
               RngState& rng_state,
               OutType* ptr,
               LenType len,
               OutType mu,
               OutType scale)
 {
-  detail::logistic(rng_state, ptr, len, mu, scale, handle.get_stream());
+  detail::logistic(rng_state, ptr, len, mu, scale, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -595,12 +604,13 @@ void logistic(raft::device_resources const& handle,
  * @param[in] lambda the exponential distribution's lambda parameter
  */
 template <typename OutputValueType, typename IndexType>
-void exponential(raft::device_resources const& handle,
+void exponential(raft::resources const& handle,
                  RngState& rng_state,
                  raft::device_vector_view<OutputValueType, IndexType> out,
                  OutputValueType lambda)
 {
-  detail::exponential(rng_state, out.data_handle(), out.extent(0), lambda, handle.get_stream());
+  detail::exponential(
+    rng_state, out.data_handle(), out.extent(0), lambda, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -615,13 +625,10 @@ void exponential(raft::device_resources const& handle,
  * @param[in] lambda the exponential distribution's lambda parameter
  */
 template <typename OutType, typename LenType = int>
-void exponential(raft::device_resources const& handle,
-                 RngState& rng_state,
-                 OutType* ptr,
-                 LenType len,
-                 OutType lambda)
+void exponential(
+  raft::resources const& handle, RngState& rng_state, OutType* ptr, LenType len, OutType lambda)
 {
-  detail::exponential(rng_state, ptr, len, lambda, handle.get_stream());
+  detail::exponential(rng_state, ptr, len, lambda, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -636,12 +643,13 @@ void exponential(raft::device_resources const& handle,
  * @param[in] sigma the distribution's sigma parameter
  */
 template <typename OutputValueType, typename IndexType>
-void rayleigh(raft::device_resources const& handle,
+void rayleigh(raft::resources const& handle,
               RngState& rng_state,
               raft::device_vector_view<OutputValueType, IndexType> out,
               OutputValueType sigma)
 {
-  detail::rayleigh(rng_state, out.data_handle(), out.extent(0), sigma, handle.get_stream());
+  detail::rayleigh(
+    rng_state, out.data_handle(), out.extent(0), sigma, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -656,15 +664,11 @@ void rayleigh(raft::device_resources const& handle,
  * @param[in] sigma the distribution's sigma parameter
  */
 template <typename OutType, typename LenType = int>
-void rayleigh(raft::device_resources const& handle,
-              RngState& rng_state,
-              OutType* ptr,
-              LenType len,
-              OutType sigma)
+void rayleigh(
+  raft::resources const& handle, RngState& rng_state, OutType* ptr, LenType len, OutType sigma)
 {
-  detail::rayleigh(rng_state, ptr, len, sigma, handle.get_stream());
+  detail::rayleigh(rng_state, ptr, len, sigma, resource::get_cuda_stream(handle));
 }
-
 /**
  * @brief Generate laplace distributed random numbers
  *
@@ -678,13 +682,14 @@ void rayleigh(raft::device_resources const& handle,
  * @param[in] scale the scale
  */
 template <typename OutputValueType, typename IndexType>
-void laplace(raft::device_resources const& handle,
+void laplace(raft::resources const& handle,
              RngState& rng_state,
              raft::device_vector_view<OutputValueType, IndexType> out,
              OutputValueType mu,
              OutputValueType scale)
 {
-  detail::laplace(rng_state, out.data_handle(), out.extent(0), mu, scale, handle.get_stream());
+  detail::laplace(
+    rng_state, out.data_handle(), out.extent(0), mu, scale, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -700,14 +705,14 @@ void laplace(raft::device_resources const& handle,
  * @param[in] scale the scale
  */
 template <typename OutType, typename LenType = int>
-void laplace(raft::device_resources const& handle,
+void laplace(raft::resources const& handle,
              RngState& rng_state,
              OutType* ptr,
              LenType len,
              OutType mu,
              OutType scale)
 {
-  detail::laplace(rng_state, ptr, len, mu, scale, handle.get_stream());
+  detail::laplace(rng_state, ptr, len, mu, scale, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -716,10 +721,10 @@ void laplace(raft::device_resources const& handle,
  * Usage example:
  * @code{.cpp}
  *  #include <raft/core/device_mdarray.hpp>
- *  #include <raft/core/device_resources.hpp>
+ *  #include <raft/core/resources.hpp>
  *  #include <raft/random/rng.cuh>
  *
- *  raft::raft::device_resources handle;
+ *  raft::resources handle;
  *  ...
  *  raft::random::RngState rng(seed);
  *  auto indices = raft::make_device_vector<int>(handle, n_samples);
@@ -737,7 +742,7 @@ void laplace(raft::device_resources const& handle,
  */
 template <typename OutType, typename WeightType, typename IndexType>
 std::enable_if_t<std::is_integral_v<OutType>> discrete(
-  raft::device_resources const& handle,
+  raft::resources const& handle,
   RngState& rng_state,
   raft::device_vector_view<OutType, IndexType> out,
   raft::device_vector_view<const WeightType, IndexType> weights)
@@ -747,7 +752,7 @@ std::enable_if_t<std::is_integral_v<OutType>> discrete(
                    weights.data_handle(),
                    out.extent(0),
                    weights.extent(0),
-                   handle.get_stream());
+                   resource::get_cuda_stream(handle));
 }
 
 /**
@@ -770,7 +775,7 @@ std::enable_if_t<std::is_integral_v<OutType>> discrete(
  * @param[in] len input array length
  */
 template <typename DataT, typename WeightsT, typename IdxT = int>
-void sampleWithoutReplacement(raft::device_resources const& handle,
+void sampleWithoutReplacement(raft::resources const& handle,
                               RngState& rng_state,
                               DataT* out,
                               IdxT* outIdx,
@@ -780,7 +785,7 @@ void sampleWithoutReplacement(raft::device_resources const& handle,
                               IdxT len)
 {
   detail::sampleWithoutReplacement(
-    rng_state, out, outIdx, in, wts, sampledLen, len, handle.get_stream());
+    rng_state, out, outIdx, in, wts, sampledLen, len, resource::get_cuda_stream(handle));
 }
 
 /**
@@ -1106,7 +1111,7 @@ class DEPR Rng : public detail::RngImpl {
    * @param stream cuda stream
    */
   template <typename DataT, typename WeightsT, typename IdxT = int>
-  void sampleWithoutReplacement(raft::device_resources const& handle,
+  void sampleWithoutReplacement(raft::resources const& handle,
                                 DataT* out,
                                 IdxT* outIdx,
                                 const DataT* in,

--- a/cpp/include/raft/random/sample_without_replacement.cuh
+++ b/cpp/include/raft/random/sample_without_replacement.cuh
@@ -21,7 +21,8 @@
 #include <cassert>
 #include <optional>
 #include <raft/core/device_mdspan.hpp>
-#include <raft/core/device_resources.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resources.hpp>
 #include <type_traits>
 #include <variant>
 
@@ -94,7 +95,7 @@ using weight_t = typename weight_alias<T>::type;
  *   equals the number of inputs `in.extent(0)`.
  */
 template <typename DataT, typename IdxT, typename WeightsVectorType, class OutIndexVectorType>
-void sample_without_replacement(raft::device_resources const& handle,
+void sample_without_replacement(raft::resources const& handle,
                                 RngState& rng_state,
                                 raft::device_vector_view<const DataT, IdxT> in,
                                 WeightsVectorType&& weights_opt,
@@ -145,7 +146,7 @@ void sample_without_replacement(raft::device_resources const& handle,
                                    wts_ptr,
                                    sampledLen,
                                    len,
-                                   handle.get_stream());
+                                   resource::get_cuda_stream(handle));
 }
 
 /**

--- a/cpp/test/random/make_blobs.cu
+++ b/cpp/test/random/make_blobs.cu
@@ -18,6 +18,8 @@
 #include <cub/cub.cuh>
 #include <gtest/gtest.h>
 #include <raft/core/device_mdarray.hpp>
+#include <raft/core/device_resources.hpp>
+
 #include <raft/random/make_blobs.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>

--- a/cpp/test/random/make_regression.cu
+++ b/cpp/test/random/make_regression.cu
@@ -20,8 +20,10 @@
 #include <thrust/device_vector.h>
 
 #include "../test_utils.cuh"
+#include <raft/core/device_resources.hpp>
 #include <raft/linalg/detail/cublas_wrappers.hpp>
 #include <raft/linalg/subtract.cuh>
+
 #include <raft/linalg/transpose.cuh>
 #include <raft/random/make_regression.cuh>
 #include <raft/util/cuda_utils.cuh>

--- a/cpp/test/random/multi_variable_gaussian.cu
+++ b/cpp/test/random/multi_variable_gaussian.cu
@@ -18,8 +18,10 @@
 #include <cmath>
 #include <gtest/gtest.h>
 #include <iostream>
+#include <raft/core/device_resources.hpp>
 #include <raft/random/multi_variable_gaussian.cuh>
 #include <raft/util/cudart_utils.hpp>
+
 #include <random>
 #include <rmm/device_uvector.hpp>
 

--- a/cpp/test/random/permute.cu
+++ b/cpp/test/random/permute.cu
@@ -16,8 +16,10 @@
 
 #include "../test_utils.cuh"
 #include <algorithm>
+#include <raft/core/device_resources.hpp>
 #include <raft/random/permute.cuh>
 #include <raft/random/rng.cuh>
+
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 #include <vector>

--- a/cpp/test/random/rmat_rectangular_generator.cu
+++ b/cpp/test/random/rmat_rectangular_generator.cu
@@ -21,8 +21,10 @@
 
 #include "../test_utils.cuh"
 
+#include <raft/core/device_resources.hpp>
 #include <raft/random/rmat_rectangular_generator.cuh>
 #include <raft/random/rng.cuh>
+
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 

--- a/cpp/test/random/rng.cu
+++ b/cpp/test/random/rng.cu
@@ -20,9 +20,11 @@
 #include "../test_utils.cuh"
 #include <cub/cub.cuh>
 #include <gtest/gtest.h>
+#include <raft/core/device_resources.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/stats/mean.cuh>
 #include <raft/stats/stddev.cuh>
+
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 

--- a/cpp/test/random/rng_discrete.cu
+++ b/cpp/test/random/rng_discrete.cu
@@ -18,9 +18,11 @@
 #include <algorithm>
 #include <cmath>
 #include <gtest/gtest.h>
+#include <raft/core/device_resources.hpp>
 #include <raft/linalg/add.cuh>
 #include <raft/linalg/unary_op.cuh>
 #include <raft/random/rng.cuh>
+
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 #include <vector>

--- a/cpp/test/random/rng_int.cu
+++ b/cpp/test/random/rng_int.cu
@@ -17,6 +17,7 @@
 #include "../test_utils.cuh"
 #include <cub/cub.cuh>
 #include <gtest/gtest.h>
+#include <raft/core/device_resources.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>

--- a/cpp/test/random/sample_without_replacement.cu
+++ b/cpp/test/random/sample_without_replacement.cu
@@ -16,6 +16,7 @@
 
 #include "../test_utils.cuh"
 #include <gtest/gtest.h>
+#include <raft/core/device_resources.hpp>
 #include <raft/random/rng.cuh>
 #include <raft/random/sample_without_replacement.cuh>
 #include <raft/util/cuda_utils.cuh>


### PR DESCRIPTION
Eventually we need to do this across all the headers in the codebase so that users have a choice as to whether they want to use `raft::device_resources` (which implicitly depends on the cuda math libs and thrust) or whether they just want to use `raft::resources` (which is agnostic of the resources it contains and allows the primitives themselves to levvy the dependency requirements). 

cc @MatthiasKohl this *should* allow cugraph-ops to completely remove the math libs dependency (though the conda recipes will also need to be changed to depend on `libraft-headers-only` and the cmake changed to turn off the CTK math libs dependency). 

**NOTE**: Before this PR is merged, it's important that it be tested w/ cugraph/cuml at the very least to spot any cases where the `device_resources.hpp` include was being assumed transitively from the RAFT functions. 