### PR TITLE
Fix CMake CUDA support for pylibraft when raft is found.

### DIFF
--- a/python/pylibraft/CMakeLists.txt
+++ b/python/pylibraft/CMakeLists.txt
@@ -14,9 +14,14 @@
 
 cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 
+include(../../fetch_rapids.cmake)
+
 set(pylibraft_version 23.08.00)
 
-include(../../fetch_rapids.cmake)
+# We always need CUDA for pylibraft because the raft dependency brings in a
+# header-only cuco dependency that enables CUDA unconditionally.
+include(rapids-cuda)
+rapids_cuda_init_architectures(pylibraft)
 
 project(
   pylibraft
@@ -25,7 +30,7 @@ project(
             # language to be enabled here. The test project that is built in scikit-build to verify
             # various linking options for the python library is hardcoded to build with C, so until
             # that is fixed we need to keep C.
-            C CXX
+            C CXX CUDA
 )
 
 option(FIND_RAFT_CPP "Search for existing RAFT C++ installations before defaulting to local files"
@@ -51,15 +56,6 @@ endif()
 include(rapids-cython)
 
 if(NOT raft_FOUND)
-  # TODO: This will not be necessary once we upgrade to CMake 3.22, which will pull in the required
-  # languages for the C++ project even if this project does not require those languages.
-  include(rapids-cuda)
-  rapids_cuda_init_architectures(pylibraft)
-  enable_language(CUDA)
-  # Since pylibraft only enables CUDA optionally we need to manually include the file that
-  # rapids_cuda_init_architectures relies on `project` including.
-  include("${CMAKE_PROJECT_pylibraft_INCLUDE}")
-
   set(BUILD_TESTS OFF)
   set(BUILD_PRIMS_BENCH OFF)
   set(BUILD_ANN_BENCH OFF)


### PR DESCRIPTION
This PR always enables CUDA language support in pylibraft's CMakeLists.txt, to work around an issue I encountered while building.

I am trying to build pylibraft in rapids-compose and saw an error in the CMake support for enabling CUDA.

```
CMake Error at ~/rapids1/compose/etc/conda/cuda_12.0/envs/rapids/share/cmake-3.26/Modules/CMakeDetermineCUDACompiler.cmake:279 (message):
  CMAKE_CUDA_ARCHITECTURES:

    NATIVE

  is not one of the following:

    * a semicolon-separated list of integers, each optionally
      followed by '-real' or '-virtual'
    * a special value: all, all-major, native

Call Stack (most recent call first):
  ~/rapids1/raft/cpp/build/release/raft-config.cmake:171 (enable_language)
  CMakeLists.txt:39 (find_package)
```

This error indicates that `rapids_cuda_init_architectures(pylibraft)` isn't being called, which handles [some preprocessing for this architectures variable so that CMake recognizes the results](https://github.com/rapidsai/rapids-cmake/blob/37c650803d997a85cf522384d42c3275a240e47e/rapids-cmake/cuda/init_architectures.cmake#L95-L97).

It seems like the error shown below comes from [this part of libraft's CMakeLists.txt](https://github.com/rapidsai/raft/blob/06b3aa0919cc9b3a14e656773c1ce7cbe5b7ac73/cpp/CMakeLists.txt#L590-L598) where the CUDA language is being enabled without having first called `rapids_cuda_init_architectures`.

Currently, `rapids_cuda_init_architectures` is called and the CUDA language is [only enabled in pylibraft when `raft_FOUND` is false](https://github.com/rapidsai/raft/blob/06b3aa0919cc9b3a14e656773c1ce7cbe5b7ac73/python/pylibraft/CMakeLists.txt#L53-L61). However, I'm building in an environment where raft _can_ be found. It seems like we always need to enable CUDA support due to a requirement in libraft itself, based on the code I see in [cuML](https://github.com/rapidsai/cuml/blob/a47c73e04676f6a831f498b6ded58dac72b385c8/python/CMakeLists.txt#L21-L24) and [cuGraph](https://github.com/rapidsai/cugraph/blob/803b854fd43be7375d6354ed005001725c7710b4/python/cugraph/CMakeLists.txt#L21-L24). Therefore, I copied a similar change into pylibraft in this PR, and it appears to work.