### PR TITLE
Add 1xtfloat capability to pairwise_matrix distance computations

### DIFF
--- a/cpp/bench/prims/distance/tune_pairwise/bench_cutlass.cu
+++ b/cpp/bench/prims/distance/tune_pairwise/bench_cutlass.cu
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tuning benchmarks.
+//
+// Goals:
+//
+// 1. Fast compile times to maintain iteration speed.
+// 2. Create benchmarks that can inform the design of the kernels.
+//
+// Non-goals:
+//
+// 1. Measure every distance operation. Instead measures just one distance
+//    operation at the same time.
+// 2. Be useful for finding performance regressions. This is handled by the
+//    normal benchmarks.
+//
+// So far, both goals are partly achieved.
+//
+// RE (1), COMPILE TIMES: kernel.cu is fast to compile. This file is not.
+// When the internals of a pairwise distance kernel is changed, this file is not
+// recompiled.
+//
+// RE 2, benchmarks with intent: this file contains a benchmark to check the
+// maximal throughput of a kernel. Measuring other things, like performance on
+// skinny or wide matrices is not yet implemented.
+
+#include "kernel_cutlass.cuh"                               // launch_kernel
+#include <algorithm>                                        // std::min
+#include <common/benchmark.hpp>                             // RAFT_BENCH_REGISTER
+#include <raft/distance/detail/pairwise_matrix/params.cuh>  // pairwise_matrix_params
+#include <rmm/device_uvector.hpp>                           // rmm::device_uvector
+#include <vector>                                           // std::vector
+
+namespace raft::bench::distance::tune_cutlass {
+
+// Max throughput benchmark.
+//
+// Goal: Measure the maximum distances/sec that can be computed.
+//
+// To achieve this, we make sure that:
+//
+// - Input data size is a multiple of the block tile size.
+//
+// - Perfect distribution of work between SMs, i.e. the number of block tiles is
+//   a large multiple (num_waves) of the number of blocks (#SMs * occupancy).
+//
+// - Multiple iterations over Kblk are executed (num_k_iters).
+struct throughput_param {
+  int m, n, k;
+  bool use_1x_tfloat;
+};
+
+const std::vector<throughput_param> throughput_params{
+  {1024, 1024, 1024, true},
+  {1024, 1024, 1 << 11, true},
+  {1024, 1024, 1 << 12, true},
+  {1024, 1024, 1 << 13, true},
+  {1024, 1 << 14, 1024, true},
+  {1024, 1 << 14, 1 << 11, true},
+  {1024, 1 << 14, 1 << 12, true},
+  {1024, 1 << 14, 1 << 13, true},
+
+  {1024, 1024, 1024, false},
+  {1024, 1024, 1 << 11, false},
+  {1024, 1024, 1 << 12, false},
+  {1024, 1024, 1 << 13, false},
+  {1024, 1 << 14, 1024, false},
+  {1024, 1 << 14, 1 << 11, false},
+  {1024, 1 << 14, 1 << 12, false},
+  {1024, 1 << 14, 1 << 13, false},
+};
+
+struct throughput_cutlass : public fixture {
+  const throughput_param p;
+
+  throughput_cutlass(const throughput_param& p_) : p(p_) {}
+
+  void run_benchmark(::benchmark::State& state) override
+  {
+    size_t m = p.m;
+    size_t n = p.n;
+    size_t k = p.k;
+
+    // DataT, OutT, IdxT, etc, are defined in tuned_kernel.cuh
+    rmm::device_uvector<DataT> x_vec(m * k, stream);
+    rmm::device_uvector<DataT> y_vec(n * k, stream);
+    rmm::device_uvector<DataT> x_norm_vec(m, stream);
+    rmm::device_uvector<DataT> y_norm_vec(n, stream);
+    rmm::device_uvector<OutT> out_vec(m * n, stream);
+
+    auto x      = x_vec.data();
+    auto y      = y_vec.data();
+    auto x_norm = x_norm_vec.data();
+    auto y_norm = y_norm_vec.data();
+    auto out    = out_vec.data();
+    FinOpT fin_op{};
+
+    // Create kernel parameter struct. Flip x and y if column major.
+    IdxT ldx    = row_major ? k : m;
+    IdxT ldy    = row_major ? k : n;
+    IdxT ld_out = row_major ? n : m;
+
+    // Template parameters of pairwise_matrix_params are defined in kernel.cuh
+    pairwise_matrix_params kparams{
+      IdxT(m), IdxT(n), IdxT(k), ldx, ldy, ld_out, x, y, x_norm, y_norm, out, fin_op, row_major};
+
+    // Run benchmark
+    loop_on_state(state, [&]() { launch_kernel(kparams, p.use_1x_tfloat, stream); });
+
+    // Report metrics. We don't report flop/s because we do not know for each
+    // distance operation how many flops it costs. For L2_unexp and l1, we can
+    // double this number to get the flop/s. For l2 expanded, core_ops/s should
+    // equal flop/s (modulo the sqrt and subtracting from the norm).
+    size_t num_core_ops = m * n * k;
+    size_t read_elts    = n * k + m * k;
+    size_t write_elts   = m * n;
+
+    state.counters["m"]        = benchmark::Counter(m);
+    state.counters["n"]        = benchmark::Counter(n);
+    state.counters["k"]        = benchmark::Counter(k);
+    state.counters["1xtfloat"] = benchmark::Counter(p.use_1x_tfloat);
+
+    state.counters["core_ops/s"] = benchmark::Counter(num_core_ops,
+                                                      benchmark::Counter::kIsIterationInvariantRate,
+                                                      benchmark::Counter::OneK::kIs1000);
+
+    state.counters["BW"] = benchmark::Counter(write_elts * sizeof(OutT) + read_elts * sizeof(DataT),
+                                              benchmark::Counter::kIsIterationInvariantRate,
+                                              benchmark::Counter::OneK::kIs1000);
+  }
+};
+
+RAFT_BENCH_REGISTER(throughput_cutlass, "", throughput_params);
+
+}  // namespace raft::bench::distance::tune_cutlass

