### PR TITLE
Fixing ann bench cmake (and docs)

### DIFF
--- a/cpp/bench/ann/CMakeLists.txt
+++ b/cpp/bench/ann/CMakeLists.txt
@@ -18,7 +18,6 @@
 option(RAFT_ANN_BENCH_USE_FAISS_BFKNN "Include faiss' brute-force knn algorithm in benchmark" ON)
 option(RAFT_ANN_BENCH_USE_FAISS_IVF_FLAT "Include faiss' ivf flat algorithm in benchmark" ON)
 option(RAFT_ANN_BENCH_USE_FAISS_IVF_PQ "Include faiss' ivf pq algorithm in benchmark" ON)
-option(RAFT_ANN_BENCH_USE_RAFT_BFKNN "Include raft's brute-force knn algorithm in benchmark" ON)
 option(RAFT_ANN_BENCH_USE_RAFT_IVF_FLAT "Include raft's ivf flat algorithm in benchmark" ON)
 option(RAFT_ANN_BENCH_USE_RAFT_IVF_PQ "Include raft's ivf pq algorithm in benchmark" ON)
 option(RAFT_ANN_BENCH_USE_RAFT_CAGRA "Include raft's CAGRA in benchmark" ON)
@@ -36,8 +35,7 @@ if(RAFT_ANN_BENCH_USE_FAISS_BFKNN
 endif()
 
 set(RAFT_ANN_BENCH_USE_RAFT OFF)
-if(RAFT_ANN_BENCH_USE_RAFT_BFKNN
-   OR RAFT_ANN_BENCH_USE_RAFT_IVF_PQ
+if(RAFT_ANN_BENCH_USE_RAFT_IVF_PQ
    OR RAFT_ANN_BENCH_USE_RAFT_IVF_FLAT
    OR RAFT_ANN_BENCH_USE_RAFT_CAGRA
 )
@@ -135,33 +133,56 @@ if(RAFT_ANN_BENCH_USE_HNSWLIB)
   )
 endif()
 
-if(RAFT_ANN_BENCH_USE_RAFT)
+if(RAFT_ANN_BENCH_USE_RAFT_IVF_PQ)
   ConfigureAnnBench(
     NAME
-    RAFT
+    RAFT_IVF_PQ
     PATH
     bench/ann/src/raft/raft_benchmark.cu
     $<$<BOOL:${RAFT_ANN_BENCH_USE_RAFT_IVF_PQ}>:bench/ann/src/raft/raft_ivf_pq.cu>
+    LINKS
+    raft::compiled
+  )
+endif()
+
+if(RAFT_ANN_BENCH_USE_RAFT_IVF_FLAT)
+  ConfigureAnnBench(
+    NAME
+    RAFT_IVF_FLAT
+    PATH
+    bench/ann/src/raft/raft_benchmark.cu
     $<$<BOOL:${RAFT_ANN_BENCH_USE_RAFT_IVF_FLAT}>:bench/ann/src/raft/raft_ivf_flat.cu>
+    LINKS
+    raft::compiled
+  )
+endif()
+
+if(RAFT_ANN_BENCH_USE_RAFT_CAGRA)
+  ConfigureAnnBench(
+    NAME
+    RAFT_CAGRA
+    PATH
+    bench/ann/src/raft/raft_benchmark.cu
     $<$<BOOL:${RAFT_ANN_BENCH_USE_RAFT_CAGRA}>:bench/ann/src/raft/raft_cagra.cu>
     LINKS
     raft::compiled
   )
-  add_compile_definitions(
-    RAFT $<$<BOOL:${RAFT_ANN_BENCH_USE_RAFT_IVF_PQ}>:RAFT_ANN_BENCH_USE_RAFT_IVF_PQ>
-  )
-  add_compile_definitions(
-    RAFT $<$<BOOL:${RAFT_ANN_BENCH_USE_RAFT_IVF_FLAT}>:RAFT_ANN_BENCH_USE_RAFT_IVF_FLAT>
-  )
-  add_compile_definitions(
-    RAFT $<$<BOOL:${RAFT_ANN_BENCH_USE_RAFT_CAGRA}>:RAFT_ANN_BENCH_USE_RAFT_CAGRA>
-  )
 endif()
 
-if(RAFT_ANN_BENCH_USE_FAISS)
+if(RAFT_ANN_BENCH_USE_FAISS_IVF_FLAT)
   ConfigureAnnBench(
     NAME FAISS_IVF_FLAT PATH bench/ann/src/faiss/faiss_benchmark.cu LINKS faiss::faiss
   )
+endif()
+
+if(RAFT_ANN_BENCH_USE_FAISS_IVF_PQ)
+  ConfigureAnnBench(
+    NAME FAISS_IVF_PQ PATH bench/ann/src/faiss/faiss_benchmark.cu LINKS faiss::faiss
+  )
+endif()
+
+if(RAFT_ANN_BENCH_USE_FAISS_BFKNN)
+  ConfigureAnnBench(NAME FAISS_BFKNN PATH bench/ann/src/faiss/faiss_benchmark.cu LINKS faiss::faiss)
 endif()
 
 if(RAFT_ANN_BENCH_USE_GGNN)

--- a/cpp/bench/ann/src/raft/raft_cagra.cu
+++ b/cpp/bench/ann/src/raft/raft_cagra.cu
@@ -15,10 +15,6 @@
  */
 #include "raft_cagra_wrapper.h"
 
-#ifdef RAFT_COMPILED
-#include <raft/neighbors/specializations.cuh>
-#endif
-
 namespace raft::bench::ann {
 template class RaftCagra<uint8_t, uint32_t>;
 template class RaftCagra<int8_t, uint32_t>;

--- a/docs/source/cuda_ann_benchmarks.md
+++ b/docs/source/cuda_ann_benchmarks.md
@@ -38,7 +38,7 @@ After the needed dependencies are satisfied, the easiest way to compile ANN benc
 
 You can limit the algorithms that are built by providing a semicolon-delimited list of executable names (each algorithm is suffixed with `_ANN_BENCH`):
 ```bash
-./build.sh bench-ann --limit-bench-ann=HNSWLIB_ANN_BENCH;RAFT_IVF_PQ_ANN_BENCH
+./build.sh bench-ann -n --limit-bench-ann=HNSWLIB_ANN_BENCH;RAFT_IVF_PQ_ANN_BENCH
 ```
 
 Available targets to use with `--limit-bench-ann` are:
@@ -47,9 +47,9 @@ Available targets to use with `--limit-bench-ann` are:
 - FAISS_BFKNN_ANN_BENCH
 - GGNN_ANN_BENCH
 - HNSWLIB_ANN_BENCH
+- RAFT_CAGRA_ANN_BENCH
 - RAFT_IVF_PQ_ANN_BENCH
 - RAFT_IVF_FLAT_ANN_BENCH
-- RAFT_BFKNN_ANN_BENCH
 
 By default, the `*_ANN_BENCH` executables program infer the dataset's datatype from the filename's extension. For example, an extension of `fbin` uses a `float` datatype, `f16bin` uses a `float16` datatype, extension of `i8bin` uses `int8_t` datatype, and `u8bin` uses `uint8_t` type. Currently, only `float`, `float16`, int8_t`, and `unit8_t` are supported.
 


### PR DESCRIPTION
I'm removing the build for the raft bfknn ann benchmark target for now since it doesn't seem to be complete anyways. I'm going to create a separate github issue to add it back it. For now, the cmake isn't even producing what the docs are saying it's producing so we need to fix that ASAP. 