### PR TITLE
Remove MetricProcessor code from brute_force::knn

### DIFF
--- a/python/pylibraft/pylibraft/test/test_brute_force.py
+++ b/python/pylibraft/pylibraft/test/test_brute_force.py
@@ -90,9 +90,6 @@ def test_knn(
         expected_indices = argsort[i]
         gpu_dists = actual_distances[i]
 
-        if metric == "correlation" or metric == "cosine":
-            gpu_dists = gpu_dists[::-1]
-
         cpu_ordered = pw_dists[i, expected_indices]
         np.testing.assert_allclose(
             cpu_ordered[:k], gpu_dists, atol=1e-4, rtol=1e-4


### PR DESCRIPTION
Stop using the MetricProcessor code to preprocess the inputs to the bfknn calls. Since the pairwise distance API supports both cosine and correlation distance, this wasn't required anymore - and it introduced NaN values to the input when passed a dataset with one of the rows being all zero.