### PR TITLE
Adjusting end-to-end start time so it doesn't include stream creation time

### DIFF
--- a/cpp/bench/ann/src/common/benchmark.hpp
+++ b/cpp/bench/ann/src/common/benchmark.hpp
@@ -287,8 +287,8 @@ void bench_search(::benchmark::State& state,
   std::shared_ptr<buf<std::size_t>> neighbors =
     std::make_shared<buf<std::size_t>>(algo_property.query_memory_type, k * query_set_size);
 
-  auto start = std::chrono::high_resolution_clock::now();
   cuda_timer gpu_timer;
+  auto start = std::chrono::high_resolution_clock::now();
   {
     nvtx_case nvtx{state.name()};
 

--- a/python/raft-ann-bench/src/raft-ann-bench/data_export/__main__.py
+++ b/python/raft-ann-bench/src/raft-ann-bench/data_export/__main__.py
@@ -114,7 +114,7 @@ def convert_json_to_csv_search(dataset, dataset_path):
                 write["build cpu_time"] = None
                 write["build GPU"] = None
 
-                for col_idx in range(5, len(build_df.columns)):
+                for col_idx in range(6, len(build_df.columns)):
                     col_name = build_df.columns[col_idx]
                     write[col_name] = None
 

--- a/python/raft-ann-bench/src/raft-ann-bench/run/conf/datasets.yaml
+++ b/python/raft-ann-bench/src/raft-ann-bench/run/conf/datasets.yaml
@@ -107,7 +107,7 @@
 
 - name: wiki_all_1M
   dims: 768
-  base_file: wiki_all_1M/base.1MM.fbin
+  base_file: wiki_all_1M/base.1M.fbin
   query_file: wiki_all_1M/queries.fbin
   groundtruth_neighbors_file: wiki_all_1M/groundtruth.1M.neighbors.ibin
   distance: euclidean


### PR DESCRIPTION
We can safely assume all cuda streams have been created before we run benchmark experiments. With the sensitivity to latencies for smaller batch sizes, this has an impact on overall throughput. 