### PR TITLE
matrix::select_k: extra tests and benchmarks

### DIFF
--- a/cpp/internal/raft_internal/matrix/select_k.cuh
+++ b/cpp/internal/raft_internal/matrix/select_k.cuh
@@ -33,6 +33,7 @@ struct params {
   bool use_index_input       = true;
   bool use_same_leading_bits = false;
   bool use_memory_pool       = true;
+  double frac_infinities     = 0.0;
 };
 
 inline auto operator<<(std::ostream& os, const params& ss) -> std::ostream&
@@ -41,8 +42,10 @@ inline auto operator<<(std::ostream& os, const params& ss) -> std::ostream&
   os << ", len: " << ss.len;
   os << ", k: " << ss.k;
   os << (ss.select_min ? ", asc" : ", dsc");
-  os << (ss.use_index_input ? "" : ", no-input-index");
-  os << (ss.use_same_leading_bits ? ", same-leading-bits}" : "}");
+  if (!ss.use_index_input) { os << ", no-input-index"; }
+  if (ss.use_same_leading_bits) { os << ", same-leading-bits"; }
+  if (ss.frac_infinities > 0) { os << ", infs: " << ss.frac_infinities; }
+  os << "}";
   return os;
 }
 

--- a/cpp/test/matrix/select_k.cu
+++ b/cpp/test/matrix/select_k.cu
@@ -70,6 +70,28 @@ auto inputs_random_largek = testing::Values(select::params{100, 100000, 1000, tr
                                             select::params{100, 100000, 2048, false},
                                             select::params{100, 100000, 1237, true});
 
+auto inputs_random_many_infs =
+  testing::Values(select::params{10, 100000, 1, true, false, false, true, 0.9},
+                  select::params{10, 100000, 16, true, false, false, true, 0.9},
+                  select::params{10, 100000, 64, true, false, false, true, 0.9},
+                  select::params{10, 100000, 128, true, false, false, true, 0.9},
+                  select::params{10, 100000, 256, true, false, false, true, 0.9},
+                  select::params{1000, 10000, 1, true, false, false, true, 0.9},
+                  select::params{1000, 10000, 16, true, false, false, true, 0.9},
+                  select::params{1000, 10000, 64, true, false, false, true, 0.9},
+                  select::params{1000, 10000, 128, true, false, false, true, 0.9},
+                  select::params{1000, 10000, 256, true, false, false, true, 0.9},
+                  select::params{10, 100000, 1, true, false, false, true, 0.999},
+                  select::params{10, 100000, 16, true, false, false, true, 0.999},
+                  select::params{10, 100000, 64, true, false, false, true, 0.999},
+                  select::params{10, 100000, 128, true, false, false, true, 0.999},
+                  select::params{10, 100000, 256, true, false, false, true, 0.999},
+                  select::params{1000, 10000, 1, true, false, false, true, 0.999},
+                  select::params{1000, 10000, 16, true, false, false, true, 0.999},
+                  select::params{1000, 10000, 64, true, false, false, true, 0.999},
+                  select::params{1000, 10000, 128, true, false, false, true, 0.999},
+                  select::params{1000, 10000, 256, true, false, false, true, 0.999});
+
 using ReferencedRandomFloatInt =
   SelectK<float, uint32_t, with_ref<select::Algo::kPublicApi>::params_random>;
 TEST_P(ReferencedRandomFloatInt, Run) { run(); }  // NOLINT
@@ -111,4 +133,16 @@ INSTANTIATE_TEST_CASE_P(                                 // NOLINT
                                    select::Algo::kRadix8bits,
                                    select::Algo::kRadix11bits,
                                    select::Algo::kRadix11bitsExtraPass)));
