### PR TITLE
[BUG] Fix search parameter check in CAGRA

### DIFF
--- a/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
@@ -175,6 +175,16 @@ struct search : public search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
     topk_workspace.resize(topk_workspace_size, resource::get_cuda_stream(res));
   }
 
+  virtual void check(const uint32_t topk)
+  {
+    RAFT_EXPECTS(num_cta_per_query * 32 >= topk,
+                 "`num_cta_per_query` (%u) * 32 must be equal to or greater than "
+                 "`topk` (%u) when 'search_mode' is \"multi-cta\". "
+                 "(`num_cta_per_query`=max(`search_width`, `itopk_size`/32))",
+                 num_cta_per_query,
+                 topk);
+  }
+
   ~search() {}
 
   void operator()(raft::resources const& res,

--- a/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_multi_cta.cuh
@@ -175,7 +175,7 @@ struct search : public search_plan_impl<DATA_T, INDEX_T, DISTANCE_T> {
     topk_workspace.resize(topk_workspace_size, resource::get_cuda_stream(res));
   }
 
-  virtual void check(const uint32_t topk)
+  void check(const uint32_t topk) override
   {
     RAFT_EXPECTS(num_cta_per_query * 32 >= topk,
                  "`num_cta_per_query` (%u) * 32 must be equal to or greater than "

--- a/cpp/include/raft/neighbors/detail/cagra/search_plan.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_plan.cuh
@@ -250,17 +250,10 @@ struct search_plan_impl : public search_plan_impl_base {
     }
   }
 
-  void check(uint32_t topk)
+  virtual void check(const uint32_t topk)
   {
+    // For multi-CTA and multi kernel
     RAFT_EXPECTS(topk <= itopk_size, "topk must be smaller than itopk_size = %lu", itopk_size);
-    if (algo == search_algo::MULTI_CTA) {
-      uint32_t mc_num_cta_per_query = max(search_width, itopk_size / 32);
-      RAFT_EXPECTS(mc_num_cta_per_query * 32 >= topk,
-                   "`mc_num_cta_per_query` (%u) * 32 must be equal to or greater than "
-                   "`topk` /%u) when 'search_mode' is \"multi-cta\"",
-                   mc_num_cta_per_query,
-                   topk);
-    }
   }
 
   inline void check_params()

--- a/cpp/include/raft/neighbors/detail/cagra/search_plan.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_plan.cuh
@@ -252,7 +252,7 @@ struct search_plan_impl : public search_plan_impl_base {
 
   virtual void check(const uint32_t topk)
   {
-    // For multi-CTA and multi kernel
+    // For single-CTA and multi kernel
     RAFT_EXPECTS(topk <= itopk_size, "topk must be smaller than itopk_size = %lu", itopk_size);
   }
 


### PR DESCRIPTION
An error occurs when using CAGRA multi-CTA implementation with topk>32. This PR fixes the bug.