### PR TITLE
IVF-PQ: Add a (faster) direct conversion fp8->half

### DIFF
--- a/cpp/include/raft/neighbors/detail/ivf_pq_fp_8bit.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_pq_fp_8bit.cuh
@@ -71,7 +71,7 @@ struct fp_8bit {
     return *this;
   }
   HDI explicit operator float() const { return fp_8bit2float(*this); }
-  HDI explicit operator half() const { return half(fp_8bit2float(*this)); }
+  HDI explicit operator half() const { return fp_8bit2half(*this); }
 
  private:
   static constexpr float kMin = 1.0f / float(1u << ExpMask);
@@ -101,8 +101,23 @@ struct fp_8bit {
       u &= ~1;  // zero the sign bit
     }
     float r;
-    *reinterpret_cast<uint32_t*>(&r) =
-      ((u << (15u + ExpBits)) + (0x3f800000u | (0x00400000u >> ValBits)) - (ExpMask << 23));
+    constexpr uint32_t kBase32       = (0x3f800000u | (0x00400000u >> ValBits)) - (ExpMask << 23);
+    *reinterpret_cast<uint32_t*>(&r) = kBase32 + (u << (15u + ExpBits));
+    if constexpr (Signed) {  // recover the sign bit
+      if (v.bitstring & 1) { r = -r; }
+    }
+    return r;
+  }
+
+  static HDI auto fp_8bit2half(const fp_8bit<ExpBits, Signed>& v) -> half
+  {
+    uint16_t u = v.bitstring;
+    if constexpr (Signed) {
+      u &= ~1;  // zero the sign bit
+    }
+    half r;
+    constexpr uint16_t kBase16       = (0x7c00u | (0x0200u >> ValBits)) - (ExpMask << 10);
+    *reinterpret_cast<uint16_t*>(&r) = kBase16 + (u << (2u + ExpBits));
     if constexpr (Signed) {  // recover the sign bit
       if (v.bitstring & 1) { r = -r; }
     }


### PR DESCRIPTION
Add a missing direct conversion from the custom ivf-pq `fp_8bit` type to `half`. This conversion is used in a tight ALU-bound loop that computes the distances between the query and the encoded cluster vectors.

This change improves QPS by 0-20% on the `deep-1B` dataset when `internal_distance_dtype = CUDA_R_16F` and `lut_dtype = CUDA_R_8U`. Note, however, on this dataset the <CUDA_R_16F, CUDA_R_8U> combination is often still slower than the <CUDA_R_16F, CUDA_R_16F> combination due to the couple extra ALU instructions. `lut_dtype = CUDA_R_8U` is the most beneficial when there's not enough shared memory for the lookup table, which is not the case for the best-performing parameter combinations on the `deep-1B` dataset.