### PR TITLE
[BUG] fix row/col-major selection for strided layouts

### DIFF
--- a/cpp/include/raft/core/device_mdspan.hpp
+++ b/cpp/include/raft/core/device_mdspan.hpp
@@ -207,8 +207,12 @@ auto constexpr make_device_strided_matrix_view(ElementType* ptr,
                                                IndexType stride)
 {
   constexpr auto is_row_major = std::is_same_v<LayoutPolicy, layout_c_contiguous>;
-  IndexType stride0           = is_row_major ? (stride > 0 ? stride : n_cols) : 1;
-  IndexType stride1           = is_row_major ? 1 : (stride > 0 ? stride : n_rows);
+  constexpr auto is_col_major = std::is_same_v<LayoutPolicy, layout_f_contiguous>;
+
+  assert(is_row_major || is_col_major);
+
+  IndexType stride0 = is_row_major ? (stride > 0 ? stride : n_cols) : 1;
+  IndexType stride1 = is_row_major ? 1 : (stride > 0 ? stride : n_rows);
 
   assert(is_row_major ? stride0 >= n_cols : stride1 >= n_rows);
   matrix_extent<IndexType> extents{n_rows, n_cols};

--- a/cpp/include/raft/sparse/linalg/spmm.hpp
+++ b/cpp/include/raft/sparse/linalg/spmm.hpp
@@ -61,11 +61,10 @@ void spmm(raft::resources const& handle,
   bool is_row_major = detail::is_row_major(y, z);
 
   auto z_tmp_view =
-    is_row_major
-      ? raft::make_device_strided_matrix_view<ValueType, IndexType, layout_c_contiguous>(
-          z.data_handle(), z.extent(0), z.extent(1), is_row_major ? z.stride(0) : z.stride(1))
-      : raft::make_device_strided_matrix_view<ValueType, IndexType, layout_f_contiguous>(
-          z.data_handle(), z.extent(0), z.extent(1), is_row_major ? z.stride(0) : z.stride(1));
+    is_row_major ? raft::make_device_strided_matrix_view<ValueType, IndexType, layout_c_contiguous>(
+                     z.data_handle(), z.extent(0), z.extent(1), z.stride(0))
+                 : raft::make_device_strided_matrix_view<ValueType, IndexType, layout_f_contiguous>(
+                     z.data_handle(), z.extent(0), z.extent(1), z.stride(1));
 
   auto descr_x = detail::create_descriptor(x);
   auto descr_y = detail::create_descriptor(y);

--- a/cpp/include/raft/sparse/linalg/spmm.hpp
+++ b/cpp/include/raft/sparse/linalg/spmm.hpp
@@ -60,8 +60,12 @@ void spmm(raft::resources const& handle,
 {
   bool is_row_major = detail::is_row_major(y, z);
 
-  auto z_tmp_view = raft::make_device_strided_matrix_view<ValueType, IndexType, LayoutPolicyZ>(
-    z.data_handle(), z.extent(0), z.extent(1), is_row_major ? z.stride(0) : z.stride(1));
+  auto z_tmp_view =
+    is_row_major
+      ? raft::make_device_strided_matrix_view<ValueType, IndexType, layout_c_contiguous>(
+          z.data_handle(), z.extent(0), z.extent(1), is_row_major ? z.stride(0) : z.stride(1))
+      : raft::make_device_strided_matrix_view<ValueType, IndexType, layout_f_contiguous>(
+          z.data_handle(), z.extent(0), z.extent(1), is_row_major ? z.stride(0) : z.stride(1));
 
   auto descr_x = detail::create_descriptor(x);
   auto descr_y = detail::create_descriptor(y);

--- a/cpp/include/raft/util/input_validation.hpp
+++ b/cpp/include/raft/util/input_validation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,8 @@ constexpr bool is_row_or_column_major(mdspan<ElementType, Extents, layout_right,
 template <class ElementType, class Extents, class Accessor>
 constexpr bool is_row_or_column_major(mdspan<ElementType, Extents, layout_stride, Accessor> m)
 {
-  return m.is_exhaustive();
+  return m.stride(0) == typename Extents::index_type(1) ||
+         m.stride(1) == typename Extents::index_type(1);
 }
 
 template <class ElementType, class Extents, class Layout, class Accessor>
@@ -63,7 +64,7 @@ constexpr bool is_row_major(mdspan<ElementType, Extents, layout_right, Accessor>
 template <class ElementType, class Extents, class Accessor>
 constexpr bool is_row_major(mdspan<ElementType, Extents, layout_stride, Accessor> m)
 {
-  return m.is_exhaustive() && m.stride(1) == typename Extents::index_type(1);
+  return m.stride(1) == typename Extents::index_type(1);
 }
 
 template <class ElementType, class Extents, class Layout, class Accessor>
@@ -87,7 +88,7 @@ constexpr bool is_col_major(mdspan<ElementType, Extents, layout_right, Accessor>
 template <class ElementType, class Extents, class Accessor>
 constexpr bool is_col_major(mdspan<ElementType, Extents, layout_stride, Accessor> m)
 {
-  return m.is_exhaustive() && m.stride(0) == typename Extents::index_type(1);
+  return m.stride(0) == typename Extents::index_type(1);
 }
 
 template <class ElementType, class IndexType, size_t... Exts, class Layout, class Accessor>


### PR DESCRIPTION
This PR fixes the SPARSE_DIST_TEST after a combination of changes introduced by #2067, #2117, and #2124.

Scope:
* layout_stride does not check for contiguous data when asked for row/col-major
* make_device_strided_matrix_view does assert when called with neither layout_c_contiguous or layout_f_contiguous
* usage adjusted accordingly in spmm

CC @cjnolet @lowener 

@trxcllnt - please verify that the initial cusparse-alignment bug is still fixed after #2124