### PR TITLE
[DOC] Fix grouping for ANN in C++ doxygen

### DIFF
--- a/cpp/doxygen/Doxyfile
+++ b/cpp/doxygen/Doxyfile
@@ -893,7 +893,7 @@ EXCLUDE                = ../include/raft/sparse/linalg/symmetrize.hpp \
                          ../include/raft/util/device_utils.cuh \
                          ../include/raft/core/error.hpp \
                          ../include/raft/core/handle.hpp \
-                         ../include/raft/util/integer_utils.hpp
+                         ../include/raft/util/integer_utils.hpp \
                          ../include/raft/util/pow2_utils.cuh \
                          ../include/raft/util/vectorized.cuh \
                          ../include/raft/raft.hpp \

--- a/cpp/include/raft/neighbors/cagra_types.hpp
+++ b/cpp/include/raft/neighbors/cagra_types.hpp
@@ -36,18 +36,22 @@
 #include <raft/core/logger.hpp>
 namespace raft::neighbors::cagra {
 /**
- * @ingroup cagra
+ * @addtogroup cagra
  * @{
  */
 
 struct index_params : ann::index_params {
-  size_t intermediate_graph_degree = 128;  // Degree of input graph for pruning.
-  size_t graph_degree              = 64;   // Degree of output graph.
+  /** Degree of input graph for pruning. */
+  size_t intermediate_graph_degree = 128;
+  /** Degree of output graph. */
+  size_t graph_degree = 64;
 };
 
 enum class search_algo {
-  SINGLE_CTA,  // for large batch
-  MULTI_CTA,   // for small batch
+  /** For large batch sizes. */
+  SINGLE_CTA,
+  /** For small batch sizes. */
+  MULTI_CTA,
   MULTI_KERNEL,
   AUTO
 };
@@ -77,7 +81,7 @@ struct search_params : ann::search_params {
   /** Number of threads used to calculate a single distance. 4, 8, 16, or 32. */
   size_t team_size = 0;
 
-  /*/ Number of graph nodes to select as the starting point for the search in each iteration. aka
+  /** Number of graph nodes to select as the starting point for the search in each iteration. aka
    * search width?*/
   size_t search_width = 1;
   /** Lower limit of search iterations. */
@@ -92,9 +96,9 @@ struct search_params : ann::search_params {
   /** Upper limit of hashmap fill rate. More than 0.1, less than 0.9.*/
   float hashmap_max_fill_rate = 0.5;
 
-  /* Number of iterations of initial random seed node selection. 1 or more. */
+  /** Number of iterations of initial random seed node selection. 1 or more. */
   uint32_t num_random_samplings = 1;
-  // Bit mask used for initial random seed node selection. */
+  /** Bit mask used for initial random seed node selection. */
   uint64_t rand_xor_mask = 0x128394;
 };
 
@@ -122,7 +126,7 @@ struct index : ann::index {
     return metric_;
   }
 
-  // /** Total length of the index (number of vectors). */
+  /** Total length of the index (number of vectors). */
   [[nodiscard]] constexpr inline auto size() const noexcept -> IdxT
   {
     return dataset_view_.extent(0);

--- a/cpp/include/raft/neighbors/ivf_flat_types.hpp
+++ b/cpp/include/raft/neighbors/ivf_flat_types.hpp
@@ -39,7 +39,7 @@
 
 namespace raft::neighbors::ivf_flat {
 /**
- * @ingroup ivf_flat
+ * @addtogroup ivf_flat
  * @{
  */
 

--- a/cpp/include/raft/neighbors/ivf_pq_types.hpp
+++ b/cpp/include/raft/neighbors/ivf_pq_types.hpp
@@ -35,7 +35,7 @@
 namespace raft::neighbors::ivf_pq {
 
 /**
- * @ingroup ivf_pq
+ * @addtogroup ivf_pq
  * @{
  */
 

--- a/docs/source/cpp_api/neighbors_ivf_flat.rst
+++ b/docs/source/cpp_api/neighbors_ivf_flat.rst
@@ -24,3 +24,14 @@ namespace *raft::neighbors::ivf_flat*
     :project: RAFT
     :members:
     :content-only:
+
+Helper Methods
+--------------
+``#include <raft/neighbors/ivf_flat_helpers.cuh>``
+
+namespace *raft::neighbors::ivf_flat::helpers*
+
+.. doxygengroup:: ivf_flat_helpers
+    :project: RAFT
+    :members:
+    :content-only:

--- a/docs/source/cpp_api/neighbors_ivf_pq.rst
+++ b/docs/source/cpp_api/neighbors_ivf_pq.rst
@@ -35,3 +35,14 @@ namespace *raft::neighbors*
     :project: RAFT
     :members:
     :content-only:
+
+Helper Methods
+--------------
+``#include <raft/neighbors/ivf_pq_helpers.cuh>``
+
+namespace *raft::neighbors::ivf_pq::helpers*
+
+.. doxygengroup:: ivf_pq_helpers
+    :project: RAFT
+    :members:
+    :content-only:


### PR DESCRIPTION
Fix #1771.
The `@ingroup` directive could only be applied to the member that followed the directive.
`@addtogroup` works better with the markers `@{` and `@}`