### PR TITLE
Check python brute-force knn inputs

### DIFF
--- a/python/pylibraft/pylibraft/common/device_ndarray.py
+++ b/python/pylibraft/pylibraft/common/device_ndarray.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,12 +89,8 @@ class device_ndarray:
         """
         Is the current device_ndarray laid out in row-major format?
         """
-        array_interface = self.ndarray_.__array_interface__
         strides = self.strides
-        return (
-            strides is None
-            or array_interface["strides"][1] == self.dtype.itemsize
-        )
+        return strides is None or strides[1] == self.dtype.itemsize
 
     @property
     def f_contiguous(self):
@@ -125,11 +121,7 @@ class device_ndarray:
         Strides of the current device_ndarray instance
         """
         array_interface = self.ndarray_.__array_interface__
-        return (
-            None
-            if "strides" not in array_interface
-            else array_interface["strides"]
-        )
+        return array_interface.get("strides")
 
     @property
     def __cuda_array_interface__(self):

--- a/python/pylibraft/pylibraft/neighbors/brute_force.pyx
+++ b/python/pylibraft/pylibraft/neighbors/brute_force.pyx
@@ -47,6 +47,7 @@ from pylibraft.distance.distance_type cimport DistanceType
 # TODO: Centralize this
 
 from pylibraft.distance.pairwise_distance import DISTANCE_TYPES
+from pylibraft.neighbors.common import _check_input_array
 
 from pylibraft.common.cpp.mdspan cimport (
     device_matrix_view,
@@ -142,6 +143,11 @@ def knn(dataset, queries, k=None, indices=None, distances=None,
         else:
             raise ValueError("Argument k must be specified if both indices "
                              "and distances arg is None")
+
+    # we require c-contiguous (rowmajor) inputs here
+    _check_input_array(dataset_cai, [np.dtype("float32")])
+    _check_input_array(queries_cai, [np.dtype("float32")],
+                       exp_cols=dataset_cai.shape[1])
 
     n_queries = queries_cai.shape[0]
 

--- a/python/pylibraft/pylibraft/test/test_handle.py
+++ b/python/pylibraft/pylibraft/test/test_handle.py
@@ -19,10 +19,7 @@ import pytest
 from pylibraft.common import DeviceResources, Stream, device_ndarray
 from pylibraft.distance import pairwise_distance
 
-try:
-    import cupy
-except ImportError:
-    pytest.skip(reason="cupy not installed.")
+cupy = pytest.importorskip("cupy")
 
 
 @pytest.mark.parametrize("stream", [cupy.cuda.Stream().ptr, Stream()])


### PR DESCRIPTION
The input validation code wasn't being triggered for the python bfknn api, causing invalid output when passed col-major inputs. Fix.