### PR TITLE
Consistently use addtogroup as opposed to ingroup

### DIFF
--- a/cpp/include/raft/core/cublas_macros.hpp
+++ b/cpp/include/raft/core/cublas_macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 namespace raft {
 
 /**
- * @ingroup error_handling
+ * @addtogroup error_handling
  * @{
  */
 
@@ -76,7 +76,7 @@ inline const char* cublas_error_to_string(cublasStatus_t err)
 #undef _CUBLAS_ERR_TO_STR
 
 /**
- * @ingroup assertion
+ * @addtogroup assertion
  * @{
  */
 

--- a/cpp/include/raft/core/cusolver_macros.hpp
+++ b/cpp/include/raft/core/cusolver_macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
 namespace raft {
 
 /**
- * @ingroup error_handling
+ * @addtogroup error_handling
  * @{
  */
 
@@ -75,7 +75,7 @@ inline const char* cusolver_error_to_string(cusolverStatus_t err)
 #undef _CUSOLVER_ERR_TO_STR
 
 /**
- * @ingroup assertion
+ * @addtogroup assertion
  * @{
  */
 

--- a/cpp/include/raft/core/cusparse_macros.hpp
+++ b/cpp/include/raft/core/cusparse_macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@
 namespace raft {
 
 /**
- * @ingroup error_handling
+ * @addtogroup error_handling
  * @{
  */
 
@@ -82,7 +82,7 @@ inline const char* cusparse_error_to_string(cusparseStatus_t err)
 #undef _CUSPARSE_ERR_TO_STR
 
 /**
- * @ingroup assertion
+ * @addtogroup assertion
  * @{
  */
 
@@ -122,7 +122,7 @@ inline const char* cusparse_error_to_string(cusparseStatus_t err)
 #endif
 
 /**
- * @ingroup assertion
+ * @addtogroup assertion
  * @{
  */
 //@todo: use logger here once logging is enabled

--- a/cpp/include/raft/core/host_mdarray.hpp
+++ b/cpp/include/raft/core/host_mdarray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ auto make_host_mdarray(extents<IndexType, Extents...> exts)
 }
 
 /**
- * @ingroup host_mdarray_factories
+ * @addtogroup host_mdarray_factories
  * @brief Create a 2-dim c-contiguous host mdarray.
  * @tparam ElementType the data type of the matrix elements
  * @tparam IndexType the index type of the extents
@@ -167,7 +167,7 @@ auto make_host_matrix(IndexType n_rows, IndexType n_cols)
 }
 
 /**
- * @ingroup host_mdarray_factories
+ * @addtogroup host_mdarray_factories
  * @brief Create a host scalar from v.
  *
  * @tparam ElementType the data type of the scalar element
@@ -217,7 +217,7 @@ auto make_host_scalar(ElementType const& v)
 }
 
 /**
- * @ingroup host_mdarray_factories
+ * @addtogroup host_mdarray_factories
  * @brief Create a 1-dim host mdarray.
  * @tparam ElementType the data type of the vector elements
  * @tparam IndexType the index type of the extents

--- a/cpp/include/raft/linalg/add.cuh
+++ b/cpp/include/raft/linalg/add.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ namespace raft {
 namespace linalg {
 
 /**
- * @ingroup arithmetic
+ * @addtogroup arithmetic
  * @brief Elementwise scalar add operation on the input buffer
  *
  * @tparam InT     input data-type. Also the data-type upon which the math ops

--- a/cpp/include/raft/neighbors/ball_cover-inl.cuh
+++ b/cpp/include/raft/neighbors/ball_cover-inl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,7 +147,7 @@ void all_knn_query(raft::resources const& handle,
 }
 
 /**
- * @ingroup random_ball_cover
+ * @addtogroup random_ball_cover
  * @{
  */
 
@@ -296,7 +296,7 @@ void knn_query(raft::resources const& handle,
 }
 
 /**
- * @ingroup random_ball_cover
+ * @addtogroup random_ball_cover
  * @{
  */
 

--- a/cpp/include/raft/neighbors/ball_cover_types.hpp
+++ b/cpp/include/raft/neighbors/ball_cover_types.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2021-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 namespace raft::neighbors::ball_cover {
 
 /**
- * @ingroup random_ball_cover
+ * @addtogroup random_ball_cover
  * @{
  */
 

--- a/cpp/include/raft/neighbors/ivf_flat-inl.cuh
+++ b/cpp/include/raft/neighbors/ivf_flat-inl.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,7 +237,7 @@ auto extend(raft::resources const& handle,
 }
 
 /**
- * @ingroup ivf_flat
+ * @addtogroup ivf_flat
  * @{
  */
 
@@ -342,7 +342,7 @@ void extend(raft::resources const& handle,
 }
 
 /**
- * @ingroup ivf_flat
+ * @addtogroup ivf_flat
  * @{
  */
 
@@ -536,7 +536,7 @@ void search(raft::resources const& handle,
 }
 
 /**
- * @ingroup ivf_flat
+ * @addtogroup ivf_flat
  * @{
  */
 

--- a/cpp/include/raft/neighbors/nn_descent_types.hpp
+++ b/cpp/include/raft/neighbors/nn_descent_types.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 
 namespace raft::neighbors::experimental::nn_descent {
 /**
- * @ingroup nn_descent
+ * @addtogroup nn_descent
  * @{
  */
 

--- a/cpp/include/raft/random/rng.cuh
+++ b/cpp/include/raft/random/rng.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ void uniform(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate uniformly distributed integers in the given range
  *
  * @tparam OutputValueType Integral type; value type of the output vector
@@ -138,7 +138,7 @@ void uniformInt(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate normal distributed numbers
  *   with a given mean and standard deviation
  *
@@ -186,7 +186,7 @@ void normal(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate normal distributed integers
  *
  * @tparam OutputValueType Integral type; value type of the output vector
@@ -240,7 +240,7 @@ void normalInt(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate normal distributed table according to the given set of
  * means and scalar standard deviations.
  *
@@ -339,7 +339,7 @@ void normalTable(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Fill a vector with the given value
  *
  * @tparam OutputValueType Value type of the output vector
@@ -378,7 +378,7 @@ void fill(
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate bernoulli distributed boolean array
  *
  * @tparam OutputValueType Type of each element of the output vector;
@@ -422,7 +422,7 @@ void bernoulli(
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate bernoulli distributed array and applies scale
  *
  * @tparam OutputValueType Data type in which to compute the probabilities
@@ -469,7 +469,7 @@ void scaled_bernoulli(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate Gumbel distributed random numbers
  *
  * @tparam OutputValueType data type of output random number
@@ -518,7 +518,7 @@ void gumbel(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate lognormal distributed numbers
  *
  * @tparam OutputValueType data type of output random number
@@ -565,7 +565,7 @@ void lognormal(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate logistic distributed random numbers
  *
  * @tparam OutputValueType data type of output random number
@@ -612,7 +612,7 @@ void logistic(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate exponentially distributed random numbers
  *
  * @tparam OutputValueType data type of output random number
@@ -652,7 +652,7 @@ void exponential(
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate rayleigh distributed random numbers
  *
  * @tparam OutputValueType data type of output random number
@@ -691,7 +691,7 @@ void rayleigh(
   detail::rayleigh(rng_state, ptr, len, sigma, resource::get_cuda_stream(handle));
 }
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate laplace distributed random numbers
  *
  * @tparam OutputValueType data type of output random number
@@ -738,7 +738,7 @@ void laplace(raft::resources const& handle,
 }
 
 /**
- * @ingroup univariate_random_sampling
+ * @addtogroup univariate_random_sampling
  * @brief Generate random integers, where the probability of i is weights[i]/sum(weights)
  *
  * Usage example:

--- a/cpp/include/raft/stats/stats_types.hpp
+++ b/cpp/include/raft/stats/stats_types.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 namespace raft::stats {
 
 /**
- * @ingroup stats_histogram
+ * @addtogroup stats_histogram
  * @{
  */
 
@@ -62,7 +62,7 @@ enum HistType {
 /** @} */
 
 /**
- * @ingroup stats_information_criterion
+ * @addtogroup stats_information_criterion
  * @{
  */
 


### PR DESCRIPTION
Following up on PR #1782 and for compatibility with changes from doxygen 1.9 to 1.10, consistently use the `@addtogroup` directive in place of the `@ingroup` directive
