### PR TITLE
[TEST] Build with libcudacxx 2.1.0.

### DIFF
--- a/cpp/template/cmake/thirdparty/fetch_rapids.cmake
+++ b/cpp/template/cmake/thirdparty/fetch_rapids.cmake
@@ -14,6 +14,8 @@
 # Use this variable to update RAPIDS and RAFT versions
 set(RAPIDS_VERSION "23.12")
 
+set(rapids-cmake-repo bdice/rapids-cmake)
+set(rapids-cmake-branch libcudacxx-2.1.0)
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RAFT_RAPIDS.cmake)
     file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${RAPIDS_VERSION}/RAPIDS.cmake
             ${CMAKE_CURRENT_BINARY_DIR}/RAFT_RAPIDS.cmake)

--- a/fetch_rapids.cmake
+++ b/fetch_rapids.cmake
@@ -11,6 +11,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 # =============================================================================
+set(rapids-cmake-repo bdice/rapids-cmake)
+set(rapids-cmake-branch libcudacxx-2.1.0)
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/RAFT_RAPIDS.cmake)
   file(DOWNLOAD https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.12/RAPIDS.cmake
        ${CMAKE_CURRENT_BINARY_DIR}/RAFT_RAPIDS.cmake


### PR DESCRIPTION
This PR tests a rapids-cmake branch with libcudacxx updated to 2.1.0. **Do not merge this PR.** The changes will be merged upstream in rapids-cmake after all libraries pass CI.
