### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/conda/recipes/libraft/conda_build_config.yaml
+++ b/conda/recipes/libraft/conda_build_config.yaml
@@ -71,3 +71,9 @@ cuda11_cuda_profiler_api_host_version:
 
 cuda11_cuda_profiler_api_run_version:
   - ">=11.4.240,<12"
+
+spdlog_version:
+  - ">=1.11.0,<1.12"
+
+fmt_version:
+  - ">=9.1.0,<10"

--- a/conda/recipes/libraft/meta.yaml
+++ b/conda/recipes/libraft/meta.yaml
@@ -63,12 +63,16 @@ outputs:
         {% endif %}
         - cuda-version ={{ cuda_version }}
         - librmm ={{ minor_version }}
+        - spdlog {{ spdlog_version }}
+        - fmt {{ fmt_version }}
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         {% if cuda_major == "11" %}
         - cudatoolkit
         {% endif %}
         - librmm ={{ minor_version }}
+        - spdlog {{ spdlog_version }}
+        - fmt {{ fmt_version }}
     about:
       home: https://rapids.ai/
       license: Apache-2.0

--- a/conda/recipes/raft-ann-bench-cpu/conda_build_config.yaml
+++ b/conda/recipes/raft-ann-bench-cpu/conda_build_config.yaml
@@ -18,3 +18,9 @@ h5py_version:
 
 nlohmann_json_version:
   - ">=3.11.2"
+
+spdlog_version:
+  - ">=1.11.0,<1.12"
+
+fmt_version:
+  - ">=9.1.0,<10"

--- a/conda/recipes/raft-ann-bench-cpu/meta.yaml
+++ b/conda/recipes/raft-ann-bench-cpu/meta.yaml
@@ -48,6 +48,8 @@ requirements:
     - glog {{ glog_version }}
     - matplotlib
     - nlohmann_json {{ nlohmann_json_version }}
+    - spdlog {{ spdlog_version }}
+    - fmt {{ fmt_version }}
     - python
     - pyyaml
     - pandas


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.