### PR TITLE
Make RMM a run dependency of the raft-ann-bench conda package

### DIFF
--- a/conda/recipes/raft-ann-bench/meta.yaml
+++ b/conda/recipes/raft-ann-bench/meta.yaml
@@ -78,8 +78,6 @@ requirements:
     - h5py {{ h5py_version }}
     - benchmark
     - matplotlib
-    # rmm is needed to determine if package is gpu-enabled
-    - rmm ={{ minor_version }}
     - python
     - pandas
     - pyyaml
@@ -100,6 +98,8 @@ requirements:
     - h5py {{ h5py_version }}
     - benchmark
     - glog {{ glog_version }}
+    # rmm is needed to determine if package is gpu-enabled
+    - rmm ={{ minor_version }}
     - matplotlib
     - python
     - pandas

--- a/conda/recipes/raft-ann-bench/meta.yaml
+++ b/conda/recipes/raft-ann-bench/meta.yaml
@@ -81,6 +81,8 @@ requirements:
     - python
     - pandas
     - pyyaml
+    # rmm is needed to determine if package is gpu-enabled
+    - rmm ={{ minor_version }}
 
   run:
     - python
@@ -98,12 +100,12 @@ requirements:
     - h5py {{ h5py_version }}
     - benchmark
     - glog {{ glog_version }}
-    # rmm is needed to determine if package is gpu-enabled
-    - rmm ={{ minor_version }}
     - matplotlib
     - python
     - pandas
     - pyyaml
+    # rmm is needed to determine if package is gpu-enabled
+    - rmm ={{ minor_version }}
 about:
   home: https://rapids.ai/
   license: Apache-2.0


### PR DESCRIPTION
RMM was listed as a `host` dependency but not `run`, made it so that installing `raft-ann-bench` does not automatically install `RMM` for end users. 