### PR TITLE
Remove extraneous host pinnings from libraft-headers-only.

### DIFF
--- a/conda/recipes/libraft/meta.yaml
+++ b/conda/recipes/libraft/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 # Usage:
 #   conda build . -c conda-forge -c nvidia -c rapidsai
@@ -62,9 +62,6 @@ outputs:
         - cuda-cudart-dev
         {% endif %}
         - cuda-version ={{ cuda_version }}
-        - librmm ={{ minor_version }}
-        - spdlog {{ spdlog_version }}
-        - fmt {{ fmt_version }}
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         {% if cuda_major == "11" %}


### PR DESCRIPTION
We have `run` pinnings for librmm, spdlog, and fmt, so we don't need to list them in `host` as well. Currently, we are allowing `fmt>=10.1.1,<11` in `host`, which is pulling a newer version 10.2.1 and adding a run-export that is `fmt >=10.2.1,<11.0a0`, which disallows `fmt 10.1.1` contrary to our intentions.