### PR TITLE
Assigning Deterministic rank to Dask Workers Based on CUDA_VISIBLE_DEVICES

### DIFF
--- a/python/raft-dask/raft_dask/common/comms.py
+++ b/python/raft-dask/raft_dask/common/comms.py
@@ -14,13 +14,11 @@
 #
 
 import logging
+import os
 import time
 import uuid
 import warnings
-from collections import OrderedDict, Counter
-import os
-
-
+from collections import Counter, OrderedDict
 
 from dask.distributed import default_client
 from dask_cuda.utils import nvml_device_index
@@ -692,10 +690,12 @@ def _func_ucp_ports(client, workers):
 
 def _func_worker_ranks(client):
     """
-    For each worker connected to the client, compute a global rank which is the sum
+    For each worker connected to the client,
+    compute a global rank which is the sum
     of the NVML device index and the worker rank offset.
 
-    Args:
+    Parameters
+    ----------
         client (object): Dask client object.
     """
     ranks = client.run(_get_nvml_device_index)
@@ -706,7 +706,8 @@ def _func_worker_ranks(client):
 
 def _get_nvml_device_index():
     """
-    Return NVML device index based on environment variable 'CUDA_VISIBLE_DEVICES'.
+    Return NVML device index based on environment variable
+    'CUDA_VISIBLE_DEVICES'.
     """
     CUDA_VISIBLE_DEVICES = os.getenv("CUDA_VISIBLE_DEVICES")
     return nvml_device_index(0, CUDA_VISIBLE_DEVICES)
@@ -715,10 +716,12 @@ def _get_nvml_device_index():
 def _get_worker_ip(worker_address):
     """
     Extract the worker IP address from the worker address string.
-    Args:
+
+    Parameters
+    ----------
         worker_address (str): Full address string of the worker
     """
-    return ":".join(worker_address.split(':')[0:2])
+    return ":".join(worker_address.split(":")[0:2])
 
 
 def _get_rank_offset_across_nodes(worker_ips):
@@ -727,7 +730,8 @@ def _get_rank_offset_across_nodes(worker_ips):
     their occurrences in the worker_ips list. The cumulative count serves as
     the rank offset.
 
-    Args:
+    Parameters
+    ----------
         worker_ips (list): List of worker IP addresses.
     """
     worker_count_dict = Counter(worker_ips)
@@ -741,12 +745,15 @@ def _get_rank_offset_across_nodes(worker_ips):
 
 def _append_rank_offset(rank_dict, worker_ip_offset_dict):
     """
-    For each worker address in the rank dictionary, add the corresponding worker offset
-    from the worker_ip_offset_dict to the rank value.
+    For each worker address in the rank dictionary, add the
+    corresponding worker offset from the worker_ip_offset_dict
+    to the rank value.
 
-    Args:
+    Parameters
+    ----------
         rank_dict (dict): Dictionary of worker addresses mapped to their ranks.
-        worker_ip_offset_dict (dict): Dictionary of worker IP addresses mapped to their offsets.
+        worker_ip_offset_dict (dict): Dictionary of worker IP addresses
+                                      mapped to their offsets.
     """
     for worker_ip, worker_offset in worker_ip_offset_dict.items():
         for worker_address in rank_dict:

--- a/python/raft-dask/raft_dask/common/comms.py
+++ b/python/raft-dask/raft_dask/common/comms.py
@@ -21,6 +21,7 @@ from collections import OrderedDict, Counter
 import os
 
 
+
 from dask.distributed import default_client
 from dask_cuda.utils import nvml_device_index
 
@@ -698,7 +699,7 @@ def _func_worker_ranks(client):
         client (object): Dask client object.
     """
     ranks = client.run(_get_nvml_device_index)
-    worker_ips = [_get_worker_ips(worker_address) for worker_address in ranks]
+    worker_ips = [_get_worker_ip(worker_address) for worker_address in ranks]
     worker_ip_offset_dict = _get_rank_offset_across_nodes(worker_ips)
     return _append_rank_offset(ranks, worker_ip_offset_dict)
 
@@ -711,12 +712,11 @@ def _get_nvml_device_index():
     return nvml_device_index(0, CUDA_VISIBLE_DEVICES)
 
 
-def _get_worker_ips(worker_address):
+def _get_worker_ip(worker_address):
     """
     Extract the worker IP address from the worker address string.
-
     Args:
-        worker_address (str): Full address string of the worker without port.
+        worker_address (str): Full address string of the worker
     """
     return ":".join(worker_address.split(':')[0:2])
 

--- a/python/raft-dask/raft_dask/common/comms.py
+++ b/python/raft-dask/raft_dask/common/comms.py
@@ -157,7 +157,7 @@ class Comms:
         Builds a dictionary of { (worker_address, worker_port) :
                                 (worker_rank, worker_port ) }
         """
-        ranks = _func_worker_ranks(workers)
+        ranks = _func_worker_ranks(self.client)
         ports = (
             _func_ucp_ports(self.client, workers) if self.comms_p2p else None
         )


### PR DESCRIPTION
Previously, `dask-raft` non-deterministically maps a process to a GPU. 

In this PR, we assign a deterministic order to each worker based on the CUDA_VISIBLE_DEVICES environment variable.
as NCCL>1.11 expects a process with `rank r` to be mapped to `r % num_gpus_per_node` . 


This  fixes https://github.com/rapidsai/cugraph/issues/3478 
and this raft-test in MNMG setting  https://github.com/rapidsai/raft/blob/c1a7b7c0e33b11d2e7ff3bc5014e3b410a2edd0d/python/raft-dask/raft_dask/test/test_comms.py#L82-L84

CC: @jnke2016


