### PR TITLE
neighbors::refine_host: check the dataset bounds

### DIFF
--- a/cpp/bench/ann/src/raft/raft_ivf_pq_wrapper.h
+++ b/cpp/bench/ann/src/raft/raft_ivf_pq_wrapper.h
@@ -192,7 +192,7 @@ void RaftIvfPQ<T, IdxT>::search(const T* queries,
                  resource::get_cuda_stream(handle_));
 
       auto dataset_v = raft::make_host_matrix_view<const T, IdxT>(
-        dataset_.data_handle(), batch_size, index_->dim());
+        dataset_.data_handle(), dataset_.extent(0), dataset_.extent(1));
 
       raft::runtime::neighbors::refine(handle_,
                                        dataset_v,


### PR DESCRIPTION
Check the dataset bounds when computing the distances.
The invalid indexes are expected to come from IVF-PQ due to filtering or insufficient size of the input.

This manifested itself in occasional segfaults in ann-benchmarks when refinement is enabled.