### PR TITLE
Add identity matrix function

### DIFF
--- a/cpp/include/raft/linalg/norm.cuh
+++ b/cpp/include/raft/linalg/norm.cuh
@@ -121,7 +121,7 @@ void norm(raft::resources const& handle,
 {
   RAFT_EXPECTS(raft::is_row_or_column_major(in), "Input must be contiguous");
 
-  auto constexpr row_major = std::is_same_v<typename decltype(out)::layout_type, raft::row_major>;
+  auto constexpr row_major = std::is_same_v<LayoutPolicy, raft::row_major>;
   auto along_rows          = apply == Apply::ALONG_ROWS;
 
   if (along_rows) {

--- a/cpp/include/raft/matrix/detail/init.cuh
+++ b/cpp/include/raft/matrix/detail/init.cuh
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace raft::matrix::detail {
+
+/**
+ * @brief Create a diagonal identity matrix
+ * @param matrix: matrix of size total_size
+ * @param lda: Leading dimension
+ * @param total_size: number of elements of the matrix
+ */
+template <typename m_t, typename idx_t = int>
+__global__ void createEyeKernel(m_t* matrix, idx_t lda, idx_t total_size)
+{
+  idx_t idx = threadIdx.x + blockDim.x * blockIdx.x;
+  if (idx < total_size) {
+    idx_t i = idx % lda, j = idx / lda;
+    matrix[idx] = m_t(j == i);
+  }
+}
+
+template <typename m_t, typename idx_t = int>
+void createEye(m_t* matrix, idx_t n_rows, idx_t n_cols, bool rowMajor, cudaStream_t stream)
+{
+  dim3 block(64);
+  dim3 grid((n_rows * n_cols + block.x - 1) / block.x);
+  idx_t lda = rowMajor ? n_cols : n_rows;
+  createEyeKernel<<<grid, block, 0, stream>>>(matrix, lda, n_rows * n_cols);
+}
+
+}  // end namespace raft::matrix::detail

--- a/cpp/test/CMakeLists.txt
+++ b/cpp/test/CMakeLists.txt
@@ -238,6 +238,7 @@ if(BUILD_TESTS)
     test/matrix/columnSort.cu
     test/matrix/diagonal.cu
     test/matrix/gather.cu
+    test/matrix/init.cu
     test/matrix/linewise_op.cu
     test/matrix/math.cu
     test/matrix/matrix.cu

--- a/cpp/test/matrix/init.cu
+++ b/cpp/test/matrix/init.cu
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../test_utils.cuh"
+#include <gtest/gtest.h>
+#include <raft/core/device_mdarray.hpp>
+#include <raft/core/resource/cuda_stream.hpp>
+
+#include <raft/matrix/init.cuh>
+#include <raft/util/cudart_utils.hpp>
+
+namespace raft::matrix {
+
+template <typename T>
+struct InitInputs {
+  int n_row;
+  int n_col;
+};
+
+template <typename T>
+::std::ostream& operator<<(::std::ostream& os, const InitInputs<T>& dims)
+{
+  return os;
+}
+
+template <typename T>
+class InitTest : public ::testing::TestWithParam<InitInputs<T>> {
+ public:
+  InitTest()
+    : params(::testing::TestWithParam<InitInputs<T>>::GetParam()),
+      stream(resource::get_cuda_stream(handle))
+  {
+  }
+
+ protected:
+  void test_eye()
+  {
+    ASSERT_TRUE(params.n_row == 4 && params.n_col == 5);
+    auto eyemat_col =
+      raft::make_device_matrix<T, int, raft::col_major>(handle, params.n_row, params.n_col);
+    raft::matrix::eye(handle, eyemat_col.view());
+    std::vector<T> eye_exp{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0};
+    std::vector<T> eye_act(params.n_col * params.n_row);
+    raft::copy(eye_act.data(), eyemat_col.data_handle(), eye_act.size(), stream);
+    resource::sync_stream(handle, stream);
+    ASSERT_TRUE(hostVecMatch(eye_exp, eye_act, raft::Compare<T>()));
+
+    auto eyemat_row =
+      raft::make_device_matrix<T, int, raft::row_major>(handle, params.n_row, params.n_col);
+    raft::matrix::eye(handle, eyemat_row.view());
+    eye_exp = std::vector<T>{1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0};
+    raft::copy(eye_act.data(), eyemat_row.data_handle(), eye_act.size(), stream);
+    resource::sync_stream(handle, stream);
+    ASSERT_TRUE(hostVecMatch(eye_exp, eye_act, raft::Compare<T>()));
+  }
+
+  void SetUp() override { test_eye(); }
+
+ protected:
+  raft::resources handle;
+  cudaStream_t stream;
+
+  InitInputs<T> params;
+};
+
+const std::vector<InitInputs<float>> inputsf1 = {{4, 5}};
+
+const std::vector<InitInputs<double>> inputsd1 = {{4, 5}};
+
+typedef InitTest<float> InitTestF;
+TEST_P(InitTestF, Result) {}
+
+typedef InitTest<double> InitTestD;
+TEST_P(InitTestD, Result) {}
+
+INSTANTIATE_TEST_SUITE_P(InitTests, InitTestF, ::testing::ValuesIn(inputsf1));
+INSTANTIATE_TEST_SUITE_P(InitTests, InitTestD, ::testing::ValuesIn(inputsd1));
+
+}  // namespace raft::matrix


### PR DESCRIPTION
This PR adds the identity matrix function `eye` (will be used in LOBPCG) and fixes a check on the layout for norm function.