### PR TITLE
Remove static checks for serialization size

### DIFF
--- a/cpp/include/raft/neighbors/detail/cagra/cagra_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/cagra_serialize.cuh
@@ -31,19 +31,7 @@
 
 namespace raft::neighbors::cagra::detail {
 
-constexpr int serialization_version = 4;
-
-// NB: we wrap this check in a struct, so that the updated RealSize is easy to see in the error
-// message.
-template <size_t RealSize, size_t ExpectedSize>
-struct check_index_layout {
-  static_assert(RealSize == ExpectedSize,
-                "The size of the index struct has changed since the last update; "
-                "paste in the new size and consider updating the serialization logic");
-};
-
-constexpr size_t expected_size = 216;
-template struct check_index_layout<sizeof(index<double, std::uint64_t>), expected_size>;
+constexpr int serialization_version = 3;
 
 /**
  * Save the index to file.

--- a/cpp/include/raft/neighbors/detail/cagra/cagra_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/cagra_serialize.cuh
@@ -31,7 +31,7 @@
 
 namespace raft::neighbors::cagra::detail {
 
-constexpr int serialization_version = 3;
+constexpr int serialization_version = 4;
 
 // NB: we wrap this check in a struct, so that the updated RealSize is easy to see in the error
 // message.
@@ -42,7 +42,7 @@ struct check_index_layout {
                 "paste in the new size and consider updating the serialization logic");
 };
 
-constexpr size_t expected_size = 200;
+constexpr size_t expected_size = 216;
 template struct check_index_layout<sizeof(index<double, std::uint64_t>), expected_size>;
 
 /**

--- a/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
@@ -29,12 +29,12 @@
 
 namespace raft::neighbors::ivf_flat::detail {
 
-// Serialization version 3
+// Serialization version
 // No backward compatibility yet; that is, can't add additional fields without breaking
 // backward compatibility.
 // TODO(hcho3) Implement next-gen serializer for IVF that allows for expansion in a backward
 //             compatible fashion.
-constexpr int serialization_version = 4;
+constexpr int serialization_version = 5;
 
 // NB: we wrap this check in a struct, so that the updated RealSize is easy to see in the error
 // message.

--- a/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
@@ -45,7 +45,7 @@ struct check_index_layout {
                 "paste in the new size and consider updating the serialization logic");
 };
 
-template struct check_index_layout<sizeof(index<double, std::uint64_t>), 328>;
+template struct check_index_layout<sizeof(index<double, std::uint64_t>), 368>;
 
 /**
  * Save the index to file.

--- a/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
@@ -34,18 +34,7 @@ namespace raft::neighbors::ivf_flat::detail {
 // backward compatibility.
 // TODO(hcho3) Implement next-gen serializer for IVF that allows for expansion in a backward
 //             compatible fashion.
-constexpr int serialization_version = 5;
-
-// NB: we wrap this check in a struct, so that the updated RealSize is easy to see in the error
-// message.
-template <size_t RealSize, size_t ExpectedSize>
-struct check_index_layout {
-  static_assert(RealSize == ExpectedSize,
-                "The size of the index struct has changed since the last update; "
-                "paste in the new size and consider updating the serialization logic");
-};
-
-template struct check_index_layout<sizeof(index<double, std::uint64_t>), 368>;
+constexpr int serialization_version = 4;
 
 /**
  * Save the index to file.

--- a/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
@@ -36,19 +36,7 @@ namespace raft::neighbors::ivf_pq::detail {
 // backward compatibility.
 // TODO(hcho3) Implement next-gen serializer for IVF that allows for expansion in a backward
 //             compatible fashion.
-constexpr int kSerializationVersion = 4;
-
-// NB: we wrap this check in a struct, so that the updated RealSize is easy to see in the error
-// message.
-template <size_t RealSize, size_t ExpectedSize>
-struct check_index_layout {
-  static_assert(RealSize == ExpectedSize,
-                "The size of the index struct has changed since the last update; "
-                "paste in the new size and consider updating the serialization logic");
-};
-
-// TODO: Recompute this and come back to it.
-template struct check_index_layout<sizeof(index<std::uint64_t>), 536>;
+constexpr int kSerializationVersion = 3;
 
 /**
  * Write the index to an output stream

--- a/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
@@ -48,7 +48,7 @@ struct check_index_layout {
 };
 
 // TODO: Recompute this and come back to it.
-template struct check_index_layout<sizeof(index<std::uint64_t>), 480>;
+template struct check_index_layout<sizeof(index<std::uint64_t>), 536>;
 
 /**
  * Write the index to an output stream

--- a/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
@@ -36,7 +36,7 @@ namespace raft::neighbors::ivf_pq::detail {
 // backward compatibility.
 // TODO(hcho3) Implement next-gen serializer for IVF that allows for expansion in a backward
 //             compatible fashion.
-constexpr int kSerializationVersion = 3;
+constexpr int kSerializationVersion = 4;
 
 // NB: we wrap this check in a struct, so that the updated RealSize is easy to see in the error
 // message.


### PR DESCRIPTION
This PR removes static checks for serialization size. Upstream changes like https://github.com/rapidsai/rmm/pull/1370 have altered these sizes and break RAFT CI. An alternative approach to verifying serialization will be developed.