### PR TITLE
[REVIEW] make raft::cache::Cache protected to allow overrides

### DIFF
--- a/cpp/include/raft/util/cache.cuh
+++ b/cpp/include/raft/util/cache.cuh
@@ -361,7 +361,7 @@ class Cache {
    */
   int GetSize() const { return cached_keys.size(); }
 
- private:
+ protected:
   int n_vec;            //!< Number of elements in a cached vector
   float cache_size;     //!< in MiB
   int n_cache_sets;     //!< number of cache sets


### PR DESCRIPTION
We are planning to do some experiments with partial cache updates within cuml. In order to implement overrides for the given public functions and to allow re-usability for the cache internals we need to move the cache members to protected.

CC @cjnolet @tfeher 