### PR TITLE
Fixing merge_labels test

### DIFF
--- a/cpp/test/label/merge_labels.cu
+++ b/cpp/test/label/merge_labels.cu
@@ -76,7 +76,8 @@ class MergeLabelsTest : public ::testing::TestWithParam<MergeLabelsInputs<Index_
   MergeLabelsInputs<Index_> params;
   rmm::device_uvector<Index_> labels_a, labels_b, expected, R;
   rmm::device_uvector<bool> mask;
-    rmm::device_scalar<bool> m;
+
+  rmm::device_scalar<bool> m;
 };
 
 using MergeLabelsTestI = MergeLabelsTest<int>;


### PR DESCRIPTION
The offending test was using an `rmm::device_scalar` for some memory that should have been a vector. Not sure how this didn't fail in the past but these changes fix it. 