### PR TITLE
Hotfix: wrong constant in IVF-PQ fp_8bit2half

### DIFF
--- a/cpp/include/raft/neighbors/detail/ivf_pq_fp_8bit.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_pq_fp_8bit.cuh
@@ -116,7 +116,7 @@ struct fp_8bit {
       u &= ~1;  // zero the sign bit
     }
     half r;
-    constexpr uint16_t kBase16       = (0x7c00u | (0x0200u >> ValBits)) - (ExpMask << 10);
+    constexpr uint16_t kBase16       = (0x3c00u | (0x0200u >> ValBits)) - (ExpMask << 10);
     *reinterpret_cast<uint16_t*>(&r) = kBase16 + (u << (2u + ExpBits));
     if constexpr (Signed) {  // recover the sign bit
       if (v.bitstring & 1) { r = -r; }


### PR DESCRIPTION
#1644 introduced a direct conversion from the custom ivf-pq fp8 type to half and a bug alongside. The exponent bias value wrong by one bit. The result is the loss of precision in some datasets.
This hotfix just changes this constant.