### PR TITLE
Remove dynamic entry-points from raft-ann-bench

### DIFF
--- a/python/raft-ann-bench/pyproject.toml
+++ b/python/raft-ann-bench/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
-dynamic = ["entry-points"]
 
 [project.urls]
 Homepage = "https://github.com/rapidsai/raft"


### PR DESCRIPTION
Building raft-ann-bench can throw a

```
  distutils.errors.DistutilsOptionError: No configuration found for dynamic 'entry-points'.
  Some dynamic fields need to be specified via `tool.setuptools.dynamic`
  others must be specified via the equivalent attribute in `setup.py`.
```

error sometimes depending on distutils version.

This is becase we were specifying dynamic=entry-points, but not including the relevant `tool.setuptools.dynamic` section in pyproject.toml. Remove this to allow building
