### PR TITLE
Un-scale output distances

### DIFF
--- a/cpp/include/raft/neighbors/detail/cagra/cagra_search.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/cagra_search.cuh
@@ -102,8 +102,8 @@ void search_main(raft::device_resources const& res,
                 "only float distances are supported at the moment");
   float* dist_out          = distances.data_handle();
   const DistanceT* dist_in = distances.data_handle();
-  // We're converting the data from T to DistanceT during distance computation;
-  // hence now we convert it back (DistanceT -> T).
+  // We're converting the data from T to DistanceT during distance computation
+  // and divide the values by kDivisor. Here we restore the original scale.
   constexpr float kScale = spatial::knn::detail::utils::config<T>::kDivisor /
                            spatial::knn::detail::utils::config<DistanceT>::kDivisor;
   ivf_pq::detail::postprocess_distances(dist_out,

--- a/cpp/include/raft/neighbors/detail/cagra/cagra_search.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/cagra_search.cuh
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <raft/neighbors/detail/ivf_pq_search.cuh>
+#include <raft/spatial/knn/detail/ann_utils.cuh>
+
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/device_resources.hpp>
 #include <raft/neighbors/cagra_types.hpp>
@@ -94,6 +97,22 @@ void search_main(raft::device_resources const& res,
             _num_executed_iterations,
             topk);
   }
+
+  static_assert(std::is_same_v<DistanceT, float>,
+                "only float distances are supported at the moment");
+  float* dist_out          = distances.data_handle();
+  const DistanceT* dist_in = distances.data_handle();
+  // We're converting the data from T to DistanceT during distance computation;
+  // hence now we convert it back (DistanceT -> T).
+  constexpr float kScale = spatial::knn::detail::utils::config<T>::kDivisor /
+                           spatial::knn::detail::utils::config<DistanceT>::kDivisor;
+  ivf_pq::detail::postprocess_distances(dist_out,
+                                        dist_in,
+                                        index.metric(),
+                                        distances.extent(0),
+                                        distances.extent(1),
+                                        kScale,
+                                        res.get_stream());
 }
 /** @} */  // end group cagra
 

--- a/cpp/include/raft/neighbors/detail/cagra/compute_distance.hpp
+++ b/cpp/include/raft/neighbors/detail/cagra/compute_distance.hpp
@@ -53,7 +53,7 @@ _RAFT_DEVICE void compute_distance_to_random_nodes(
   INDEX_T* const result_indices_ptr,       // [num_pickup]
   DISTANCE_T* const result_distances_ptr,  // [num_pickup]
   const float* const query_buffer,
-  const DATA_T* const dataset_ptr,  // [dataset_size, dataset_dim]
+  const DATA_T* const dataset_ptr,         // [dataset_size, dataset_dim]
   const std::size_t dataset_dim,
   const std::size_t dataset_size,
   const std::size_t num_pickup,

--- a/cpp/include/raft/neighbors/detail/cagra/compute_distance.hpp
+++ b/cpp/include/raft/neighbors/detail/cagra/compute_distance.hpp
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <raft/spatial/knn/detail/ann_utils.cuh>
+
 #include "device_common.hpp"
 #include "hashmap.hpp"
 #include "utils.hpp"
@@ -51,7 +53,7 @@ _RAFT_DEVICE void compute_distance_to_random_nodes(
   INDEX_T* const result_indices_ptr,       // [num_pickup]
   DISTANCE_T* const result_distances_ptr,  // [num_pickup]
   const float* const query_buffer,
-  const DATA_T* const dataset_ptr,         // [dataset_size, dataset_dim]
+  const DATA_T* const dataset_ptr,  // [dataset_size, dataset_dim]
   const std::size_t dataset_dim,
   const std::size_t dataset_size,
   const std::size_t num_pickup,
@@ -102,7 +104,7 @@ _RAFT_DEVICE void compute_distance_to_random_nodes(
             const uint32_t kv = k + v;
             // if (kv >= dataset_dim) break;
             DISTANCE_T diff = query_buffer[device::swizzling(kv)];
-            diff -= static_cast<float>(dl_buff[e].data[v]) * device::fragment_scale<DATA_T>();
+            diff -= spatial::knn::detail::utils::mapping<float>{}(dl_buff[e].data[v]);
             norm2 += diff * diff;
           }
         }
@@ -229,7 +231,7 @@ _RAFT_DEVICE void compute_distance_to_child_nodes(INDEX_T* const result_child_in
             const unsigned kv = k + v;
             diff              = query_buffer[device::swizzling(kv)];
           }
-          diff -= static_cast<float>(dl_buff[e].data[v]) * device::fragment_scale<DATA_T>();
+          diff -= spatial::knn::detail::utils::mapping<float>{}(dl_buff[e].data[v]);
           norm2 += diff * diff;
         }
       }