+
+using ReferencedRandomFloatIntkWarpsortAsGT =
+  SelectK<float, uint32_t, with_ref<select::Algo::kWarpImmediate>::params_random>;
+TEST_P(ReferencedRandomFloatIntkWarpsortAsGT, Run) { run(); }  // NOLINT
+INSTANTIATE_TEST_CASE_P(                                       // NOLINT
+  SelectK,
+  ReferencedRandomFloatIntkWarpsortAsGT,
+  testing::Combine(inputs_random_many_infs,
+                   testing::Values(select::Algo::kRadix8bits,
+                                   select::Algo::kRadix11bits,
+                                   select::Algo::kRadix11bitsExtraPass)));
+
 }  // namespace raft::matrix

--- a/cpp/test/matrix/select_k.cuh
+++ b/cpp/test/matrix/select_k.cuh
@@ -49,14 +49,16 @@ auto gen_simple_ids(uint32_t batch_size, uint32_t len) -> std::vector<IdxT>
 template <typename KeyT, typename IdxT>
 struct io_simple {
  public:
-  bool not_supported = false;
+  bool not_supported               = false;
+  std::optional<select::Algo> algo = std::nullopt;
 
   io_simple(const select::params& spec,
             const std::vector<KeyT>& in_dists,
+            const std::optional<std::vector<IdxT>>& in_ids,
             const std::vector<KeyT>& out_dists,
             const std::vector<IdxT>& out_ids)
     : in_dists_(in_dists),
-      in_ids_(gen_simple_ids<IdxT>(spec.batch_size, spec.len)),
+      in_ids_(in_ids.value_or(gen_simple_ids<IdxT>(spec.batch_size, spec.len))),
       out_dists_(out_dists),
       out_ids_(out_ids)
   {
@@ -78,12 +80,14 @@ template <typename KeyT, typename IdxT>
 struct io_computed {
  public:
   bool not_supported = false;
+  select::Algo algo;
 
   io_computed(const select::params& spec,
               const select::Algo& algo,
               const std::vector<KeyT>& in_dists,
               const std::optional<std::vector<IdxT>>& in_ids = std::nullopt)
-    : in_dists_(in_dists),
+    : algo(algo),
+      in_dists_(in_dists),
       in_ids_(in_ids.value_or(gen_simple_ids<IdxT>(spec.batch_size, spec.len))),
       out_dists_(spec.batch_size * spec.k),
       out_ids_(spec.batch_size * spec.k)
@@ -223,32 +227,62 @@ struct SelectK  // NOLINT
     if (ref.not_supported || res.not_supported) { GTEST_SKIP(); }
     ASSERT_TRUE(hostVecMatch(ref.get_out_dists(), res.get_out_dists(), Compare<KeyT>()));
 
-    // If the dists (keys) are the same, different corresponding ids may end up in the selection due
-    // to non-deterministic nature of some implementations.
-    auto& in_ids     = ref.get_in_ids();
-    auto& in_dists   = ref.get_in_dists();
-    auto compare_ids = [&in_ids, &in_dists](const IdxT& i, const IdxT& j) {
+    // If the dists (keys) are the same, different corresponding ids may end up in the selection
+    // due to non-deterministic nature of some implementations.
+    auto compare_ids = [this](const IdxT& i, const IdxT& j) {
       if (i == j) return true;
+      auto& in_ids   = ref.get_in_ids();
+      auto& in_dists = ref.get_in_dists();
       auto ix_i = static_cast<int64_t>(std::find(in_ids.begin(), in_ids.end(), i) - in_ids.begin());
       auto ix_j = static_cast<int64_t>(std::find(in_ids.begin(), in_ids.end(), j) - in_ids.begin());
-      if (static_cast<size_t>(ix_i) >= in_ids.size() || static_cast<size_t>(ix_j) >= in_ids.size())
-        return false;
+      auto forgive_i = forgive_algo(ref.algo, i);
+      auto forgive_j = forgive_algo(res.algo, j);
+      // Some algorithms return invalid indices in special cases.
+      // This can be considered as TODO for us to fix.
+      if (static_cast<size_t>(ix_i) >= in_ids.size()) return forgive_i;
+      if (static_cast<size_t>(ix_j) >= in_ids.size()) return forgive_j;
       auto dist_i = in_dists[ix_i];
       auto dist_j = in_dists[ix_j];
       if (dist_i == dist_j) return true;
+      const auto bound = spec.select_min ? raft::upper_bound<KeyT>() : raft::lower_bound<KeyT>();
+      if (forgive_i && dist_i == bound) return true;
+      if (forgive_j && dist_j == bound) return true;
+      // Otherwise really fail
       std::cout << "ERROR: ref[" << ix_i << "] = " << dist_i << " != "
                 << "res[" << ix_j << "] = " << dist_j << std::endl;
       return false;
     };
     ASSERT_TRUE(hostVecMatch(ref.get_out_ids(), res.get_out_ids(), compare_ids));
   }
+
+  auto forgive_algo(const std::optional<select::Algo>& algo, IdxT ix) const -> bool
+  {
+    if (!algo.has_value()) { return false; }
+    switch (algo.value()) {
+      // not sure which algo this is.
+      case select::Algo::kPublicApi: return true;
+      // warp-sort-based algos currently return zero index for inf distances.
+      case select::Algo::kWarpAuto:
+      case select::Algo::kWarpImmediate:
+      case select::Algo::kWarpFiltered:
+      case select::Algo::kWarpDistributed:
+      case select::Algo::kWarpDistributedShm: return ix == 0;
+      // FAISS version returns a special invalid value:
+      case select::Algo::kFaissBlockSelect: return ix == std::numeric_limits<IdxT>::max();
+      // Do not forgive by default
+      default: return false;
+    }
+  }
 };
 
 template <typename KeyT, typename IdxT>
 struct params_simple {
-  using io_t = io_simple<KeyT, IdxT>;
-  using input_t =
-    std::tuple<select::params, std::vector<KeyT>, std::vector<KeyT>, std::vector<IdxT>>;
+  using io_t     = io_simple<KeyT, IdxT>;
+  using input_t  = std::tuple<select::params,
+                             std::vector<KeyT>,
+                             std::optional<std::vector<IdxT>>,
+                             std::vector<KeyT>,
+                             std::vector<IdxT>>;
   using params_t = std::tuple<input_t, select::Algo>;
 
   static auto read(params_t ps) -> Params<io_t>
@@ -259,15 +293,17 @@ struct params_simple {
       std::get<0>(ins),
       algo,
       io_simple<KeyT, IdxT>(
-        std::get<0>(ins), std::get<1>(ins), std::get<2>(ins), std::get<3>(ins)));
+        std::get<0>(ins), std::get<1>(ins), std::get<2>(ins), std::get<3>(ins), std::get<4>(ins)));
   }
 };
 
