### PR TITLE
Add constraints to `hnswlib` in `raft-bench-ann`

### DIFF
--- a/python/raft-ann-bench/src/raft-ann-bench/constraints/__init__.py
+++ b/python/raft-ann-bench/src/raft-ann-bench/constraints/__init__.py
@@ -38,3 +38,7 @@ def raft_ivf_pq_search_constraints(params, build_params, k, batch_size):
 def raft_cagra_search_constraints(params, build_params, k, batch_size):
     if "itopk" in params:
         return params["itopk"] >= k
+
+def hnswlib_search_constraints(params, build_params, k, batch_size):
+    if "ef" in params:
+        return params["ef"] >= k

--- a/python/raft-ann-bench/src/raft-ann-bench/constraints/__init__.py
+++ b/python/raft-ann-bench/src/raft-ann-bench/constraints/__init__.py
@@ -39,6 +39,7 @@ def raft_cagra_search_constraints(params, build_params, k, batch_size):
     if "itopk" in params:
         return params["itopk"] >= k
 
+
 def hnswlib_search_constraints(params, build_params, k, batch_size):
     if "ef" in params:
         return params["ef"] >= k

--- a/python/raft-ann-bench/src/raft-ann-bench/run/conf/algos/hnswlib.yaml
+++ b/python/raft-ann-bench/src/raft-ann-bench/run/conf/algos/hnswlib.yaml
@@ -1,4 +1,6 @@
 name: hnswlib
+constraints:
+  search: raft-ann-bench.constraints.hnswlib_search_constraints
 groups:
   base:
     build:


### PR DESCRIPTION
This PR adds a constraint for `hnswlib` search params such that `ef >= k`