### PR TITLE
Fix the CAGRA paper citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ If citing the single-linkage agglomerative clustering APIs, please consider the 
       archivePrefix={arXiv},
       primaryClass={cs.LG}
 }
+```
 
 If citing CAGRA, please consider the following bibtex:
 ```bibtex
@@ -404,3 +405,4 @@ If citing CAGRA, please consider the following bibtex:
       archivePrefix={arXiv},
       primaryClass={cs.DS}
 }
+```


### PR DESCRIPTION
This PR fixes the citation info for the CAGRA paper in README.md.
I forgot to write closing '```' in the citation part in README.md

rel: https://github.com/rapidsai/raft/pull/1787