### PR TITLE
Cagra clear sccache

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 
 rapids-configure-conda-channels
 
+export SCCACHE_RECACHE=1
 source rapids-configure-sccache
-
 source rapids-date-string
 
 export CMAKE_GENERATOR=Ninja

--- a/conda/recipes/libraft/meta.yaml
+++ b/conda/recipes/libraft/meta.yaml
@@ -30,6 +30,7 @@ outputs:
         - PARALLEL_LEVEL
         - RAPIDS_ARTIFACTS_DIR
         - SCCACHE_BUCKET
+        - SCCACHE_RECACHE
         - SCCACHE_IDLE_TIMEOUT
         - SCCACHE_REGION
         - SCCACHE_S3_KEY_PREFIX=libraft-aarch64 # [aarch64]

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -346,6 +346,10 @@ if(RAFT_COMPILE_LIBRARY)
     src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim256_t16.cu
     src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim512_t32.cu
     src/neighbors/detail/cagra/search_multi_cta_float_uint32_dim1024_t32.cu
+    src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim128_t8.cu
+    src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim256_t16.cu
+    src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim512_t32.cu
+    src/neighbors/detail/cagra/search_multi_cta_float_uint64_dim1024_t32.cu
     src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim128_t8.cu
     src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim256_t16.cu
     src/neighbors/detail/cagra/search_multi_cta_half_uint32_dim512_t32.cu
@@ -362,6 +366,10 @@ if(RAFT_COMPILE_LIBRARY)
     src/neighbors/detail/cagra/search_single_cta_float_uint32_dim256_t16.cu
     src/neighbors/detail/cagra/search_single_cta_float_uint32_dim512_t32.cu
     src/neighbors/detail/cagra/search_single_cta_float_uint32_dim1024_t32.cu
+    src/neighbors/detail/cagra/search_single_cta_float_uint64_dim128_t8.cu
+    src/neighbors/detail/cagra/search_single_cta_float_uint64_dim256_t16.cu
+    src/neighbors/detail/cagra/search_single_cta_float_uint64_dim512_t32.cu
+    src/neighbors/detail/cagra/search_single_cta_float_uint64_dim1024_t32.cu
     src/neighbors/detail/cagra/search_single_cta_half_uint32_dim128_t8.cu
     src/neighbors/detail/cagra/search_single_cta_half_uint32_dim256_t16.cu
     src/neighbors/detail/cagra/search_single_cta_half_uint32_dim512_t32.cu

--- a/cpp/include/raft/neighbors/detail/cagra/search_multi_cta_kernel-ext.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_multi_cta_kernel-ext.cuh
@@ -95,6 +95,14 @@ instantiate_kernel_selection(
 instantiate_kernel_selection(
   32, 512, float, uint32_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
 instantiate_kernel_selection(
+  32, 1024, float, uint64_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
+instantiate_kernel_selection(
+  8, 128, float, uint64_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
+instantiate_kernel_selection(
+  16, 256, float, uint64_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
+instantiate_kernel_selection(
+  32, 512, float, uint64_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
+instantiate_kernel_selection(
   32, 1024, half, uint32_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
 instantiate_kernel_selection(
   8, 128, half, uint32_t, float, raft::neighbors::filtering::none_cagra_sample_filter);

--- a/cpp/include/raft/neighbors/detail/cagra/search_single_cta_kernel-ext.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/search_single_cta_kernel-ext.cuh
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <raft/neighbors/sample_filter_types.hpp>
 #include <raft/util/raft_explicit.hpp>  // RAFT_EXPLICIT
 
@@ -98,6 +99,14 @@ instantiate_single_cta_select_and_run(
   16, 256, float, uint32_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
 instantiate_single_cta_select_and_run(
   32, 512, float, uint32_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
+instantiate_single_cta_select_and_run(
+  32, 1024, float, uint64_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
+instantiate_single_cta_select_and_run(
+  8, 128, float, uint64_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
+instantiate_single_cta_select_and_run(
+  16, 256, float, uint64_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
+instantiate_single_cta_select_and_run(
+  32, 512, float, uint64_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
 instantiate_single_cta_select_and_run(
   32, 1024, half, uint32_t, float, raft::neighbors::filtering::none_cagra_sample_filter);
 instantiate_single_cta_select_and_run(


### PR DESCRIPTION
The sccache has some cagra objects that don't have fpic enabled. This will cause a clean build of them