--- a/cpp/include/raft/neighbors/detail/cagra/device_common.hpp
+++ b/cpp/include/raft/neighbors/detail/cagra/device_common.hpp
@@ -27,30 +27,6 @@ namespace device {
 // warpSize for compile time calculation
 constexpr unsigned warp_size = 32;
 
-// scaling factor for distance computation
-template <class T>
-_RAFT_HOST_DEVICE constexpr float fragment_scale();
-template <>
-_RAFT_HOST_DEVICE constexpr float fragment_scale<float>()
-{
-  return 1.0;
-};
-template <>
-_RAFT_HOST_DEVICE constexpr float fragment_scale<half>()
-{
-  return 1.0;
-};
-template <>
-_RAFT_HOST_DEVICE constexpr float fragment_scale<uint8_t>()
-{
-  return 1.0 / 256.0;
-};
-template <>
-_RAFT_HOST_DEVICE constexpr float fragment_scale<int8_t>()
-{
-  return 1.0 / 128.0;
-};
-
 /** Xorshift rondem number generator.
  *
  * See https://en.wikipedia.org/wiki/Xorshift#xorshift for reference.

--- a/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #pragma once
+
+#include <raft/spatial/knn/detail/ann_utils.cuh>
+
 #include <algorithm>
 #include <cassert>
 #include <iostream>
@@ -43,7 +46,7 @@ namespace multi_cta_search {
 template <class INDEX_T>
 __device__ void pickup_next_parents(INDEX_T* const next_parent_indices,  // [num_parents]
                                     const uint32_t num_parents,
-                                    INDEX_T* const itopk_indices,        // [num_itopk]
+                                    INDEX_T* const itopk_indices,  // [num_itopk]
                                     const size_t num_itopk,
                                     uint32_t* const terminate_flag)
 {
@@ -80,8 +83,8 @@ __device__ void pickup_next_parents(INDEX_T* const next_parent_indices,  // [num
 }
 
 template <unsigned MAX_ELEMENTS>
-__device__ inline void topk_by_bitonic_sort(float* distances,         // [num_elements]
-                                            uint32_t* indices,        // [num_elements]
+__device__ inline void topk_by_bitonic_sort(float* distances,   // [num_elements]
+                                            uint32_t* indices,  // [num_elements]
                                             const uint32_t num_elements,
                                             const uint32_t num_itopk  // num_itopk <= num_elements
 )
@@ -137,7 +140,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__ void search_kernel(
   const uint32_t graph_degree,
   const unsigned num_distilation,
   const uint64_t rand_xor_mask,
-  const INDEX_T* seed_ptr,              // [num_queries, num_seeds]
+  const INDEX_T* seed_ptr,  // [num_queries, num_seeds]
   const uint32_t num_seeds,
   uint32_t* const visited_hashmap_ptr,  // [num_queries, 1 << hash_bitlen]
   const uint32_t hash_bitlen,
@@ -204,7 +207,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__ void search_kernel(
   for (unsigned i = threadIdx.x; i < MAX_DATASET_DIM; i += BLOCK_SIZE) {
     unsigned j = device::swizzling(i);
     if (i < dataset_dim) {
-      query_buffer[j] = static_cast<float>(query_ptr[i]) * device::fragment_scale<DATA_T>();
+      query_buffer[j] = spatial::knn::detail::utils::mapping<float>{}(query_ptr[i]);
     } else {
       query_buffer[j] = 0.0;
     }
@@ -561,9 +564,9 @@ struct search : public search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
   void operator()(raft::device_resources const& res,
                   raft::device_matrix_view<const DATA_T, INDEX_T, row_major> dataset,
                   raft::device_matrix_view<const INDEX_T, INDEX_T, row_major> graph,
-                  INDEX_T* const topk_indices_ptr,          // [num_queries, topk]
-                  DISTANCE_T* const topk_distances_ptr,     // [num_queries, topk]
-                  const DATA_T* const queries_ptr,          // [num_queries, dataset_dim]
+                  INDEX_T* const topk_indices_ptr,       // [num_queries, topk]
+                  DISTANCE_T* const topk_distances_ptr,  // [num_queries, topk]
+                  const DATA_T* const queries_ptr,       // [num_queries, dataset_dim]
                   const uint32_t num_queries,
                   const INDEX_T* dev_seed_ptr,              // [num_queries, num_seeds]
                   uint32_t* const num_executed_iterations,  // [num_queries,]

--- a/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
@@ -46,7 +46,7 @@ namespace multi_cta_search {
 template <class INDEX_T>
 __device__ void pickup_next_parents(INDEX_T* const next_parent_indices,  // [num_parents]
                                     const uint32_t num_parents,
-                                    INDEX_T* const itopk_indices,  // [num_itopk]
+                                    INDEX_T* const itopk_indices,        // [num_itopk]
                                     const size_t num_itopk,
                                     uint32_t* const terminate_flag)
 {
@@ -83,8 +83,8 @@ __device__ void pickup_next_parents(INDEX_T* const next_parent_indices,  // [num
 }
 
 template <unsigned MAX_ELEMENTS>
-__device__ inline void topk_by_bitonic_sort(float* distances,   // [num_elements]
-                                            uint32_t* indices,  // [num_elements]
+__device__ inline void topk_by_bitonic_sort(float* distances,         // [num_elements]
+                                            uint32_t* indices,        // [num_elements]
                                             const uint32_t num_elements,
                                             const uint32_t num_itopk  // num_itopk <= num_elements
 )
@@ -140,7 +140,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__ void search_kernel(
   const uint32_t graph_degree,
   const unsigned num_distilation,
   const uint64_t rand_xor_mask,
-  const INDEX_T* seed_ptr,  // [num_queries, num_seeds]
+  const INDEX_T* seed_ptr,              // [num_queries, num_seeds]
   const uint32_t num_seeds,
   uint32_t* const visited_hashmap_ptr,  // [num_queries, 1 << hash_bitlen]
   const uint32_t hash_bitlen,
@@ -564,9 +564,9 @@ struct search : public search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
   void operator()(raft::device_resources const& res,
                   raft::device_matrix_view<const DATA_T, INDEX_T, row_major> dataset,
                   raft::device_matrix_view<const INDEX_T, INDEX_T, row_major> graph,
-                  INDEX_T* const topk_indices_ptr,       // [num_queries, topk]
-                  DISTANCE_T* const topk_distances_ptr,  // [num_queries, topk]
-                  const DATA_T* const queries_ptr,       // [num_queries, dataset_dim]
+                  INDEX_T* const topk_indices_ptr,          // [num_queries, topk]
+                  DISTANCE_T* const topk_distances_ptr,     // [num_queries, topk]
+                  const DATA_T* const queries_ptr,          // [num_queries, dataset_dim]
                   const uint32_t num_queries,
                   const INDEX_T* dev_seed_ptr,              // [num_queries, num_seeds]
                   uint32_t* const num_executed_iterations,  // [num_queries,]

--- a/cpp/include/raft/neighbors/detail/cagra/search_multi_kernel.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_multi_kernel.cuh
@@ -96,7 +96,7 @@ __global__ void random_pickup_kernel(
   const std::size_t num_pickup,
   const unsigned num_distilation,
   const uint64_t rand_xor_mask,
-  const INDEX_T* seed_ptr,  // [num_queries, num_seeds]
+  const INDEX_T* seed_ptr,                   // [num_queries, num_seeds]
   const uint32_t num_seeds,
   INDEX_T* const result_indices_ptr,         // [num_queries, ldr]
   DISTANCE_T* const result_distances_ptr,    // [num_queries, ldr]
@@ -167,7 +167,7 @@ void random_pickup(const DATA_T* const dataset_ptr,  // [dataset_size, dataset_d
                    const std::size_t num_pickup,
                    const unsigned num_distilation,
                    const uint64_t rand_xor_mask,
-                   const INDEX_T* seed_ptr,  // [num_queries, num_seeds]
+                   const INDEX_T* seed_ptr,                   // [num_queries, num_seeds]
                    const uint32_t num_seeds,
                    INDEX_T* const result_indices_ptr,         // [num_queries, ldr]
                    DISTANCE_T* const result_distances_ptr,    // [num_queries, ldr]
@@ -305,17 +305,17 @@ template <unsigned TEAM_SIZE,
 __global__ void compute_distance_to_child_nodes_kernel(
   const INDEX_T* const parent_node_list,  // [num_queries, num_parents]
   const std::uint32_t num_parents,
-  const DATA_T* const dataset_ptr,  // [dataset_size, data_dim]
+  const DATA_T* const dataset_ptr,        // [dataset_size, data_dim]
   const std::uint32_t data_dim,
   const std::uint32_t dataset_size,
-  const INDEX_T* const neighbor_graph_ptr,  // [dataset_size, graph_degree]
+  const INDEX_T* const neighbor_graph_ptr,   // [dataset_size, graph_degree]
   const std::uint32_t graph_degree,
   const DATA_T* query_ptr,                   // [num_queries, data_dim]
   std::uint32_t* const visited_hashmap_ptr,  // [num_queries, 1 << hash_bitlen]
   const std::uint32_t hash_bitlen,
-  INDEX_T* const result_indices_ptr,       // [num_queries, ldd]
-  DISTANCE_T* const result_distances_ptr,  // [num_queries, ldd]
-  const std::uint32_t ldd                  // (*) ldd >= num_parents * graph_degree
+  INDEX_T* const result_indices_ptr,         // [num_queries, ldd]
+  DISTANCE_T* const result_distances_ptr,    // [num_queries, ldd]
+  const std::uint32_t ldd                    // (*) ldd >= num_parents * graph_degree
 )
 {
   const uint32_t ldb        = hashmap::get_size(hash_bitlen);
@@ -364,18 +364,18 @@ template <unsigned TEAM_SIZE,
 void compute_distance_to_child_nodes(
   const INDEX_T* const parent_node_list,  // [num_queries, num_parents]
   const uint32_t num_parents,
-  const DATA_T* const dataset_ptr,  // [dataset_size, data_dim]
+  const DATA_T* const dataset_ptr,        // [dataset_size, data_dim]
   const std::uint32_t data_dim,
   const std::uint32_t dataset_size,
-  const INDEX_T* const neighbor_graph_ptr,  // [dataset_size, graph_degree]
+  const INDEX_T* const neighbor_graph_ptr,   // [dataset_size, graph_degree]
   const std::uint32_t graph_degree,
-  const DATA_T* query_ptr,  // [num_queries, data_dim]
+  const DATA_T* query_ptr,                   // [num_queries, data_dim]
   const std::uint32_t num_queries,
   std::uint32_t* const visited_hashmap_ptr,  // [num_queries, 1 << hash_bitlen]
   const std::uint32_t hash_bitlen,
-  INDEX_T* const result_indices_ptr,       // [num_queries, ldd]
-  DISTANCE_T* const result_distances_ptr,  // [num_queries, ldd]
-  const std::uint32_t ldd,                 // (*) ldd >= num_parents * graph_degree
+  INDEX_T* const result_indices_ptr,         // [num_queries, ldd]
+  DISTANCE_T* const result_distances_ptr,    // [num_queries, ldd]
+  const std::uint32_t ldd,                   // (*) ldd >= num_parents * graph_degree
   cudaStream_t cuda_stream = 0)
 {
   const auto block_size = 128;
@@ -426,7 +426,7 @@ void remove_parent_bit(const std::uint32_t num_queries,
 }
 
 template <class T>
-__global__ void batched_memcpy_kernel(T* const dst,  // [batch_size, ld_dst]
+__global__ void batched_memcpy_kernel(T* const dst,        // [batch_size, ld_dst]
                                       const uint64_t ld_dst,
                                       const T* const src,  // [batch_size, ld_src]
                                       const uint64_t ld_src,
@@ -441,7 +441,7 @@ __global__ void batched_memcpy_kernel(T* const dst,  // [batch_size, ld_dst]
 }
 
 template <class T>
-void batched_memcpy(T* const dst,  // [batch_size, ld_dst]
+void batched_memcpy(T* const dst,        // [batch_size, ld_dst]
                     const uint64_t ld_dst,
                     const T* const src,  // [batch_size, ld_src]
                     const uint64_t ld_src,
@@ -585,9 +585,9 @@ struct search : search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
   void operator()(raft::device_resources const& res,
                   raft::device_matrix_view<const DATA_T, INDEX_T, row_major> dataset,
                   raft::device_matrix_view<const INDEX_T, INDEX_T, row_major> graph,
-                  INDEX_T* const topk_indices_ptr,       // [num_queries, topk]
-                  DISTANCE_T* const topk_distances_ptr,  // [num_queries, topk]
-                  const DATA_T* const queries_ptr,       // [num_queries, dataset_dim]
+                  INDEX_T* const topk_indices_ptr,          // [num_queries, topk]
+                  DISTANCE_T* const topk_distances_ptr,     // [num_queries, topk]
+                  const DATA_T* const queries_ptr,          // [num_queries, dataset_dim]
                   const uint32_t num_queries,
                   const INDEX_T* dev_seed_ptr,              // [num_queries, num_seeds]
                   uint32_t* const num_executed_iterations,  // [num_queries,]

--- a/cpp/include/raft/neighbors/detail/cagra/search_single_cta.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_single_cta.cuh
@@ -92,8 +92,7 @@ struct topk_by_radix_sort_base {
   static constexpr std::uint32_t vecLen           = 2;  // TODO
 };
 template <unsigned MAX_INTERNAL_TOPK, unsigned BLOCK_SIZE, class = void>
-struct topk_by_radix_sort : topk_by_radix_sort_base<MAX_INTERNAL_TOPK> {
-};
+struct topk_by_radix_sort : topk_by_radix_sort_base<MAX_INTERNAL_TOPK> {};
 
 template <unsigned MAX_INTERNAL_TOPK, unsigned BLOCK_SIZE>
 struct topk_by_radix_sort<MAX_INTERNAL_TOPK,
@@ -260,8 +259,8 @@ __device__ inline void topk_by_bitonic_sort_1st(
 
 template <unsigned MAX_ITOPK, unsigned MULTI_WARPS = 0>
 __device__ inline void topk_by_bitonic_sort_2nd(
-  float* itopk_distances,        // [num_itopk]
-  std::uint32_t* itopk_indices,  // [num_itopk]
+  float* itopk_distances,            // [num_itopk]
+  std::uint32_t* itopk_indices,      // [num_itopk]
   const std::uint32_t num_itopk,
   float* candidate_distances,        // [num_candidates]
   std::uint32_t* candidate_indices,  // [num_candidates]
@@ -468,8 +467,8 @@ template <unsigned MAX_ITOPK,
           unsigned MAX_CANDIDATES,
           unsigned MULTI_WARPS_1,
           unsigned MULTI_WARPS_2>
-__device__ void topk_by_bitonic_sort(float* itopk_distances,        // [num_itopk]
-                                     std::uint32_t* itopk_indices,  // [num_itopk]
+__device__ void topk_by_bitonic_sort(float* itopk_distances,            // [num_itopk]
+                                     std::uint32_t* itopk_indices,      // [num_itopk]
                                      const std::uint32_t num_itopk,
                                      float* candidate_distances,        // [num_candidates]
                                      std::uint32_t* candidate_indices,  // [num_candidates]
@@ -530,7 +529,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__
   void search_kernel(INDEX_T* const result_indices_ptr,       // [num_queries, top_k]
                      DISTANCE_T* const result_distances_ptr,  // [num_queries, top_k]
                      const std::uint32_t top_k,
-                     const DATA_T* const dataset_ptr,  // [dataset_size, dataset_dim]
+                     const DATA_T* const dataset_ptr,         // [dataset_size, dataset_dim]
                      const std::size_t dataset_dim,
                      const std::size_t dataset_size,
                      const DATA_T* const queries_ptr,  // [num_queries, dataset_dim]
@@ -538,7 +537,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__
                      const std::uint32_t graph_degree,
                      const unsigned num_distilation,
                      const uint64_t rand_xor_mask,
-                     const INDEX_T* seed_ptr,  // [num_queries, num_seeds]
+                     const INDEX_T* seed_ptr,                   // [num_queries, num_seeds]
                      const uint32_t num_seeds,
                      std::uint32_t* const visited_hashmap_ptr,  // [num_queries, 1 << hash_bitlen]
                      const std::uint32_t internal_topk,
@@ -1113,9 +1112,9 @@ struct search : search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
   void operator()(raft::device_resources const& res,
                   raft::device_matrix_view<const DATA_T, INDEX_T, row_major> dataset,
                   raft::device_matrix_view<const INDEX_T, INDEX_T, row_major> graph,
-                  INDEX_T* const result_indices_ptr,       // [num_queries, topk]
-                  DISTANCE_T* const result_distances_ptr,  // [num_queries, topk]
-                  const DATA_T* const queries_ptr,         // [num_queries, dataset_dim]
+                  INDEX_T* const result_indices_ptr,             // [num_queries, topk]
+                  DISTANCE_T* const result_distances_ptr,        // [num_queries, topk]
+                  const DATA_T* const queries_ptr,               // [num_queries, dataset_dim]
                   const std::uint32_t num_queries,
                   const INDEX_T* dev_seed_ptr,                   // [num_queries, num_seeds]
                   std::uint32_t* const num_executed_iterations,  // [num_queries]

--- a/cpp/include/raft/spatial/knn/detail/ann_utils.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_utils.cuh
@@ -46,8 +46,7 @@ enum class pointer_residency {
 };
 
 template <typename... Types>
-struct pointer_residency_count {
-};
+struct pointer_residency_count {};
 
 template <>
 struct pointer_residency_count<> {
@@ -137,8 +136,7 @@ struct with_mapped_memory_t {
 };
 
 template <typename T>
-struct config {
-};
+struct config {};
 
 template <>
 struct config<double> {

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -314,6 +314,8 @@ if(BUILD_TESTS)
     NEIGHBORS_TEST
     PATH
     test/neighbors/ann_cagra/test_float_uint32_t.cu
+    test/neighbors/ann_cagra/test_int8_t_uint32_t.cu
+    test/neighbors/ann_cagra/test_uint8_t_uint32_t.cu
     test/neighbors/ann_ivf_flat/test_float_int64_t.cu
     test/neighbors/ann_ivf_flat/test_int8_t_int64_t.cu
     test/neighbors/ann_ivf_flat/test_uint8_t_int64_t.cu

--- a/cpp/test/neighbors/ann_cagra.cuh
+++ b/cpp/test/neighbors/ann_cagra.cuh
@@ -225,7 +225,7 @@ inline std::vector<AnnCagraInputs> generate_inputs()
     {100},
     {1000},
     {8},
-    {1, 16, 33},  // k
+    {1, 16, 33},   // k
     {search_algo::SINGLE_CTA, search_algo::MULTI_KERNEL},
     {1, 10, 100},  // query size
     {0},

--- a/cpp/test/neighbors/ann_cagra.cuh
+++ b/cpp/test/neighbors/ann_cagra.cuh
@@ -82,6 +82,10 @@ class AnnCagraTest : public ::testing::TestWithParam<AnnCagraInputs> {
  protected:
   void testCagra()
   {
+    if (ps.dim * sizeof(DataT) % 8 != 0) {
+      GTEST_SKIP()
+        << "CAGRA requires the input data rows to be aligned at least to 8 bytes for now.";
+    }
     size_t queries_size = ps.n_queries * ps.k;
     std::vector<IdxT> indices_Cagra(queries_size);
     std::vector<IdxT> indices_naive(queries_size);
@@ -221,7 +225,7 @@ inline std::vector<AnnCagraInputs> generate_inputs()
     {100},
     {1000},
     {8},
-    {1, 16, 33},   // k
+    {1, 16, 33},  // k
     {search_algo::SINGLE_CTA, search_algo::MULTI_KERNEL},
     {1, 10, 100},  // query size
     {0},

--- a/cpp/test/neighbors/ann_cagra/test_int8_t_uint32_t.cu
+++ b/cpp/test/neighbors/ann_cagra/test_int8_t_uint32_t.cu
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../ann_cagra.cuh"
+
+namespace raft::neighbors::experimental::cagra {
+
+typedef AnnCagraTest<float, std::int8_t, std::uint32_t> AnnCagraTestI8;
+TEST_P(AnnCagraTestI8, AnnCagra) { this->testCagra(); }
+
+INSTANTIATE_TEST_CASE_P(AnnCagraTest, AnnCagraTestI8, ::testing::ValuesIn(inputs));
+
+}  // namespace raft::neighbors::experimental::cagra

--- a/cpp/test/neighbors/ann_cagra/test_uint8_t_uint32_t.cu
+++ b/cpp/test/neighbors/ann_cagra/test_uint8_t_uint32_t.cu
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "../ann_cagra.cuh"
+
+namespace raft::neighbors::experimental::cagra {
+
+typedef AnnCagraTest<float, std::uint8_t, std::uint32_t> AnnCagraTestU8;
+TEST_P(AnnCagraTestU8, AnnCagra) { this->testCagra(); }
+
+INSTANTIATE_TEST_CASE_P(AnnCagraTest, AnnCagraTestU8, ::testing::ValuesIn(inputs));
+
+}  // namespace raft::neighbors::experimental::cagra


### PR DESCRIPTION
Reverts the scaling of input data and queries that normally happens for int8/uint8 types before distance computation.
Reuses the ivf-pq post-processing step for that.

Along the way, replaces the custom `fragment_scale` helper with the `utils::mapping` that is shared among several ANN methods.

Solves https://github.com/rapidsai/raft/issues/1457