### PR TITLE
Remove unnecessary dataset path check in ANN bench

### DIFF
--- a/python/raft-ann-bench/src/raft-ann-bench/run/__main__.py
+++ b/python/raft-ann-bench/src/raft-ann-bench/run/__main__.py
@@ -243,8 +243,6 @@ def main():
     dataset_path = args.dataset_path
     if not os.path.exists(conf_filepath):
         raise FileNotFoundError(conf_filename)
-    if not os.path.exists(os.path.join(args.dataset_path, dataset_name)):
-        raise FileNotFoundError(os.path.join(args.dataset_path, dataset_name))
 
     with open(conf_filepath, "r") as f:
         conf_file = json.load(f)


### PR DESCRIPTION
This PR removes a superfluous path check. This check is not necessary, since the actual dataset path is computed differently (see `legacy_result_folder`), using the path field in the config file. 

The existing test ties the dataset file name to the config file name, therefore imposes an unnecessary restriction. In practice I often have multiple json configs using the same dataset dir.