+auto inf_f           = std::numeric_limits<float>::max();
 auto inputs_simple_f = testing::Values(
   params_simple<float, uint32_t>::input_t(
     {5, 5, 5, true, true},
     {5.0, 4.0, 3.0, 2.0, 1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 2.0, 3.0, 5.0,
      1.0, 4.0, 5.0, 3.0, 2.0, 4.0, 1.0, 1.0, 3.0, 2.0, 5.0, 4.0},
+    std::nullopt,
     {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0,
      4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
     {4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 3, 0, 1, 4, 2, 4, 2, 1, 3, 0, 0, 2, 1, 4, 3}),
@@ -275,12 +311,14 @@ auto inputs_simple_f = testing::Values(
     {5, 5, 3, true, true},
     {5.0, 4.0, 3.0, 2.0, 1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 2.0, 3.0, 5.0,
      1.0, 4.0, 5.0, 3.0, 2.0, 4.0, 1.0, 1.0, 3.0, 2.0, 5.0, 4.0},
+    std::nullopt,
     {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0},
     {4, 3, 2, 0, 1, 2, 3, 0, 1, 4, 2, 1, 0, 2, 1}),
   params_simple<float, uint32_t>::input_t(
     {5, 5, 5, true, false},
     {5.0, 4.0, 3.0, 2.0, 1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 2.0, 3.0, 5.0,
      1.0, 4.0, 5.0, 3.0, 2.0, 4.0, 1.0, 1.0, 3.0, 2.0, 5.0, 4.0},
+    std::nullopt,
     {1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0,
      4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0},
     {4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 3, 0, 1, 4, 2, 4, 2, 1, 3, 0, 0, 2, 1, 4, 3}),
@@ -288,20 +326,31 @@ auto inputs_simple_f = testing::Values(
     {5, 5, 3, true, false},
     {5.0, 4.0, 3.0, 2.0, 1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 2.0, 3.0, 5.0,
      1.0, 4.0, 5.0, 3.0, 2.0, 4.0, 1.0, 1.0, 3.0, 2.0, 5.0, 4.0},
+    std::nullopt,
     {1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0},
     {4, 3, 2, 0, 1, 2, 3, 0, 1, 4, 2, 1, 0, 2, 1}),
   params_simple<float, uint32_t>::input_t(
     {5, 7, 3, true, true},
     {5.0, 4.0, 3.0, 2.0, 1.3, 7.5, 19.0, 9.0, 2.0, 3.0, 3.0, 5.0, 6.0, 4.0, 2.0, 3.0, 5.0, 1.0,
      4.0, 1.0, 1.0, 5.0, 7.0, 2.5, 4.0,  7.0, 8.0, 8.0, 1.0, 3.0, 2.0, 5.0, 4.0, 1.1, 1.2},
+    std::nullopt,
     {1.3, 2.0, 3.0, 2.0, 3.0, 3.0, 1.0, 1.0, 1.0, 2.5, 4.0, 5.0, 1.0, 1.1, 1.2},
     {4, 3, 2, 1, 2, 3, 3, 5, 6, 2, 3, 0, 0, 5, 6}),
-  params_simple<float, uint32_t>::input_t(
-    {1, 7, 3, true, true}, {2.0, 3.0, 5.0, 1.0, 4.0, 1.0, 1.0}, {1.0, 1.0, 1.0}, {3, 5, 6}),
-  params_simple<float, uint32_t>::input_t(
-    {1, 7, 3, false, false}, {2.0, 3.0, 5.0, 1.0, 4.0, 1.0, 1.0}, {5.0, 4.0, 3.0}, {2, 4, 1}),
-  params_simple<float, uint32_t>::input_t(
-    {1, 7, 3, false, true}, {2.0, 3.0, 5.0, 9.0, 4.0, 9.0, 9.0}, {9.0, 9.0, 9.0}, {3, 5, 6}),
+  params_simple<float, uint32_t>::input_t({1, 7, 3, true, true},
+                                          {2.0, 3.0, 5.0, 1.0, 4.0, 1.0, 1.0},
+                                          std::nullopt,
+                                          {1.0, 1.0, 1.0},
+                                          {3, 5, 6}),
+  params_simple<float, uint32_t>::input_t({1, 7, 3, false, false},
+                                          {2.0, 3.0, 5.0, 1.0, 4.0, 1.0, 1.0},
+                                          std::nullopt,
+                                          {5.0, 4.0, 3.0},
+                                          {2, 4, 1}),
+  params_simple<float, uint32_t>::input_t({1, 7, 3, false, true},
+                                          {2.0, 3.0, 5.0, 9.0, 4.0, 9.0, 9.0},
+                                          std::nullopt,
+                                          {9.0, 9.0, 9.0},
+                                          {3, 5, 6}),
   params_simple<float, uint32_t>::input_t(
     {1, 130, 5, false, true},
     {19, 1, 0, 1, 0, 1,  0,  1,  0,  1,  0,  1,  0,  1,  0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
@@ -309,6 +358,7 @@ auto inputs_simple_f = testing::Values(
      0,  1, 0, 1, 0, 1,  0,  1,  1,  2,  1,  2,  1,  2,  1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
      1,  2, 1, 2, 1, 2,  1,  2,  1,  2,  1,  2,  1,  2,  1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 3, 4,
      5,  6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 4, 4, 2, 3, 2, 3, 2, 3, 2, 3, 2, 20},
+    std::nullopt,
     {20, 19, 18, 17, 16},
     {129, 0, 117, 116, 115}),
   params_simple<float, uint32_t>::input_t(
@@ -318,8 +368,20 @@ auto inputs_simple_f = testing::Values(
      0,  1, 0, 1, 0, 1,  0,  1,  1,  2,  1,  2,  1,  2,  1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
      1,  2, 1, 2, 1, 2,  1,  2,  1,  2,  1,  2,  1,  2,  1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 3, 4,
      5,  6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 4, 4, 2, 3, 2, 3, 2, 3, 2, 3, 2, 20},
+    std::nullopt,
     {20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6},
-    {129, 0, 117, 116, 115, 114, 113, 112, 111, 110, 109, 108, 107, 106, 105}));
+    {129, 0, 117, 116, 115, 114, 113, 112, 111, 110, 109, 108, 107, 106, 105}),
+  params_simple<float, uint32_t>::input_t(
+    select::params{1, 32, 31, true, true},
+    {0,  1,  2,  3,  inf_f, inf_f, 6,  7,  8,  9,  10, 11, 12, 13, 14, 15,
+     16, 17, 18, 19, 20,    21,    22, 23, 24, 25, 26, 27, 28, 29, 30, 31},
+    std::optional{std::vector<uint32_t>{31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21,
+                                        20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+                                        9,  8,  7,  6,  75, 74, 3,  2,  1,  0}},
+    {0,  1,  2,  3,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,   17,
+     18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, inf_f},
+    {31, 30, 29, 28, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14,
+     13, 12, 11, 10, 9,  8,  7,  6,  75, 74, 3,  2,  1,  0,  27}));
 
 using SimpleFloatInt = SelectK<float, uint32_t, params_simple>;
 TEST_P(SimpleFloatInt, Run) { run(); }  // NOLINT
