### PR TITLE
Adjust PR pipeline job dependency

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -86,7 +86,7 @@ jobs:
       test-unittest: "python -m pytest ./python/pylibraft/pylibraft/test"
       test-smoketest: "python ./ci/wheel_smoke_test_pylibraft.py"
   wheel-build-raft-dask:
-    needs: wheel-tests-pylibraft
+    needs: wheel-build-pylibraft
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-manylinux-build.yml@py-39
     with:


### PR DESCRIPTION
Presumably the `wheel-build-raft-dask` job can start right after the `wheel-build-pylibraft` job is complete, right?

I don't see why `wheel-build-raft-dask` would need to wait for the `wheel-tests-pylibraft` job to complete.
