### PR TITLE
Remove include statements from inside namespace

### DIFF
--- a/cpp/include/raft/core/detail/nvtx.hpp
+++ b/cpp/include/raft/core/detail/nvtx.hpp
@@ -18,8 +18,6 @@
 
 #include <rmm/cuda_stream_view.hpp>
 
-namespace raft::common::nvtx::detail {
-
 #ifdef NVTX_ENABLED
 
 #include <cstdint>
@@ -29,6 +27,8 @@ namespace raft::common::nvtx::detail {
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+
+namespace raft::common::nvtx::detail {
 
 /**
  * @brief An internal struct to store associated state with the color
@@ -191,7 +191,11 @@ inline void pop_range()
   nvtxDomainRangePop(domain_store<Domain>::value());
 }
 
+}  // namespace raft::common::nvtx::detail
+
 #else   // NVTX_ENABLED
+
+namespace raft::common::nvtx::detail {
 
 template <typename Domain, typename... Args>
 inline void push_range(const char* format, Args... args)
@@ -203,6 +207,6 @@ inline void pop_range()
 {
 }
 
-#endif  // NVTX_ENABLED
-
 }  // namespace raft::common::nvtx::detail
+
+#endif  // NVTX_ENABLED


### PR DESCRIPTION
Bringing in the below headers into the `raft::common::nvtx::detail` namespace breaks downstream users that need to use global symbols they provide. In the direct case I encountered the dlopen and dlclose functions became unusable.
```
#include <cstdint>
#include <cstdlib>
#include <mutex>
#include <nvtx3/nvToolsExt.h>
#include <string>
#include <type_traits>
#include <unordered_map>
```
