### PR TITLE
Use exceptions instead of `exit(-1)`

### DIFF
--- a/cpp/include/raft/neighbors/detail/cagra/graph_core.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/graph_core.cuh
@@ -284,12 +284,11 @@ void sort_knn_graph(raft::resources const& res,
     constexpr int numElementsPerThread = 32;
     kernel_sort                        = kern_sort<DataT, IdxT, numElementsPerThread>;
   } else {
-    RAFT_LOG_ERROR(
-      "[ERROR] The degree of input knn graph is too large (%u). "
-      "It must be equal to or small than %d.\n",
+    RAFT_FAIL(
+      "The degree of input knn graph is too large (%u). "
+      "It must be equal to or smaller than %d.",
       input_graph_degree,
       1024);
-    exit(-1);
   }
   const auto block_size          = 256;
   const auto num_warps_per_block = block_size / raft::WarpSize;
@@ -394,12 +393,11 @@ void prune(raft::resources const& res,
     if (input_graph_degree <= MAX_DEGREE) {
       kernel_prune = kern_prune<MAX_DEGREE, IdxT>;
     } else {
-      RAFT_LOG_ERROR(
-        "[ERROR] The degree of input knn graph is too large (%u). "
-        "It must be equal to or small than %d.\n",
+      RAFT_FAIL(
+        "The degree of input knn graph is too large (%u). "
+        "It must be equal to or smaller than %d.",
         input_graph_degree,
         1024);
-      exit(-1);
     }
     const uint32_t batch_size =
       std::min(static_cast<uint32_t>(graph_size), static_cast<uint32_t>(256 * 1024));

--- a/cpp/include/raft/neighbors/detail/cagra/search_plan.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_plan.cuh
@@ -187,11 +187,9 @@ struct search_plan_impl : public search_plan_impl_base {
           hash_bitlen = 0;
           break;
         } else {
-          RAFT_LOG_DEBUG(
-            "[CAGRA Error]"
+          RAFT_FAIL(
             "small-hash cannot be used because the required hash size exceeds the limit (%u)",
             hashmap::get_size(max_bitlen));
-          exit(-1);
         }
       }
       small_hash_bitlen = hash_bitlen;

--- a/cpp/include/raft/neighbors/detail/cagra/topk_for_cagra/topk_core.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/topk_for_cagra/topk_core.cuh
@@ -871,38 +871,36 @@ inline void _cuann_find_topk(uint32_t topK,
   } while (0)
 
   // V: vecLen
-#define SET_KERNEL_V(V, ValT)                                                                \
-  do {                                                                                       \
-    if (topK <= 32) {                                                                        \
-      SET_KERNEL_VKT(V, 32, 32, ValT);                                                       \
-    } else if (topK <= 64) {                                                                 \
-      SET_KERNEL_VKT(V, 64, 32, ValT);                                                       \
-    } else if (topK <= 96) {                                                                 \
-      SET_KERNEL_VKT(V, 96, 32, ValT);                                                       \
-    } else if (topK <= 128) {                                                                \
-      SET_KERNEL_VKT(V, 128, 32, ValT);                                                      \
-    } else if (topK <= 192) {                                                                \
-      SET_KERNEL_VKT(V, 192, 64, ValT);                                                      \
-    } else if (topK <= 256) {                                                                \
-      SET_KERNEL_VKT(V, 256, 64, ValT);                                                      \
-    } else if (topK <= 384) {                                                                \
-      SET_KERNEL_VKT(V, 384, 128, ValT);                                                     \
-    } else if (topK <= 512) {                                                                \
-      SET_KERNEL_VKT(V, 512, 128, ValT);                                                     \
-    } else if (topK <= 768) {                                                                \
-      SET_KERNEL_VKT(V, 768, 256, ValT);                                                     \
-    } else if (topK <= 1024) {                                                               \
-      SET_KERNEL_VKT(V, 1024, 256, ValT);                                                    \
+#define SET_KERNEL_V(V, ValT)                                \
+  do {                                                       \
+    if (topK <= 32) {                                        \
+      SET_KERNEL_VKT(V, 32, 32, ValT);                       \
+    } else if (topK <= 64) {                                 \
+      SET_KERNEL_VKT(V, 64, 32, ValT);                       \
+    } else if (topK <= 96) {                                 \
+      SET_KERNEL_VKT(V, 96, 32, ValT);                       \
+    } else if (topK <= 128) {                                \
+      SET_KERNEL_VKT(V, 128, 32, ValT);                      \
+    } else if (topK <= 192) {                                \
+      SET_KERNEL_VKT(V, 192, 64, ValT);                      \
+    } else if (topK <= 256) {                                \
+      SET_KERNEL_VKT(V, 256, 64, ValT);                      \
+    } else if (topK <= 384) {                                \
+      SET_KERNEL_VKT(V, 384, 128, ValT);                     \
+    } else if (topK <= 512) {                                \
+      SET_KERNEL_VKT(V, 512, 128, ValT);                     \
+    } else if (topK <= 768) {                                \
+      SET_KERNEL_VKT(V, 768, 256, ValT);                     \
+    } else if (topK <= 1024) {                               \
+      SET_KERNEL_VKT(V, 1024, 256, ValT);                    \
     } \
         /* else if (topK <= 1536) { SET_KERNEL_VKT(V, 1536, 512); } */ \
         /* else if (topK <= 2048) { SET_KERNEL_VKT(V, 2048, 512); } */ \
         /* else if (topK <= 3072) { SET_KERNEL_VKT(V, 3072, 1024); } */ \
         /* else if (topK <= 4096) { SET_KERNEL_VKT(V, 4096, 1024); } */ \
-        else {                                                                                      \
-      RAFT_LOG_DEBUG(                                                                        \
-        "[ERROR] (%s, %d) topk must be lower than or equla to 1024.\n", __func__, __LINE__); \
-      exit(-1);                                                                              \
-    }                                                                                        \
+        else {                                                      \
+      RAFT_FAIL("topk must be lower than or equal to 1024"); \
+    }                                                        \
   } while (0)
 
   int _vecLen = _get_vecLen(ldIK, 2);


### PR DESCRIPTION
Rather than exit the process immediately, use the `RAFT_FAIL` macro to throw an exception inside the cagra code when certain conditions aren't met
