### PR TITLE
[ENH] Enable building with clang (limit strict error checking to GCC)

### DIFF
--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -17,8 +17,16 @@ if(DISABLE_DEPRECATION_WARNINGS)
   list(APPEND RAFT_CUDA_FLAGS -Xcompiler=-Wno-deprecated-declarations)
 endif()
 
+# Be very strict when compiling with GCC as host compiler (and thus more lenient when compiling with
+# clang)
 if(CMAKE_COMPILER_IS_GNUCXX)
   list(APPEND RAFT_CXX_FLAGS -Wall -Werror -Wno-unknown-pragmas -Wno-error=deprecated-declarations)
+  list(APPEND RAFT_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations)
+
+  # set warnings as errors
+  if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2.0)
+    list(APPEND RAFT_CUDA_FLAGS -Werror=all-warnings)
+  endif()
 endif()
 
 if(CUDA_LOG_COMPILE_TIME)
@@ -30,12 +38,6 @@ list(APPEND RAFT_CXX_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
 list(APPEND RAFT_CUDA_FLAGS "-DCUDA_API_PER_THREAD_DEFAULT_STREAM")
 # make sure we produce smallest binary size
 list(APPEND RAFT_CUDA_FLAGS -Xfatbin=-compress-all)
-
-# set warnings as errors
-if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2.0)
-  list(APPEND RAFT_CUDA_FLAGS -Werror=all-warnings)
-endif()
-list(APPEND RAFT_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations)
 
 # Option to enable line info in CUDA device compilation to allow introspection when profiling /
 # memchecking


### PR DESCRIPTION
Compiling RAFT with a non-GCC compiler can be tricky as there is very strict error checking (`-Werror=all-warnings` for instance) and therefore, the build is almost guaranteed to fail due to warnings elevated to errors. 

I am sometimes building RAFT with clang because of its `-ftime-trace` feature, which helps find code that increases compile times.

This PR contains the changes I typically make to the CMakeLists.txt to enable clang compilation. With this change, strict error checking is only performed when the host compiler is GCC.

Tested with clang version 11.1.

