### PR TITLE
Fix ucx-py version pinning in dependencies.yaml.

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -69,6 +69,8 @@ for FILE in dependencies.yaml conda/environments/*.yaml; do
     sed_runner "/-.* ${DEP}==/ s/==.*/==${NEXT_SHORT_TAG_PEP440}\.*/g" ${FILE};
   done
   sed_runner "/-.* ucx-py==/ s/==.*/==${NEXT_UCX_PY_SHORT_TAG_PEP440}\.*/g" ${FILE};
+  sed_runner "/-.* ucx-py-cu11==/ s/==.*/==${NEXT_UCX_PY_SHORT_TAG_PEP440}\.*/g" ${FILE};
+  sed_runner "/-.* ucx-py-cu12==/ s/==.*/==${NEXT_UCX_PY_SHORT_TAG_PEP440}\.*/g" ${FILE};
 done
 for FILE in python/*/pyproject.toml; do
   for DEP in "${DEPENDENCIES[@]}"; do

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -461,13 +461,13 @@ dependencies:
           - matrix: {cuda: "12.2"}
             packages: &run_raft_dask_packages_cu12
               - &pylibraft_cu12 pylibraft-cu12==24.2.*
-              - &ucx_py_cu12 ucx-py-cu12==0.35.*
+              - &ucx_py_cu12 ucx-py-cu12==0.36.*
           - {matrix: {cuda: "12.1"}, packages: *run_raft_dask_packages_cu12}
           - {matrix: {cuda: "12.0"}, packages: *run_raft_dask_packages_cu12}
           - matrix: {cuda: "11.8"}
             packages: &run_raft_dask_packages_cu11
               - &pylibraft_cu11 pylibraft-cu11==24.2.*
-              - &ucx_py_cu11 ucx-py-cu11==0.35.*
+              - &ucx_py_cu11 ucx-py-cu11==0.36.*
           - {matrix: {cuda: "11.5"}, packages: *run_raft_dask_packages_cu11}
           - {matrix: {cuda: "11.4"}, packages: *run_raft_dask_packages_cu11}
           - {matrix: {cuda: "11.2"}, packages: *run_raft_dask_packages_cu11}


### PR DESCRIPTION
There is an entry missing from the `update-version.sh` for ucx-py wheels, so ucx-py is pinned at 0.35 instead of 0.36. This was probably overlooked when adding devcontainers. This updates to the correct versions and fixes the version update script.