--- a/cpp/bench/prims/distance/tune_pairwise/kernel_cutlass.cu
+++ b/cpp/bench/prims/distance/tune_pairwise/kernel_cutlass.cu
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernel_cutlass.cuh"
+#include <raft/distance/detail/distance_ops/all_ops.cuh>  // distance_op
+#include <raft/distance/detail/pairwise_matrix/dispatch_sm80.cuh>
+#include <raft/distance/detail/pairwise_matrix/params.cuh>
+#include <raft/distance/distance_types.hpp>  // Compute_options
+#include <raft/util/arch.cuh>                // raft::util::arch::SM_compute_arch
+
+namespace raft::bench::distance::tune_cutlass {
+
+// Distance op
+using OpT = raft::distance::detail::ops::l2_exp_distance_op<DataT, AccT, IdxT>;
+
+constexpr bool perform_sqrt = false;
+OpT distance_op{perform_sqrt};
+
+// Architecture
+namespace arch                 = raft::util::arch;
+constexpr auto sm_compat_range = arch::SM_range(arch::SM_80(), arch::SM_future());
+
+void launch_kernel(pairwise_matrix_params params, bool use_1x_tfloat, cudaStream_t stream)
+{
+  raft::distance::detail::pairwise_matrix_sm80_dispatch(
+    distance_op,
+    use_1x_tfloat ? raft::distance::Compute_options::Fast_Reduced_Precision
+                  : raft::distance::Compute_options::Fast_Similar_Precision,
+    params,
+    sm_compat_range,
+    stream);
+  RAFT_CUDA_TRY(cudaGetLastError());
+}
+
+}  // namespace raft::bench::distance::tune_cutlass

--- a/cpp/bench/prims/distance/tune_pairwise/kernel_cutlass.cuh
+++ b/cpp/bench/prims/distance/tune_pairwise/kernel_cutlass.cuh
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <raft/core/operators.hpp>                          // raft::identity_op
+#include <raft/distance/detail/pairwise_matrix/params.cuh>  // pairwise_matrix_params
+
+namespace raft::bench::distance::tune_cutlass {
+
+// Launch one specific kernel with the following template parameters
+constexpr bool row_major = true;
+using DataT              = float;
+using AccT               = float;
+using OutT               = DataT;
+using IdxT               = int;
+
+using FinOpT = raft::identity_op;
+
+using pairwise_matrix_params =
+  raft::distance::detail::pairwise_matrix_params<IdxT, DataT, OutT, FinOpT>;
+
+void launch_kernel(pairwise_matrix_params params, bool use_1x_tfloat, cudaStream_t stream);
+
+}  // namespace raft::bench::distance::tune_cutlass

--- a/cpp/include/raft/distance/detail/pairwise_matrix/dispatch-inl.cuh
+++ b/cpp/include/raft/distance/detail/pairwise_matrix/dispatch-inl.cuh
@@ -34,7 +34,8 @@
 #include <raft/distance/detail/distance_ops/cutlass.cuh>           // ops::has_cutlass_op
 #include <raft/distance/detail/pairwise_matrix/dispatch_sm60.cuh>  // dispatch_sm60
 #include <raft/distance/detail/pairwise_matrix/params.cuh>         // pairwise_matrix_params
