### PR TITLE
Forward-merge branch-24.02 to branch-24.04

### DIFF
--- a/conda/recipes/libraft/meta.yaml
+++ b/conda/recipes/libraft/meta.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
 
 # Usage:
 #   conda build . -c conda-forge -c nvidia -c rapidsai
@@ -62,9 +62,6 @@ outputs:
         - cuda-cudart-dev
         {% endif %}
         - cuda-version ={{ cuda_version }}
-        - librmm ={{ minor_version }}
-        - spdlog {{ spdlog_version }}
-        - fmt {{ fmt_version }}
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         {% if cuda_major == "11" %}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-24.02` that creates a PR to keep `branch-24.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.