### PR TITLE
Enable sccache hits from local builds

### DIFF
--- a/conda/recipes/libraft/meta.yaml
+++ b/conda/recipes/libraft/meta.yaml
@@ -36,6 +36,7 @@ outputs:
         - SCCACHE_S3_KEY_PREFIX=libraft-aarch64 # [aarch64]
         - SCCACHE_S3_KEY_PREFIX=libraft-linux64 # [linux64]
         - SCCACHE_S3_USE_SSL
+        - SCCACHE_S3_NO_CREDENTIALS
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:


### PR DESCRIPTION
This change passes through the value of `SCCACHE_S3_NO_CREDENTIALS` to our `conda` builds, enabling devs to utilize the `sccache` cache that's populated by CI when they are reproducing build issues locally as per [these](https://docs.rapids.ai/resources/reproducing-ci/) instructions.