### PR TITLE
CAGRA pad dataset for 128bit vectorized load

### DIFF
--- a/cpp/include/raft/neighbors/cagra.cuh
+++ b/cpp/include/raft/neighbors/cagra.cuh
@@ -237,21 +237,28 @@ index<T, IdxT> build(raft::resources const& res,
                      const index_params& params,
                      mdspan<const T, matrix_extent<IdxT>, row_major, Accessor> dataset)
 {
-  size_t degree = params.intermediate_graph_degree;
-  if (degree >= static_cast<size_t>(dataset.extent(0))) {
+  size_t intermediate_degree       = params.intermediate_graph_degree;
+  size_t graph_degree = params.graph_degree;
+  if (intermediate_degree >= static_cast<size_t>(dataset.extent(0))) {
     RAFT_LOG_WARN(
       "Intermediate graph degree cannot be larger than dataset size, reducing it to %lu",
       dataset.extent(0));
-    degree = dataset.extent(0) - 1;
+    intermediate_degree = dataset.extent(0) - 1;
   }
-  RAFT_EXPECTS(degree >= params.graph_degree,
-               "Intermediate graph degree cannot be smaller than final graph degree");
+  if (intermediate_degree < graph_degree) {
+    RAFT_LOG_WARN(
+      "Graph degree (%lu) cannot be larger than intermediate graph degree (%lu), reducing "
+      "graph_degree.",
+      graph_degree,
+      intermediate_degree);
+    graph_degree = intermediate_degree;
+  }
 
-  auto knn_graph = raft::make_host_matrix<IdxT, IdxT>(dataset.extent(0), degree);
+  auto knn_graph = raft::make_host_matrix<IdxT, IdxT>(dataset.extent(0), intermediate_degree);
 
   build_knn_graph(res, dataset, knn_graph.view());
 
-  auto cagra_graph = raft::make_host_matrix<IdxT, IdxT>(dataset.extent(0), params.graph_degree);
+  auto cagra_graph = raft::make_host_matrix<IdxT, IdxT>(dataset.extent(0), graph_degree);
 
   prune<IdxT>(res, knn_graph.view(), cagra_graph.view());
 
@@ -290,7 +297,6 @@ void search(raft::resources const& res,
 
   RAFT_EXPECTS(neighbors.extent(1) == distances.extent(1),
                "Number of columns in output neighbors and distances matrices must equal k");
-
   RAFT_EXPECTS(queries.extent(1) == idx.dim(),
                "Number of query dimensions should equal number of dimensions in the index.");
 

--- a/cpp/include/raft/neighbors/cagra.cuh
+++ b/cpp/include/raft/neighbors/cagra.cuh
@@ -237,8 +237,8 @@ index<T, IdxT> build(raft::resources const& res,
                      const index_params& params,
                      mdspan<const T, matrix_extent<IdxT>, row_major, Accessor> dataset)
 {
-  size_t intermediate_degree       = params.intermediate_graph_degree;
-  size_t graph_degree = params.graph_degree;
+  size_t intermediate_degree = params.intermediate_graph_degree;
+  size_t graph_degree        = params.graph_degree;
   if (intermediate_degree >= static_cast<size_t>(dataset.extent(0))) {
     RAFT_LOG_WARN(
       "Intermediate graph degree cannot be larger than dataset size, reducing it to %lu",

--- a/cpp/include/raft/neighbors/cagra_types.hpp
+++ b/cpp/include/raft/neighbors/cagra_types.hpp
@@ -26,6 +26,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/util/integer_utils.hpp>
+#include <raft/util/pow2_utils.cuh>
 
 #include <memory>
 #include <optional>
@@ -82,8 +83,6 @@ struct search_params : ann::search_params {
   /** Lower limit of search iterations. */
   size_t min_iterations = 0;
 
-  /** Bit length for reading the dataset vectors. 0, 64 or 128. Auto selection when 0. */
-  size_t load_bit_length = 0;
   /** Thread block size. 0, 64, 128, 256, 512, 1024. Auto selection when 0. */
   size_t thread_block_size = 0;
   /** Hashmap type. Auto selection when AUTO. */
@@ -113,6 +112,7 @@ static_assert(std::is_aggregate_v<search_params>);
  */
 template <typename T, typename IdxT>
 struct index : ann::index {
+  using AlignDim = raft::Pow2<16 / sizeof(T)>;
   static_assert(!raft::is_narrowing_v<uint32_t, IdxT>,
                 "IdxT must be able to represent all values of uint32_t");
 
@@ -124,12 +124,15 @@ struct index : ann::index {
   }
 
   // /** Total length of the index. */
-  [[nodiscard]] constexpr inline auto size() const noexcept -> IdxT { return dataset_.extent(0); }
+  [[nodiscard]] constexpr inline auto size() const noexcept -> IdxT
+  {
+    return dataset_view_.extent(0);
+  }
 
   /** Dimensionality of the data. */
   [[nodiscard]] constexpr inline auto dim() const noexcept -> uint32_t
   {
-    return dataset_.extent(1);
+    return dataset_view_.extent(1);
   }
   /** Graph degree */
   [[nodiscard]] constexpr inline auto graph_degree() const noexcept -> uint32_t
@@ -138,9 +141,10 @@ struct index : ann::index {
   }
 
   /** Dataset [size, dim] */
-  [[nodiscard]] inline auto dataset() const noexcept -> device_matrix_view<const T, IdxT, row_major>
+  [[nodiscard]] inline auto dataset() const noexcept
+    -> device_matrix_view<const T, IdxT, layout_stride>
   {
-    return dataset_.view();
+    return dataset_view_;
   }
 
   /** neighborhood graph [size, graph-degree] */
@@ -179,15 +183,36 @@ struct index : ann::index {
         mdspan<IdxT, matrix_extent<IdxT>, row_major, graph_accessor> knn_graph)
     : ann::index(),
       metric_(metric),
-      dataset_(make_device_matrix<T, IdxT>(res, dataset.extent(0), dataset.extent(1))),
+      dataset_(
+        make_device_matrix<T, IdxT>(res, dataset.extent(0), AlignDim::roundUp(dataset.extent(1)))),
       graph_(make_device_matrix<IdxT, IdxT>(res, knn_graph.extent(0), knn_graph.extent(1)))
   {
     RAFT_EXPECTS(dataset.extent(0) == knn_graph.extent(0),
                  "Dataset and knn_graph must have equal number of rows");
-    raft::copy(dataset_.data_handle(),
-               dataset.data_handle(),
-               dataset.size(),
-               resource::get_cuda_stream(res));
+    if (dataset_.extent(1) == dataset.extent(1)) {
+      raft::copy(dataset_.data_handle(),
+                 dataset.data_handle(),
+                 dataset.size(),
+                 resource::get_cuda_stream(res));
+    } else {
+      // copy with padding
+      RAFT_CUDA_TRY(cudaMemsetAsync(
+        dataset_.data_handle(), 0, dataset_.size() * sizeof(T), resource::get_cuda_stream(res)));
+      RAFT_CUDA_TRY(cudaMemcpy2DAsync(dataset_.data_handle(),
+                                      sizeof(T) * dataset_.extent(1),
+                                      dataset.data_handle(),
+                                      sizeof(T) * dataset.extent(1),
+                                      sizeof(T) * dataset.extent(1),
+                                      dataset.extent(0),
+                                      cudaMemcpyDefault,
+                                      resource::get_cuda_stream(res)));
+    }
+    dataset_view_ = make_device_strided_matrix_view<T, IdxT>(
+      dataset_.data_handle(), dataset_.extent(0), dataset.extent(1), dataset_.extent(1));
+    RAFT_LOG_DEBUG("CAGRA dataset strided matrix view %zux%zu, stride %zu",
+                  static_cast<size_t>(dataset_view_.extent(0)),
+                  static_cast<size_t>(dataset_view_.extent(1)),
+                  static_cast<size_t>(dataset_view_.stride(0)));
     raft::copy(graph_.data_handle(),
                knn_graph.data_handle(),
                knn_graph.size(),
@@ -199,6 +224,7 @@ struct index : ann::index {
   raft::distance::DistanceType metric_;
   raft::device_matrix<T, IdxT, row_major> dataset_;
   raft::device_matrix<IdxT, IdxT, row_major> graph_;
+  raft::device_matrix_view<T, IdxT, layout_stride> dataset_view_;
 };
 
 /** @} */

--- a/cpp/include/raft/neighbors/cagra_types.hpp
+++ b/cpp/include/raft/neighbors/cagra_types.hpp
@@ -210,9 +210,9 @@ struct index : ann::index {
     dataset_view_ = make_device_strided_matrix_view<T, IdxT>(
       dataset_.data_handle(), dataset_.extent(0), dataset.extent(1), dataset_.extent(1));
     RAFT_LOG_DEBUG("CAGRA dataset strided matrix view %zux%zu, stride %zu",
-                  static_cast<size_t>(dataset_view_.extent(0)),
-                  static_cast<size_t>(dataset_view_.extent(1)),
-                  static_cast<size_t>(dataset_view_.stride(0)));
+                   static_cast<size_t>(dataset_view_.extent(0)),
+                   static_cast<size_t>(dataset_view_.extent(1)),
+                   static_cast<size_t>(dataset_view_.stride(0)));
     raft::copy(graph_.data_handle(),
                knn_graph.data_handle(),
                knn_graph.size(),

--- a/cpp/include/raft/neighbors/detail/cagra/cagra_build.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/cagra_build.cuh
@@ -46,7 +46,6 @@ void build_knn_graph(raft::resources const& res,
                      std::optional<ivf_pq::index_params> build_params   = std::nullopt,
                      std::optional<ivf_pq::search_params> search_params = std::nullopt)
 {
-
   RAFT_EXPECTS(!build_params || build_params->metric == distance::DistanceType::L2Expanded,
                "Currently only L2Expanded metric is supported");
 

--- a/cpp/include/raft/neighbors/detail/cagra/cagra_build.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/cagra_build.cuh
@@ -46,9 +46,6 @@ void build_knn_graph(raft::resources const& res,
                      std::optional<ivf_pq::index_params> build_params   = std::nullopt,
                      std::optional<ivf_pq::search_params> search_params = std::nullopt)
 {
-  RAFT_EXPECTS(
-    dataset.extent(1) * sizeof(DataT) % 8 == 0,
-    "Dataset rows are expected to have at least 8 bytes alignment. Try padding feature dims.");
 
   RAFT_EXPECTS(!build_params || build_params->metric == distance::DistanceType::L2Expanded,
                "Currently only L2Expanded metric is supported");

--- a/cpp/include/raft/neighbors/detail/cagra/cagra_search.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/cagra_search.cuh
@@ -27,8 +27,6 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include "factory.cuh"
-#include "search_multi_cta.cuh"
-#include "search_multi_kernel.cuh"
 #include "search_plan.cuh"
 #include "search_single_cta.cuh"
 
@@ -92,8 +90,12 @@ void search_main(raft::resources const& res,
         : nullptr;
     uint32_t* _num_executed_iterations = nullptr;
 
-    auto dataset_internal = raft::make_device_matrix_view<const T, internal_IdxT, row_major>(
-      index.dataset().data_handle(), index.dataset().extent(0), index.dataset().extent(1));
+    //    auto dataset_internal = index.dataset();
+    auto dataset_internal = make_device_strided_matrix_view<const T, internal_IdxT, row_major>(
+      index.dataset().data_handle(),
+      index.dataset().extent(0),
+      index.dataset().extent(1),
+      index.dataset().stride(0));
     auto graph_internal =
       raft::make_device_matrix_view<const internal_IdxT, internal_IdxT, row_major>(
         reinterpret_cast<const internal_IdxT*>(index.graph().data_handle()),

--- a/cpp/include/raft/neighbors/detail/cagra/cagra_search.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/cagra_search.cuh
@@ -90,7 +90,6 @@ void search_main(raft::resources const& res,
         : nullptr;
     uint32_t* _num_executed_iterations = nullptr;
 
-    //    auto dataset_internal = index.dataset();
     auto dataset_internal = make_device_strided_matrix_view<const T, internal_IdxT, row_major>(
       index.dataset().data_handle(),
       index.dataset().extent(0),

--- a/cpp/include/raft/neighbors/detail/cagra/compute_distance.hpp
+++ b/cpp/include/raft/neighbors/detail/cagra/compute_distance.hpp
@@ -56,6 +56,7 @@ _RAFT_DEVICE void compute_distance_to_random_nodes(
   const DATA_T* const dataset_ptr,         // [dataset_size, dataset_dim]
   const std::size_t dataset_dim,
   const std::size_t dataset_size,
+  const std::size_t dataset_ld,
   const std::size_t num_pickup,
   const unsigned num_distilation,
   const uint64_t rand_xor_mask,
@@ -93,7 +94,7 @@ _RAFT_DEVICE void compute_distance_to_random_nodes(
         for (uint32_t e = 0; e < nelem; e++) {
           const uint32_t k = (lane_id + (TEAM_SIZE * e)) * vlen;
           if (k >= dataset_dim) break;
-          dl_buff[e].load = ((LOAD_T*)(dataset_ptr + k + (dataset_dim * seed_index)))[0];
+          dl_buff[e].load = ((LOAD_T*)(dataset_ptr + k + (dataset_ld * seed_index)))[0];
         }
 #pragma unroll
         for (uint32_t e = 0; e < nelem; e++) {
@@ -146,6 +147,7 @@ _RAFT_DEVICE void compute_distance_to_child_nodes(INDEX_T* const result_child_in
                                                   // [dataset_dim, dataset_size]
                                                   const DATA_T* const dataset_ptr,
                                                   const std::size_t dataset_dim,
+                                                  const std::size_t dataset_ld,
                                                   // [knn_k, dataset_size]
                                                   const INDEX_T* const knn_graph,
                                                   const std::uint32_t knn_k,
@@ -215,7 +217,7 @@ _RAFT_DEVICE void compute_distance_to_child_nodes(INDEX_T* const result_child_in
       for (unsigned e = 0; e < nelem; e++) {
         const unsigned k = (lane_id + (TEAM_SIZE * e)) * vlen;
         if (k >= dataset_dim) break;
-        dl_buff[e].load = ((LOAD_T*)(dataset_ptr + k + (dataset_dim * child_id)))[0];
+        dl_buff[e].load = ((LOAD_T*)(dataset_ptr + k + (dataset_ld * child_id)))[0];
       }
 #pragma unroll
       for (unsigned e = 0; e < nelem; e++) {

--- a/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
@@ -330,14 +330,14 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__ void search_kernel(
 }
 
 #define SET_MC_KERNEL_3(BLOCK_SIZE, BLOCK_COUNT, MAX_ELEMENTS) \
-  kernel = search_kernel<TEAM_SIZE,                                    \
-                         BLOCK_SIZE,                                   \
-                         BLOCK_COUNT,                                  \
-                         MAX_ELEMENTS,                                 \
-                         MAX_DATASET_DIM,                              \
-                         DATA_T,                                       \
-                         DISTANCE_T,                                   \
-                         INDEX_T,                                      \
+  kernel = search_kernel<TEAM_SIZE,                            \
+                         BLOCK_SIZE,                           \
+                         BLOCK_COUNT,                          \
+                         MAX_ELEMENTS,                         \
+                         MAX_DATASET_DIM,                      \
+                         DATA_T,                               \
+                         DISTANCE_T,                           \
+                         INDEX_T,                              \
                          device::LOAD_128BIT_T>;
 
 #define SET_MC_KERNEL_1(MAX_ELEMENTS)         \

--- a/cpp/include/raft/neighbors/detail/cagra/search_plan.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_plan.cuh
@@ -77,7 +77,6 @@ struct search_plan_impl : public search_plan_impl_base {
   uint32_t result_buffer_size;
 
   uint32_t smem_size;
-  uint32_t load_bit_lenght;
   uint32_t topk;
   uint32_t num_seeds;
 
@@ -107,7 +106,7 @@ struct search_plan_impl : public search_plan_impl_base {
   virtual ~search_plan_impl() {}
 
   virtual void operator()(raft::resources const& res,
-                          raft::device_matrix_view<const DATA_T, INDEX_T, row_major> dataset,
+                          raft::device_matrix_view<const DATA_T, INDEX_T, layout_stride> dataset,
                           raft::device_matrix_view<const INDEX_T, INDEX_T, row_major> graph,
                           INDEX_T* const result_indices_ptr,       // [num_queries, topk]
                           DISTANCE_T* const result_distances_ptr,  // [num_queries, topk]
@@ -286,14 +285,10 @@ struct search_plan_impl : public search_plan_impl_base {
       error_message +=
         "`team_size` must be 0, 4, 8, 16 or 32. " + std::to_string(team_size) + " has been given.";
     }
-    if (load_bit_length != 0 && load_bit_length != 64 && load_bit_length != 128) {
-      error_message += "`load_bit_length` must be 0, 64 or 128. " +
-                       std::to_string(load_bit_length) + " has been given.";
-    }
     if (thread_block_size != 0 && thread_block_size != 64 && thread_block_size != 128 &&
         thread_block_size != 256 && thread_block_size != 512 && thread_block_size != 1024) {
       error_message += "`thread_block_size` must be 0, 64, 128, 256 or 512. " +
-                       std::to_string(load_bit_length) + " has been given.";
+                       std::to_string(thread_block_size) + " has been given.";
     }
     if (hashmap_min_bitlen > 20) {
       error_message += "`hashmap_min_bitlen` must be equal to or smaller than 20. " +

--- a/cpp/include/raft/neighbors/detail/cagra/search_single_cta.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_single_cta.cuh
@@ -811,8 +811,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__
 #endif
 }
 
-#define SET_KERNEL_3(                                                               \
-  BLOCK_SIZE, BLOCK_COUNT, MAX_ITOPK, MAX_CANDIDATES, TOPK_BY_BITONIC_SORT) \
+#define SET_KERNEL_3(BLOCK_SIZE, BLOCK_COUNT, MAX_ITOPK, MAX_CANDIDATES, TOPK_BY_BITONIC_SORT) \
   kernel = search_kernel<TEAM_SIZE,                                                            \
                          BLOCK_SIZE,                                                           \
                          BLOCK_COUNT,                                                          \

--- a/cpp/include/raft/neighbors/detail/cagra/search_single_cta.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_single_cta.cuh
@@ -540,6 +540,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__
                      const DATA_T* const dataset_ptr,         // [dataset_size, dataset_dim]
                      const std::size_t dataset_dim,
                      const std::size_t dataset_size,
+                     const std::size_t dataset_ld,     // stride of dataset
                      const DATA_T* const queries_ptr,  // [num_queries, dataset_dim]
                      const INDEX_T* const knn_graph,   // [dataset_size, graph_degree]
                      const std::uint32_t graph_degree,
@@ -634,6 +635,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__
     dataset_ptr,
     dataset_dim,
     dataset_size,
+    dataset_ld,
     result_buffer_size,
     num_distilation,
     rand_xor_mask,
@@ -758,6 +760,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__
         query_buffer,
         dataset_ptr,
         dataset_dim,
+        dataset_ld,
         knn_graph,
         graph_degree,
         local_visited_hashmap_ptr,
@@ -809,59 +812,42 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__
 }
 
 #define SET_KERNEL_3(                                                               \
-  BLOCK_SIZE, BLOCK_COUNT, MAX_ITOPK, MAX_CANDIDATES, TOPK_BY_BITONIC_SORT, LOAD_T) \
-  kernel = search_kernel<TEAM_SIZE,                                                 \
-                         BLOCK_SIZE,                                                \
-                         BLOCK_COUNT,                                               \
-                         MAX_ITOPK,                                                 \
-                         MAX_CANDIDATES,                                            \
-                         TOPK_BY_BITONIC_SORT,                                      \
-                         MAX_DATASET_DIM,                                           \
-                         DATA_T,                                                    \
-                         DISTANCE_T,                                                \
-                         INDEX_T,                                                   \
-                         LOAD_T>;
-
-#define SET_KERNEL_2(BLOCK_SIZE, BLOCK_COUNT, MAX_ITOPK, MAX_CANDIDATES, TOPK_BY_BITONIC_SORT) \
-  if (load_bit_length == 128) {                                                                \
-    SET_KERNEL_3(BLOCK_SIZE,                                                                   \
-                 BLOCK_COUNT,                                                                  \
-                 MAX_ITOPK,                                                                    \
-                 MAX_CANDIDATES,                                                               \
-                 TOPK_BY_BITONIC_SORT,                                                         \
-                 device::LOAD_128BIT_T)                                                        \
-  } else if (load_bit_length == 64) {                                                          \
-    SET_KERNEL_3(BLOCK_SIZE,                                                                   \
-                 BLOCK_COUNT,                                                                  \
-                 MAX_ITOPK,                                                                    \
-                 MAX_CANDIDATES,                                                               \
-                 TOPK_BY_BITONIC_SORT,                                                         \
-                 device::LOAD_64BIT_T)                                                         \
-  }
+  BLOCK_SIZE, BLOCK_COUNT, MAX_ITOPK, MAX_CANDIDATES, TOPK_BY_BITONIC_SORT) \
+  kernel = search_kernel<TEAM_SIZE,                                                            \
+                         BLOCK_SIZE,                                                           \
+                         BLOCK_COUNT,                                                          \
+                         MAX_ITOPK,                                                            \
+                         MAX_CANDIDATES,                                                       \
+                         TOPK_BY_BITONIC_SORT,                                                 \
+                         MAX_DATASET_DIM,                                                      \
+                         DATA_T,                                                               \
+                         DISTANCE_T,                                                           \
+                         INDEX_T,                                                              \
+                         device::LOAD_128BIT_T>;
 
 #define SET_KERNEL_1B(MAX_ITOPK, MAX_CANDIDATES)              \
   /* if ( block_size == 32 ) {                                \
       SET_KERNEL_2( 32, 20, MAX_ITOPK, MAX_CANDIDATES, 1 )    \
   } else */                                                   \
   if (block_size == 64) {                                     \
-    SET_KERNEL_2(64, 16 /*20*/, MAX_ITOPK, MAX_CANDIDATES, 1) \
+    SET_KERNEL_3(64, 16 /*20*/, MAX_ITOPK, MAX_CANDIDATES, 1) \
   } else if (block_size == 128) {                             \
-    SET_KERNEL_2(128, 8, MAX_ITOPK, MAX_CANDIDATES, 1)        \
+    SET_KERNEL_3(128, 8, MAX_ITOPK, MAX_CANDIDATES, 1)        \
   } else if (block_size == 256) {                             \
-    SET_KERNEL_2(256, 4, MAX_ITOPK, MAX_CANDIDATES, 1)        \
+    SET_KERNEL_3(256, 4, MAX_ITOPK, MAX_CANDIDATES, 1)        \
   } else if (block_size == 512) {                             \
-    SET_KERNEL_2(512, 2, MAX_ITOPK, MAX_CANDIDATES, 1)        \
+    SET_KERNEL_3(512, 2, MAX_ITOPK, MAX_CANDIDATES, 1)        \
   } else {                                                    \
-    SET_KERNEL_2(1024, 1, MAX_ITOPK, MAX_CANDIDATES, 1)       \
+    SET_KERNEL_3(1024, 1, MAX_ITOPK, MAX_CANDIDATES, 1)       \
   }
 
 #define SET_KERNEL_1R(MAX_ITOPK, MAX_CANDIDATES)        \
   if (block_size == 256) {                              \
-    SET_KERNEL_2(256, 4, MAX_ITOPK, MAX_CANDIDATES, 0)  \
+    SET_KERNEL_3(256, 4, MAX_ITOPK, MAX_CANDIDATES, 0)  \
   } else if (block_size == 512) {                       \
-    SET_KERNEL_2(512, 2, MAX_ITOPK, MAX_CANDIDATES, 0)  \
+    SET_KERNEL_3(512, 2, MAX_ITOPK, MAX_CANDIDATES, 0)  \
   } else {                                              \
-    SET_KERNEL_2(1024, 1, MAX_ITOPK, MAX_CANDIDATES, 0) \
+    SET_KERNEL_3(1024, 1, MAX_ITOPK, MAX_CANDIDATES, 0) \
   }
 
 #define SET_KERNEL                                                                \
@@ -871,6 +857,7 @@ __launch_bounds__(BLOCK_SIZE, BLOCK_COUNT) __global__
                                   const DATA_T* const dataset_ptr,                \
                                   const std::size_t dataset_dim,                  \
                                   const std::size_t dataset_size,                 \
+                                  const std::size_t dataset_ld,                   \
                                   const DATA_T* const queries_ptr,                \
                                   const INDEX_T* const knn_graph,                 \
                                   const std::uint32_t graph_degree,               \
@@ -943,7 +930,6 @@ struct search : search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::num_parents;
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::min_iterations;
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::max_iterations;
-  using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::load_bit_length;
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::thread_block_size;
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::hashmap_mode;
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::hashmap_min_bitlen;
@@ -965,7 +951,6 @@ struct search : search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::result_buffer_size;
 
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::smem_size;
-  using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::load_bit_lenght;
 
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::hashmap;
   using search_plan_impl<DATA_T, INDEX_T, DISTANCE_T>::num_executed_iterations;
@@ -1066,22 +1051,6 @@ struct search : search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
                  max_block_size);
     thread_block_size = block_size;
 
-    // Determine load bit length
-    const uint32_t total_bit_length = dim * sizeof(DATA_T) * 8;
-    if (load_bit_length == 0) {
-      load_bit_length = 128;
-      while (total_bit_length % load_bit_length) {
-        load_bit_length /= 2;
-      }
-    }
-    RAFT_LOG_DEBUG("# load_bit_length: %u  (%u loads per vector)",
-                   load_bit_length,
-                   total_bit_length / load_bit_length);
-    RAFT_EXPECTS(total_bit_length % load_bit_length == 0,
-                 "load_bit_length must be a divisor of dim*sizeof(data_t)*8=%u",
-                 total_bit_length);
-    RAFT_EXPECTS(load_bit_length >= 64, "load_bit_lenght cannot be less than 64");
-
     if (num_itopk_candidates <= 256) {
       RAFT_LOG_DEBUG("# bitonic-sort based topk routine is used");
     } else {
@@ -1129,7 +1098,7 @@ struct search : search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
   }
 
   void operator()(raft::resources const& res,
-                  raft::device_matrix_view<const DATA_T, INDEX_T, row_major> dataset,
+                  raft::device_matrix_view<const DATA_T, INDEX_T, layout_stride> dataset,
                   raft::device_matrix_view<const INDEX_T, INDEX_T, row_major> graph,
                   INDEX_T* const result_indices_ptr,             // [num_queries, topk]
                   DISTANCE_T* const result_distances_ptr,        // [num_queries, topk]
@@ -1154,6 +1123,7 @@ struct search : search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
                                                            dataset.data_handle(),
                                                            dataset.extent(1),
                                                            dataset.extent(0),
+                                                           dataset.stride(0),
                                                            queries_ptr,
                                                            graph.data_handle(),
                                                            graph.extent(1),


### PR DESCRIPTION
This PR adds padding to the dataset (if necessary) to make reading any of its rows compatible with 128bit vectorized loads. This change also enables handling arbitrary number of input features (before this PR each row had to be at least 64bit aligned, which constrained the acceptable number of input features).

Fixes #1458.

With this change, it is sufficient to keep a single "load type" specialization for the search kernels, which shall cut the binary size by half (#1459).
