### PR TITLE
Update rapids-cmake functions to non-deprecated signatures

### DIFF
--- a/cpp/cmake/thirdparty/get_cutlass.cmake
+++ b/cpp/cmake/thirdparty/get_cutlass.cmake
@@ -70,10 +70,12 @@ function(find_and_configure_cutlass)
   # Tell cmake where it can find the generated NvidiaCutlass-config.cmake we wrote.
   include("${rapids-cmake-dir}/export/find_package_root.cmake")
   rapids_export_find_package_root(
-          INSTALL NvidiaCutlass [=[${CMAKE_CURRENT_LIST_DIR}/../]=] raft-exports
+          INSTALL NvidiaCutlass [=[${CMAKE_CURRENT_LIST_DIR}/../]=]
+          EXPORT_SET raft-exports
   )
   rapids_export_find_package_root(
-          BUILD NvidiaCutlass [=[${CMAKE_CURRENT_LIST_DIR}]=] raft-exports
+          BUILD NvidiaCutlass [=[${CMAKE_CURRENT_LIST_DIR}]=]
+          EXPORT_SET raft-exports
   )
 endfunction()
 

--- a/cpp/cmake/thirdparty/get_faiss.cmake
+++ b/cpp/cmake/thirdparty/get_faiss.cmake
@@ -63,7 +63,8 @@ function(find_and_configure_faiss)
 
     # Tell cmake where it can find the generated faiss-config.cmake we wrote.
     include("${rapids-cmake-dir}/export/find_package_root.cmake")
-    rapids_export_find_package_root(BUILD faiss [=[${CMAKE_CURRENT_LIST_DIR}]=] raft-ann-bench-exports)
+    rapids_export_find_package_root(BUILD faiss [=[${CMAKE_CURRENT_LIST_DIR}]=]
+                                    EXPORT_SET raft-ann-bench-exports)
 endfunction()
 
 if(NOT RAFT_FAISS_GIT_TAG)


### PR DESCRIPTION
Update to use non deprecated signatures for `rapids_export` functions