### PR TITLE
Update recipes to GTest version >=1.13.0

### DIFF
--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -24,7 +24,9 @@ dependencies:
 - distributed==2023.3.2.1
 - doxygen>=1.8.20
 - gcc_linux-64=11.*
+- gmock>=1.13.0.*
 - graphviz
+- gtest>=1.13.0.*
 - ipython
 - joblib>=0.11
 - libcublas-dev=11.11.3.6

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -24,9 +24,9 @@ dependencies:
 - distributed==2023.3.2.1
 - doxygen>=1.8.20
 - gcc_linux-64=11.*
-- gmock>=1.13.0.*
+- gmock>=1.13.0
 - graphviz
-- gtest>=1.13.0.*
+- gtest>=1.13.0
 - ipython
 - joblib>=0.11
 - libcublas-dev=11.11.3.6

--- a/conda/recipes/libraft/conda_build_config.yaml
+++ b/conda/recipes/libraft/conda_build_config.yaml
@@ -17,7 +17,7 @@ nccl_version:
   - ">=2.9.9"
 
 gtest_version:
-  - "=1.10.0"
+  - ">=1.13.0"
 
 glog_version:
   - ">=0.6.0"

--- a/cpp/test/linalg/eig.cu
+++ b/cpp/test/linalg/eig.cu
@@ -273,5 +273,9 @@ INSTANTIATE_TEST_SUITE_P(EigTests, EigTestVecJacobiF, ::testing::ValuesIn(inputs
 
 INSTANTIATE_TEST_SUITE_P(EigTests, EigTestVecJacobiD, ::testing::ValuesIn(inputsd2));
 
+INSTANTIATE_TEST_SUITE_P(EigTests, EigTestVecCompareF, ::testing::ValuesIn(inputsf2));
+
+INSTANTIATE_TEST_SUITE_P(EigTests, EigTestVecCompareD, ::testing::ValuesIn(inputsd2));
+
 }  // namespace linalg
 }  // namespace raft

--- a/cpp/test/linalg/svd.cu
+++ b/cpp/test/linalg/svd.cu
@@ -202,6 +202,10 @@ INSTANTIATE_TEST_SUITE_P(SvdTests, SvdTestLeftVecF, ::testing::ValuesIn(inputsf2
 
 INSTANTIATE_TEST_SUITE_P(SvdTests, SvdTestLeftVecD, ::testing::ValuesIn(inputsd2));
 
+INSTANTIATE_TEST_SUITE_P(SvdTests, SvdTestRightVecF, ::testing::ValuesIn(inputsf2));
+
+INSTANTIATE_TEST_SUITE_P(SvdTests, SvdTestRightVecD, ::testing::ValuesIn(inputsd2));
+
 // INSTANTIATE_TEST_SUITE_P(SvdTests, SvdTestRightVecF,
 // ::testing::ValuesIn(inputsf2));
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -222,8 +222,8 @@ dependencies:
     common:
       - output_types: [conda]
         packages:
-          - gtest>=1.13.0.*
-          - gmock>=1.13.0.*
+          - gtest>=1.13.0
+          - gmock>=1.13.0
   docs:
     common:
       - output_types: [conda]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -10,6 +10,7 @@ files:
       - build_pylibraft
       - cudatoolkit
       - develop
+      - test_libraft
       - docs
       - run_raft_dask
       - run_pylibraft
@@ -29,6 +30,7 @@ files:
     output: none
     includes:
       - cudatoolkit
+      - test_libraft
   test_python:
     output: none
     includes:
@@ -216,6 +218,12 @@ dependencies:
               - *libcusolver114
               - *libcusparse_dev114
               - *libcusparse114
+  test_libraft:
+    common:
+      - output_types: [conda]
+        packages:
+          - gtest>=1.13.0.*
+          - gmock>=1.13.0.*
   docs:
     common:
       - output_types: [conda]


### PR DESCRIPTION
This PR updates GTest pinnings to >=1.13.0. This aligns with recent changes in rapids-cmake: https://github.com/rapidsai/rapids-cmake/pull/401.
