### PR TITLE
Conditionally include `hnsw` wrapper source in CMake

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -433,7 +433,7 @@ if(RAFT_COMPILE_LIBRARY)
     src/raft_runtime/neighbors/cagra_search.cu
     src/raft_runtime/neighbors/cagra_serialize.cu
     src/raft_runtime/neighbors/eps_neighborhood.cu
-    src/raft_runtime/neighbors/hnsw.cpp
+    $<$<BOOL:${BUILD_CAGRA_HNSWLIB}>:src/raft_runtime/neighbors/hnsw.cpp>
     src/raft_runtime/neighbors/ivf_flat_build.cu
     src/raft_runtime/neighbors/ivf_flat_search.cu
     src/raft_runtime/neighbors/ivf_flat_serialize.cu


### PR DESCRIPTION
This PR conditionally includes `hnsw` sources, to prevent build errors like those seen in cuGraph after #2022 was merged. See also: https://github.com/rapidsai/cugraph/pull/4121, https://github.com/rapidsai/cugraph/pull/4122