### PR TITLE
Remove unused header

### DIFF
--- a/cpp/include/raft/core/detail/copy.hpp
+++ b/cpp/include/raft/core/detail/copy.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 #include <cstdio>
-#include <execution>
 #include <raft/core/cuda_support.hpp>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/error.hpp>


### PR DESCRIPTION
Including the <execution> header can cause compilation issues under certain conditions when an implicit dependency on TBB is brought in. This header was unused anyway, so it has been removed.