### PR TITLE
Fix `__repr__` on CAGRA python index

### DIFF
--- a/python/pylibraft/pylibraft/neighbors/cagra/cagra.pyx
+++ b/python/pylibraft/pylibraft/neighbors/cagra/cagra.pyx
@@ -160,11 +160,9 @@ cdef class IndexFloat(Index):
             deref(handle_))
 
     def __repr__(self):
-        m_str = "metric=" + _get_metric_string(self.index.metric())
-        attr_str = [attr + "=" + str(getattr(self, attr))
-                    for attr in ["metric", "dim", "graph_degree"]]
-        attr_str = m_str + attr_str
-        return "Index(type=CAGRA, " + (", ".join(attr_str)) + ")"
+        metric = _get_metric_string(self.index.metric())
+        return f"Index(type=CAGRA, metric={metric}, dim={self.dim}, " \
+            f"graph_degree={self.graph_degree}, dtype=float32)"
 
     @property
     def metric(self):
@@ -200,11 +198,9 @@ cdef class IndexInt8(Index):
             deref(handle_))
 
     def __repr__(self):
-        m_str = "metric=" + _get_metric_string(self.index.metric())
-        attr_str = [attr + "=" + str(getattr(self, attr))
-                    for attr in ["metric", "dim", "graph_degree"]]
-        attr_str = m_str + attr_str
-        return "Index(type=CAGRA, " + (", ".join(attr_str)) + ")"
+        metric = _get_metric_string(self.index.metric())
+        return f"Index(type=CAGRA, metric={metric}, dim={self.dim}, " \
+            f"graph_degree={self.graph_degree}, dtype=int8)"
 
     @property
     def metric(self):
@@ -240,11 +236,9 @@ cdef class IndexUint8(Index):
             deref(handle_))
 
     def __repr__(self):
-        m_str = "metric=" + _get_metric_string(self.index.metric())
-        attr_str = [attr + "=" + str(getattr(self, attr))
-                    for attr in ["metric", "dim", "graph_degree"]]
-        attr_str = m_str + attr_str
-        return "Index(type=CAGRA, " + (", ".join(attr_str)) + ")"
+        metric = _get_metric_string(self.index.metric())
+        return f"Index(type=CAGRA, metric={metric}, dim={self.dim}, " \
+            f"graph_degree={self.graph_degree}, dtype=uint8)"
 
     @property
     def metric(self):

--- a/python/pylibraft/pylibraft/test/test_cagra.py
+++ b/python/pylibraft/pylibraft/test/test_cagra.py
@@ -294,3 +294,13 @@ def test_save_load(dtype):
 
     assert np.all(neighbors == neighbors2)
     assert np.allclose(dist, dist2, rtol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", ["float32", "int8", "uint8"])
+def test_repr(dtype):
+    n_rows, n_cols = 10000, 16
+    dataset = generate_data((n_rows, n_cols), dtype)
+    index = cagra.build(cagra.IndexParams(), dataset)
+
+    assert dtype in repr(index)
+    assert dtype in str(index)


### PR DESCRIPTION
Running `cagra.build(params, dataset)` in a jupyter notebook would throw an exception (`TypeError: can only concatenate str (not "list") to str`). This was happening in the `__repr__` method on the index

Fix an add a basic unittest
