### PR TITLE
Make get_cache_idx a weak symbol with dummy template

### DIFF
--- a/cpp/include/raft/util/cache_util.cuh
+++ b/cpp/include/raft/util/cache_util.cuh
@@ -328,15 +328,16 @@ __global__ void assign_cache_idx(const int* keys,
  * @param [out] is_cached whether the element is cached size[n]
  * @param [in] time iteration counter (used for time stamping)
  */
-__global__ inline void get_cache_idx(int* keys,
-                                     int n,
-                                     int* cached_keys,
-                                     int n_cache_sets,
-                                     int associativity,
-                                     int* cache_time,
-                                     int* cache_idx,
-                                     bool* is_cached,
-                                     int time)
+template <typename = void>
+__global__ void get_cache_idx(int* keys,
+                              int n,
+                              int* cached_keys,
+                              int n_cache_sets,
+                              int associativity,
+                              int* cache_time,
+                              int* cache_idx,
+                              bool* is_cached,
+                              int time)
 {
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   if (tid < n) {


### PR DESCRIPTION
Fixes issue #1511. Make get_cache_idx a weak symbol (to allow linking multiple symbols) without marking it inline (to avoid compilation warnings that are promoted to errors in nvcc 12). 

Related issues:
- #1490 
- #1722 

Related PRs:
- #1732 
- #1492 

