### PR TITLE
Fix ann-bench conda recipe to use faiss only in x86 for 11.8 in recipe

### DIFF
--- a/conda/recipes/raft-ann-bench/meta.yaml
+++ b/conda/recipes/raft-ann-bench/meta.yaml
@@ -72,8 +72,8 @@ requirements:
     - nlohmann_json {{ nlohmann_json_version }}
     # Temporarily ignore faiss benchmarks on CUDA 12 because packages do not exist yet
     {% if cuda_major == "11" %}
-    - faiss-proc=*=cuda
-    - libfaiss {{ faiss_version }}
+    - faiss-proc=*=cuda # [linux64]
+    - libfaiss {{ faiss_version }} # [linux64]
     {% endif %}
     - h5py {{ h5py_version }}
     - benchmark
@@ -94,8 +94,8 @@ requirements:
     - glog {{ glog_version }}
     # Temporarily ignore faiss benchmarks on CUDA 12 because packages do not exist yet
     {% if cuda_major == "11" %}
-    - faiss-proc=*=cuda
-    - libfaiss {{ faiss_version }}
+    - faiss-proc=*=cuda # [linux64]
+    - libfaiss {{ faiss_version }} # [linux64]
     {% endif %}
     - h5py {{ h5py_version }}
     - benchmark


### PR DESCRIPTION
Even though conda packages are being produced for AARCH64 with CUDA 11.8, their dependency is broken due to there not being packages available in the rapidsai-nightly channel. Doesn't affect CUDA 12.0 packages or release packages since the latter ones use the rapidsai channel. 