-#include <raft/util/arch.cuh>                                      // raft::util::arch::SM_*
+#include <raft/distance/distance_types.hpp>  // raft::distance::Compute_options
+#include <raft/util/arch.cuh>                // raft::util::arch::SM_*
 
 // NOTE: to minimize compile times, we do not include dispatch_sm80.cuh.
 // Including dispatch_sm80.cuh can slow down compile times (due to CUTLASS).
@@ -56,6 +57,7 @@ template <typename OpT,
           typename FinOpT,
           typename SM_compat_t>
 void pairwise_matrix_sm80_dispatch(OpT,
+                                   Compute_options,
                                    pairwise_matrix_params<IdxT, DataT, OutT, FinOpT>,
                                    SM_compat_t,
                                    cudaStream_t);
@@ -67,6 +69,7 @@ template <typename OpT,
           typename FinOpT,
           typename IdxT = int>
 void pairwise_matrix_dispatch(OpT distance_op,
+                              // Compute_options compute_options, TODO.
                               IdxT m,
                               IdxT n,
                               IdxT k,
@@ -118,7 +121,8 @@ void pairwise_matrix_dispatch(OpT distance_op,
 
     if (cutlass_range.contains(runtime_arch)) {
       // If device is SM_80 or later, use CUTLASS-based kernel.
-      pairwise_matrix_sm80_dispatch(distance_op, params, cutlass_range, stream);
+      pairwise_matrix_sm80_dispatch(
+        distance_op, Compute_options::Fast_Similar_Precision, params, cutlass_range, stream);
     } else {
       // Reuse kernel wrapper that we obtained above. This avoids performing the
       // dispatch twice.

--- a/cpp/include/raft/distance/detail/pairwise_matrix/dispatch_sm80.cuh
+++ b/cpp/include/raft/distance/detail/pairwise_matrix/dispatch_sm80.cuh
@@ -18,6 +18,7 @@
 #include <algorithm>                                                 // std::min
 #include <raft/distance/detail/pairwise_distance_cutlass_base.cuh>   // cutlassDistanceKernel
 #include <raft/distance/detail/pairwise_matrix/dispatch_layout.cuh>  // dispatch_layout
+#include <raft/distance/distance_types.hpp>  // raft::distance::Compute_options
 
 namespace raft::distance::detail {
 
@@ -28,6 +29,7 @@ template <typename OpT,
           typename FinOpT,
           typename SM_compat_t>
 void pairwise_matrix_sm80_dispatch(OpT distance_op,
+                                   Compute_options compute_options,
                                    pairwise_matrix_params<IdxT, DataT, OutT, FinOpT> params,
                                    SM_compat_t sm_compat_range,
                                    cudaStream_t stream)
@@ -44,20 +46,22 @@ void pairwise_matrix_sm80_dispatch(OpT distance_op,
     constexpr int vec_len = std::min(vec_len_aligned(), static_cast<int>(16 / sizeof(DataT)));
 
     using AccT = typename OpT::AccT;
-    cutlassDistanceKernel<DataT, AccT, OutT, IdxT, vec_len, FinOpT, OpT, row_major()>(params.x,
-                                                                                      params.y,
-                                                                                      params.x_norm,
-                                                                                      params.y_norm,
-                                                                                      params.m,
-                                                                                      params.n,
-                                                                                      params.k,
-                                                                                      params.ldx,
-                                                                                      params.ldy,
-                                                                                      params.ld_out,
-                                                                                      params.out,
-                                                                                      params.fin_op,
-                                                                                      distance_op,
-                                                                                      stream);
+    cutlassDistanceKernel<DataT, AccT, OutT, IdxT, vec_len, FinOpT, OpT, row_major()>(
+      params.x,
+      params.y,
+      params.x_norm,
+      params.y_norm,
+      params.m,
+      params.n,
+      params.k,
+      params.ldx,
+      params.ldy,
+      params.ld_out,
+      params.out,
+      params.fin_op,
+      distance_op,
+      compute_options,
+      stream);
   };
 
   // Dispatch_layout calls f with appropriate compile time constants based on

--- a/cpp/include/raft/distance/distance_types.hpp
+++ b/cpp/include/raft/distance/distance_types.hpp
@@ -19,6 +19,60 @@
 namespace raft {
 namespace distance {
 
+/**
+ * @brief Describes how precise and fast distance should be computed.
+ */
+enum class Compute_options {
+  /** The choice of speed and accuracy is left to the implementation.
+   *
+   *  This will use Fast_Similar_Precision by default. If the environment
+   *  variable `NVIDIA_TF32_OVERRIDE` is set, this will default to
+   *  Fast_Reduced_Precision.
+   *
+   * */
+  Unspecified,
+  /** Use the most numerically accurate option.
+   * */
+  Precise,
+  /** Use fast computation with similar precision.
+   *
+   *  - If possible, expand the norm computation for two points into the sum of
+   *  norms minus an inner product:
+   *
+   *  || x - y ||^2 = || x ||^2 + || y ||^2 - 2 <x , y>
+   *
+   *  The inner product becomes a matrix multiplication for many points.
+   *
+   *  - If possible, execute the matrix multiplication using 3xtfloat, as
+   *  described in [0].
+   *
+   *  [0] Ootomo H, Yokota R. Recovering single precision accuracy from Tensor Cores
+   *  while surpassing the FP32 theoretical peak performance. The International
+   *  Journal of High Performance Computing Applications. 2022;36(4):475-491.
+   *  doi:10.1177/10943420221090256
+   *
+   * */
+  Fast_Similar_Precision,
+  /** Use reduced precision to speed up computation.
+   *
+   *  1. Use inner product expansion, as described above.
+   *  2. Use tensor float precision instead of fp32 precision.
+   *
+   * */
+  Fast_Reduced_Precision
+};
+
+/**
+ * @brief Describes how the L2 norm should be computed.
+ *
+ */
+struct L2_options {
+  /** If true, compute squared L2 norm. */
+  bool squared;
+  /** Specify speed and precision of computation. */
+  Compute_options compute_options;
+};
+
 /** enum to tell how to compute distance */
 enum DistanceType : unsigned short {
 

--- a/docs/source/cpp_api/distance.rst
+++ b/docs/source/cpp_api/distance.rst
@@ -15,6 +15,9 @@ Distance Types
 
 namespace *raft::distance*
 
+.. doxygenenum:: raft::distance::Compute_options
+.. doxygenenum:: raft::distance::L2_options
+
 .. doxygenenum:: raft::distance::DistanceType
    :project: RAFT
 


### PR DESCRIPTION
This PR adds the possibility to use 1xtfloat in the pairwise matrix computations of `raft::distance`.

When 1xtfloat is enabled, the throughput more than triples compared to using 3xtfloat.

Benchmarks below were taken on H100 (unlocked clocks, SXM). The distance computed was the square L2 expanded distance. Therefore, one core_op corresponds to one fused multiply add. 

| Time     | Iterations | 1xtfloat | BW         | core_ops/s | k      | m    | n       |
|----------|------------|----------|------------|------------|--------|------|---------|
| 0.050 ms | 13697      | ✅       | 249.475G/s | 21.2885T/s | 1024   | 1024 | 1024    |
| 0.087 ms | 8071       | ✅       | 242.288G/s | 24.8103T/s | 2.048k | 1024 | 1024    |
| 0.160 ms | 4392       | ✅       | 235.911G/s | 26.8414T/s | 4.096k | 1024 | 1024    |
| 0.297 ms | 2361       | ✅       | 240.406G/s | 28.9619T/s | 8.192k | 1024 | 1024    |
| 0.265 ms | 2633       | ✅       | 523.272G/s | 64.9491T/s | 1024   | 1024 | 16.384k |
| 0.490 ms | 1430       | ✅       | 428.423G/s | 70.1928T/s | 2.048k | 1024 | 16.384k |
| 0.945 ms | 741        | ✅       | 372.783G/s | 72.7105T/s | 4.096k | 1024 | 16.384k |
| 1.85 ms  | 378        | ✅       | 344.673G/s | 74.3042T/s | 8.192k | 1024 | 16.384k |
| 0.132 ms | 5304       |          | 95.2914G/s | 8.13154T/s | 1024   | 1024 | 1024    |
| 0.249 ms | 2808       |          | 84.1437G/s | 8.61631T/s | 2.048k | 1024 | 1024    |
| 0.484 ms | 1445       |          | 77.9194G/s | 8.8655T/s  | 4.096k | 1024 | 1024    |
| 0.955 ms | 733        |          | 74.636G/s  | 8.99144T/s | 8.192k | 1024 | 1024    |
| 0.816 ms | 857        |          | 169.614G/s | 21.0526T/s | 1024   | 1024 | 16.384k |
| 1.58 ms  | 442        |          | 132.367G/s | 21.687T/s  | 2.048k | 1024 | 16.384k |
| 3.13 ms  | 224        |          | 112.65G/s  | 21.9721T/s | 4.096k | 1024 | 16.384k |
| 6.21 ms  | 113        |          | 102.705G/s | 22.141T/s  | 8.192k | 1024 | 16.384k |