### PR TITLE
add top-level conda build to avoid rebuild in subs

### DIFF
--- a/conda/recipes/libraft/build_base.sh
+++ b/conda/recipes/libraft/build_base.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022-2024, NVIDIA CORPORATION.
+
+./build.sh libraft --allgpuarch --compile-lib --build-metrics=compile_lib --incl-cache-stats --no-nvtx -n

--- a/conda/recipes/libraft/build_libraft.sh
+++ b/conda/recipes/libraft/build_libraft.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
-./build.sh libraft --allgpuarch --compile-lib --build-metrics=compile_lib --incl-cache-stats --no-nvtx
+cmake --install cpp/build --component compiled

--- a/conda/recipes/libraft/build_libraft_static.sh
+++ b/conda/recipes/libraft/build_libraft_static.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 # Copyright (c) 2022-2023, NVIDIA CORPORATION.
 
-./build.sh libraft --allgpuarch --compile-static-lib --build-metrics=compile_lib_static --incl-cache-stats --no-nvtx -n
 cmake --install cpp/build --component compiled-static

--- a/conda/recipes/libraft/meta.yaml
+++ b/conda/recipes/libraft/meta.yaml
@@ -14,28 +14,66 @@ package:
 source:
   path: ../../..
 
+build:
+  number: {{ GIT_DESCRIBE_NUMBER }}
+  script: "${RECIPE_DIR}/build_base.sh"
+  script_env:
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
+    - CMAKE_C_COMPILER_LAUNCHER
+    - CMAKE_CUDA_COMPILER_LAUNCHER
+    - CMAKE_CXX_COMPILER_LAUNCHER
+    - CMAKE_GENERATOR
+    - PARALLEL_LEVEL
+    - RAPIDS_ARTIFACTS_DIR
+    - SCCACHE_BUCKET
+    - SCCACHE_IDLE_TIMEOUT
+    - SCCACHE_REGION
+    - SCCACHE_S3_KEY_PREFIX=libraft-aarch64 # [aarch64]
+    - SCCACHE_S3_KEY_PREFIX=libraft-linux64 # [linux64]
+    - SCCACHE_S3_USE_SSL
+    - SCCACHE_S3_NO_CREDENTIALS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    {% if cuda_major == "11" %}
+    - {{ compiler('cuda11') }} ={{ cuda_version }}
+    {% else %}
+    - {{ compiler('cuda') }}
+    {% endif %}
+    - cuda-version ={{ cuda_version }}
+    - cmake {{ cmake_version }}
+    - ninja
+    - sysroot_{{ target_platform }} {{ sysroot_version }}
+  host:
+    - cuda-version ={{ cuda_version }}
+    {% if cuda_major == "11" %}
+    - cuda-profiler-api {{ cuda11_cuda_profiler_api_host_version }}
+    - libcublas {{ cuda11_libcublas_host_version }}
+    - libcublas-dev {{ cuda11_libcublas_host_version }}
+    - libcurand {{ cuda11_libcurand_host_version }}
+    - libcurand-dev {{ cuda11_libcurand_host_version }}
+    - libcusolver {{ cuda11_libcusolver_host_version }}
+    - libcusolver-dev {{ cuda11_libcusolver_host_version }}
+    - libcusparse {{ cuda11_libcusparse_host_version }}
+    - libcusparse-dev {{ cuda11_libcusparse_host_version }}
+    {% else %}
+    - cuda-cudart-dev
+    - cuda-profiler-api
+    - libcublas-dev
+    - libcurand-dev
+    - libcusolver-dev
+    - libcusparse-dev
+    {% endif %}
+
 outputs:
   - name: libraft-headers-only
     version: {{ version }}
     script: build_libraft_headers.sh
     build:
-      script_env: &script_env
-        - AWS_ACCESS_KEY_ID
-        - AWS_SECRET_ACCESS_KEY
-        - AWS_SESSION_TOKEN
-        - CMAKE_C_COMPILER_LAUNCHER
-        - CMAKE_CUDA_COMPILER_LAUNCHER
-        - CMAKE_CXX_COMPILER_LAUNCHER
-        - CMAKE_GENERATOR
-        - PARALLEL_LEVEL
-        - RAPIDS_ARTIFACTS_DIR
-        - SCCACHE_BUCKET
-        - SCCACHE_IDLE_TIMEOUT
-        - SCCACHE_REGION
-        - SCCACHE_S3_KEY_PREFIX=libraft-aarch64 # [aarch64]
-        - SCCACHE_S3_KEY_PREFIX=libraft-linux64 # [linux64]
-        - SCCACHE_S3_USE_SSL
-        - SCCACHE_S3_NO_CREDENTIALS
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
@@ -124,7 +162,6 @@ outputs:
     version: {{ version }}
     script: build_libraft.sh
     build:
-      script_env: *script_env
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
@@ -190,7 +227,6 @@ outputs:
     version: {{ version }}
     script: build_libraft_static.sh
     build:
-      script_env: *script_env
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
@@ -252,7 +288,6 @@ outputs:
     version: {{ version }}
     script: build_libraft_tests.sh
     build:
-      script_env: *script_env
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:
@@ -324,7 +359,6 @@ outputs:
     version: {{ version }}
     script: build_libraft_template.sh
     build:
-      script_env: *script_env
       number: {{ GIT_DESCRIBE_NUMBER }}
       string: cuda{{ cuda_major }}_{{ date_string }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
       ignore_run_exports_from:


### PR DESCRIPTION
Adjusts the conda recipe to do the build of all components once, and then uses the subpackage scripts to bundle the produced binaries appropriately into $PREFIX.

This is a draft. I've put it up for discussion and awarenesss, but it's not really ready yet. In particular, the script_env stuff is broken. I don't really understand the scoping rules in YAML, but it seems that declaring the anchor section in the top-level build section does not make it available in the outputs.

fix #2175