### PR TITLE
Use nvtx3 includes.

### DIFF
--- a/cpp/bench/ann/src/common/benchmark.hpp
+++ b/cpp/bench/ann/src/common/benchmark.hpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #ifdef NVTX
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 #endif
 #include <unistd.h>
 

--- a/cpp/include/raft/core/detail/nvtx.hpp
+++ b/cpp/include/raft/core/detail/nvtx.hpp
@@ -25,7 +25,7 @@ namespace raft::common::nvtx::detail {
 #include <cstdint>
 #include <cstdlib>
 #include <mutex>
-#include <nvToolsExt.h>
+#include <nvtx3/nvToolsExt.h>
 #include <string>
 #include <type_traits>
 #include <unordered_map>


### PR DESCRIPTION
This PR updates raft to use `#include <nvtx3/nvToolsExt.h>` instead of `#include <nvToolsExt.h>`. This ensures we fetch the header-only NVTX v3. See NVTX docs for more information: https://nvidia.github.io/NVTX/#c-and-c