### PR TITLE
[Experiment] Compile libraft.so with separable compilation

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -444,6 +444,7 @@ if(RAFT_COMPILE_LIBRARY)
                CUDA_STANDARD_REQUIRED ON
                POSITION_INDEPENDENT_CODE ON
                INTERFACE_POSITION_INDEPENDENT_CODE ON
+               CUDA_SEPARABLE_COMPILATION ON
   )
 
   target_link_libraries(
@@ -465,8 +466,10 @@ if(RAFT_COMPILE_LIBRARY)
   # RAFT_EXPLICIT_INSTANTIATE_ONLY is set during compilation of libraft.so (due to "PRIVATE")
   target_compile_definitions(raft_lib PRIVATE "RAFT_EXPLICIT_INSTANTIATE_ONLY")
 
-  # ensure CUDA symbols aren't relocated to the middle of the debug build binaries
-  target_link_options(raft_lib PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/fatbin.ld")
+  # ensure CUDA symbols aren't relocated to the middle of the debug build binaries. Disable this for
+  # now. It causes issues in the device linking step.
+
+  # disable: target_link_options(raft_lib PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/fatbin.ld")
 
 endif()
 


### PR DESCRIPTION
With separable compilation, device code is linked together at the end of compilation. This could be advantageous for RAFT, as we have many duplicate kernel templates.

Previously, these duplicate kernel templates would be deduplicated on the host side during linking, but not on device side, causing sometimes up to 80 duplicate kernels to be left in the binary.

With this change, both host and device side weak symbols (e.g., kernel templates) should be deduplicated. Hopefully this has an impact on binary size.