### PR TITLE
Add rmm to pylibraft run dependencies, since it is used by Cython.

### DIFF
--- a/conda/recipes/pylibraft/meta.yaml
+++ b/conda/recipes/pylibraft/meta.yaml
@@ -61,6 +61,7 @@ requirements:
     - libraft {{ version }}
     - libraft-headers {{ version }}
     - python x.x
+    - rmm ={{ minor_version }}
 
 tests:
   requirements:


### PR DESCRIPTION
There is a build error in https://github.com/rapidsai/cugraph/pull/3456:
```
$PREFIX/lib/python3.9/site-packages/pylibraft/common/handle.pxd:47:8: 'cuda_stream_view' is not a type identifier
```

pylibraft should have a `run` dependency on `rmm` so that Cython users of pylibraft (pylibcugraph in this case) can `cimport` and use pylibraft Cython at build time.