### PR TITLE
ANN-benchmarks: avoid using the dataset during search when possible

### DIFF
--- a/cpp/bench/ann/src/common/conf.cpp
+++ b/cpp/bench/ann/src/common/conf.cpp
@@ -78,7 +78,7 @@ void Configuration::parse_dataset_(const nlohmann::json& conf)
     } else if (!filename.compare(filename.size() - 5, 5, "i8bin")) {
       dataset_conf_.dtype = "int8";
     } else {
-      log_error("Could not determine data type of the dataset");
+      log_error("Could not determine data type of the dataset %s", filename.c_str());
     }
   }
 }

--- a/cpp/bench/ann/src/raft/raft_ivf_pq_wrapper.h
+++ b/cpp/bench/ann/src/raft/raft_ivf_pq_wrapper.h
@@ -73,7 +73,7 @@ class RaftIvfPQ : public ANN<T> {
     AlgoProperty property;
     property.dataset_memory_type      = MemoryType::Host;
     property.query_memory_type        = MemoryType::Device;
-    property.need_dataset_when_search = true;  // actually it is only used during refinement
+    property.need_dataset_when_search = refine_ratio_ > 1.0;
     return property;
   }
   void save(const std::string& file) const override;


### PR DESCRIPTION
This PR changes the behavior of ANN benchmark `dataset.h` to defer reading the data until it is definitely needed. This allows to avoid copying/reading huge datasets in search benchmarks when the database (index) is already built.