@@ -334,6 +396,12 @@ INSTANTIATE_TEST_CASE_P(                // NOLINT
                                    select::Algo::kWarpImmediate,
                                    select::Algo::kWarpFiltered,
                                    select::Algo::kWarpDistributed)));
+
+template <typename KeyT>
+struct replace_with_mask {
+  KeyT replacement;
+  constexpr auto inline operator()(KeyT x, uint8_t mask) -> KeyT { return mask ? replacement : x; }
+};
 
 template <select::Algo RefAlgo>
 struct with_ref {
@@ -354,6 +422,19 @@ struct with_ref {
         rmm::device_uvector<KeyT> dists_d(spec.len * spec.batch_size, s);
         raft::random::RngState r(42);
         normal(handle, r, dists_d.data(), dists_d.size(), KeyT(10.0), KeyT(100.0));
+
+        if (spec.frac_infinities > 0.0) {
+          rmm::device_uvector<uint8_t> mask_buf(dists_d.size(), s);
+          auto mask = make_device_vector_view<uint8_t, size_t>(mask_buf.data(), mask_buf.size());
+          raft::random::bernoulli(handle, r, mask, spec.frac_infinities);
+          KeyT bound = spec.select_min ? raft::upper_bound<KeyT>() : raft::lower_bound<KeyT>();
+          auto mask_in =
+            make_device_vector_view<const uint8_t, size_t>(mask_buf.data(), mask_buf.size());
+          auto dists_in  = make_device_vector_view<const KeyT>(dists_d.data(), dists_d.size());
+          auto dists_out = make_device_vector_view<KeyT>(dists_d.data(), dists_d.size());
+          raft::linalg::map(handle, dists_out, replace_with_mask<KeyT>{bound}, dists_in, mask_in);
+        }
+
         update_host(dists.data(), dists_d.data(), dists_d.size(), s);
         s.synchronize();
       }


### PR DESCRIPTION
Add a few extra test and benchmark cases; in particular:
  1. Allow specifying non-trivial input indices
  2. Allow filling the input data with infinities to see how algorithms perform in edge cases

These tests are borrowed from the controversial workaround https://github.com/rapidsai/raft/pull/1742