### PR TITLE
Using expanded distance computations in `pylibraft`

### DIFF
--- a/python/pylibraft/pylibraft/distance/pairwise_distance.pyx
+++ b/python/pylibraft/pylibraft/distance/pairwise_distance.pyx
@@ -61,8 +61,8 @@ cdef extern from "raft_runtime/distance/pairwise_distance.hpp" \
 
 DISTANCE_TYPES = {
     "l2": DistanceType.L2SqrtUnexpanded,
-    "sqeuclidean": DistanceType.L2Unexpanded,
-    "euclidean": DistanceType.L2SqrtUnexpanded,
+    "sqeuclidean": DistanceType.L2Expanded,
+    "euclidean": DistanceType.L2SqrtExpanded,
     "l1": DistanceType.L1,
     "cityblock": DistanceType.L1,
     "inner_product": DistanceType.InnerProduct,


### PR DESCRIPTION
We are noticing a perf hit of nearly 2x with the unexpanded distance computations vs the expanded sitances. 