### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/cpp/include/raft/neighbors/detail/cagra/cagra_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/cagra_serialize.cuh
@@ -33,18 +33,6 @@ namespace raft::neighbors::cagra::detail {
 
 constexpr int serialization_version = 3;
 
-// NB: we wrap this check in a struct, so that the updated RealSize is easy to see in the error
-// message.
-template <size_t RealSize, size_t ExpectedSize>
-struct check_index_layout {
-  static_assert(RealSize == ExpectedSize,
-                "The size of the index struct has changed since the last update; "
-                "paste in the new size and consider updating the serialization logic");
-};
-
-constexpr size_t expected_size = 200;
-template struct check_index_layout<sizeof(index<double, std::uint64_t>), expected_size>;
-
 /**
  * Save the index to file.
  *

--- a/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_flat_serialize.cuh
@@ -29,23 +29,12 @@
 
 namespace raft::neighbors::ivf_flat::detail {
 
-// Serialization version 3
+// Serialization version
 // No backward compatibility yet; that is, can't add additional fields without breaking
 // backward compatibility.
 // TODO(hcho3) Implement next-gen serializer for IVF that allows for expansion in a backward
 //             compatible fashion.
 constexpr int serialization_version = 4;
-
-// NB: we wrap this check in a struct, so that the updated RealSize is easy to see in the error
-// message.
-template <size_t RealSize, size_t ExpectedSize>
-struct check_index_layout {
-  static_assert(RealSize == ExpectedSize,
-                "The size of the index struct has changed since the last update; "
-                "paste in the new size and consider updating the serialization logic");
-};
-
-template struct check_index_layout<sizeof(index<double, std::uint64_t>), 328>;
 
 /**
  * Save the index to file.

--- a/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_pq_serialize.cuh
@@ -38,18 +38,6 @@ namespace raft::neighbors::ivf_pq::detail {
 //             compatible fashion.
 constexpr int kSerializationVersion = 3;
 
-// NB: we wrap this check in a struct, so that the updated RealSize is easy to see in the error
-// message.
-template <size_t RealSize, size_t ExpectedSize>
-struct check_index_layout {
-  static_assert(RealSize == ExpectedSize,
-                "The size of the index struct has changed since the last update; "
-                "paste in the new size and consider updating the serialization logic");
-};
-
-// TODO: Recompute this and come back to it.
-template struct check_index_layout<sizeof(index<std::uint64_t>), 480>;
-
 /**
  * Write the index to an output stream
  *


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.