### PR TITLE
Align ucx version pinning with ucx-py/ucxx.

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -57,5 +57,5 @@ dependencies:
 - sysroot_linux-aarch64==2.17
 - ucx-proc=*=gpu
 - ucx-py==0.37.*
-- ucx>=1.13.0
+- ucx>=1.15.0,<1.16.0
 name: all_cuda-118_arch-aarch64

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -57,5 +57,5 @@ dependencies:
 - sysroot_linux-64==2.17
 - ucx-proc=*=gpu
 - ucx-py==0.37.*
-- ucx>=1.13.0
+- ucx>=1.15.0,<1.16.0
 name: all_cuda-118_arch-x86_64

--- a/conda/environments/all_cuda-122_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-122_arch-aarch64.yaml
@@ -53,5 +53,5 @@ dependencies:
 - sysroot_linux-aarch64==2.17
 - ucx-proc=*=gpu
 - ucx-py==0.37.*
-- ucx>=1.13.0
+- ucx>=1.15.0,<1.16.0
 name: all_cuda-122_arch-aarch64

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -53,5 +53,5 @@ dependencies:
 - sysroot_linux-64==2.17
 - ucx-proc=*=gpu
 - ucx-py==0.37.*
-- ucx>=1.13.0
+- ucx>=1.15.0,<1.16.0
 name: all_cuda-122_arch-x86_64

--- a/conda/recipes/raft-dask/conda_build_config.yaml
+++ b/conda/recipes/raft-dask/conda_build_config.yaml
@@ -14,7 +14,7 @@ sysroot_version:
   - "2.17"
 
 ucx_version:
-  - ">=1.14.1,<1.16.0"
+  - ">=1.15.0,<1.16.0"
 
 ucx_py_version:
   - "0.37.*"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -443,7 +443,7 @@ dependencies:
           - ucx-py==0.37.*
       - output_types: conda
         packages:
-          - ucx>=1.13.0
+          - ucx>=1.15.0,<1.16.0
           - ucx-proc=*=gpu
           - &ucx_py_conda ucx-py==0.37.*
       - output_types: pyproject


### PR DESCRIPTION
As of https://github.com/rapidsai/ucx-py/pull/1032 and https://github.com/rapidsai/ucxx/pull/205, the `ucx` version pinning in RAPIDS has been updated. This PR aligns with those changes.

Closes https://github.com/rapidsai/build-planning/issues/27.