### PR TITLE
Forward-merge branch-23.08 to branch-23.10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,16 +54,19 @@ jobs:
       sha: ${{ inputs.sha }}
       skip_upload_pkgs: libraft-template
   docs-build:
-    if: github.ref_type == 'branch' && github.event_name == 'push'
+    if: github.ref_type == 'branch'
     needs: python-build
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/custom-job.yaml@branch-23.08
     with:
-      build_type: branch
-      node_type: "gpu-latest-1"
       arch: "amd64"
+      branch: ${{ inputs.branch }}
+      build_type: ${{ inputs.build_type || 'branch' }}
       container_image: "rapidsai/ci:latest"
+      date: ${{ inputs.date }}
+      node_type: "gpu-v100-latest-1"
       run_script: "ci/build_docs.sh"
+      sha: ${{ inputs.sha }}
   wheel-build-pylibraft:
     secrets: inherit
     uses: rapidsai/shared-action-workflows/.github/workflows/wheels-build.yaml@branch-23.08


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.08` that creates a PR to keep `branch-23.10` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.