### PR TITLE
Enable conservative memory allocations for RAFT IVF-Flat benchmarks.

### DIFF
--- a/cpp/bench/ann/src/raft/raft_ivf_flat_wrapper.h
+++ b/cpp/bench/ann/src/raft/raft_ivf_flat_wrapper.h
@@ -97,6 +97,7 @@ RaftIvfFlatGpu<T, IdxT>::RaftIvfFlatGpu(Metric metric, int dim, const BuildParam
     mr_(rmm::mr::get_current_device_resource(), 1024 * 1024 * 1024ull)
 {
   index_params_.metric = parse_metric_type(metric);
+  index_params_.conservative_memory_allocation = true;
   rmm::mr::set_current_device_resource(&mr_);
   RAFT_CUDA_TRY(cudaGetDevice(&device_));
 }

--- a/cpp/bench/ann/src/raft/raft_ivf_flat_wrapper.h
+++ b/cpp/bench/ann/src/raft/raft_ivf_flat_wrapper.h
@@ -96,7 +96,7 @@ RaftIvfFlatGpu<T, IdxT>::RaftIvfFlatGpu(Metric metric, int dim, const BuildParam
     dimension_(dim),
     mr_(rmm::mr::get_current_device_resource(), 1024 * 1024 * 1024ull)
 {
-  index_params_.metric = parse_metric_type(metric);
+  index_params_.metric                         = parse_metric_type(metric);
   index_params_.conservative_memory_allocation = true;
   rmm::mr::set_current_device_resource(&mr_);
   RAFT_CUDA_TRY(cudaGetDevice(&device_));


### PR DESCRIPTION
In the benchmark we add the whole dataset at once to the index, there is no need to allocate extra space to amortize future extension of the dataset.  We can save memory by enabling the conservative allocation, and this enables running larger benchmarks.