### PR TITLE
Add CAGRA-Q to ANN benchmarks

### DIFF
--- a/cpp/bench/ann/src/raft/raft_ann_bench_param_parser.h
+++ b/cpp/bench/ann/src/raft/raft_ann_bench_param_parser.h
@@ -222,7 +222,7 @@ void parse_build_param(const nlohmann::json& conf,
   nlohmann::json comp_search_conf = collect_conf_with_prefix(conf, "compression_");
   if (!comp_search_conf.empty()) {
     raft::neighbors::vpq_params vpq_pams;
-    parse_build_param(ivf_pq_build_conf, vpq_pams);
+    parse_build_param(comp_search_conf, vpq_pams);
     param.cagra_params.compression.emplace(vpq_pams);
   }
 }

--- a/cpp/bench/ann/src/raft/raft_cagra_wrapper.h
+++ b/cpp/bench/ann/src/raft/raft_cagra_wrapper.h
@@ -29,6 +29,7 @@
 #include <raft/neighbors/cagra.cuh>
 #include <raft/neighbors/cagra_serialize.cuh>
 #include <raft/neighbors/cagra_types.hpp>
+#include <raft/neighbors/dataset.hpp>
 #include <raft/neighbors/detail/cagra/cagra_build.cuh>
 #include <raft/neighbors/ivf_pq_types.hpp>
 #include <raft/neighbors/nn_descent_types.hpp>
@@ -56,6 +57,7 @@ class RaftCagra : public ANN<T>, public AnnGPU {
 
   struct SearchParam : public AnnSearchParam {
     raft::neighbors::experimental::cagra::search_params p;
+    float refine_ratio;
     AllocatorType graph_mem   = AllocatorType::Device;
     AllocatorType dataset_mem = AllocatorType::Device;
     auto needs_dataset() const -> bool override { return true; }
@@ -98,6 +100,8 @@ class RaftCagra : public ANN<T>, public AnnGPU {
   // will be filled with (size_t)-1
   void search(
     const T* queries, int batch_size, int k, size_t* neighbors, float* distances) const override;
+  void search_base(
+    const T* queries, int batch_size, int k, size_t* neighbors, float* distances) const;
 
   [[nodiscard]] auto get_sync_stream() const noexcept -> cudaStream_t override
   {
@@ -124,6 +128,7 @@ class RaftCagra : public ANN<T>, public AnnGPU {
   raft::mr::cuda_huge_page_resource mr_huge_page_;
   AllocatorType graph_mem_;
   AllocatorType dataset_mem_;
+  float refine_ratio_;
   BuildParam index_params_;
   bool need_dataset_update_;
   raft::neighbors::cagra::search_params search_params_;
@@ -151,6 +156,9 @@ void RaftCagra<T, IdxT>::build(const T* dataset, size_t nrow)
 
   auto& params = index_params_.cagra_params;
 
+  // Do include the compressed dataset for the CAGRA-Q
+  bool shall_include_dataset = params.compression.has_value();
+
   index_ = std::make_shared<raft::neighbors::cagra::index<T, IdxT>>(
     std::move(raft::neighbors::cagra::detail::build(handle_,
                                                     params,
@@ -159,7 +167,7 @@ void RaftCagra<T, IdxT>::build(const T* dataset, size_t nrow)
                                                     index_params_.ivf_pq_refine_rate,
                                                     index_params_.ivf_pq_build_params,
                                                     index_params_.ivf_pq_search_params,
-                                                    false)));
+                                                    shall_include_dataset)));
 }
 
 inline std::string allocator_to_string(AllocatorType mem_type)
@@ -179,6 +187,7 @@ void RaftCagra<T, IdxT>::set_search_param(const AnnSearchParam& param)
 {
   auto search_param = dynamic_cast<const SearchParam&>(param);
   search_params_    = search_param.p;
+  refine_ratio_     = search_param.refine_ratio;
   if (search_param.graph_mem != graph_mem_) {
     // Move graph to correct memory space
     graph_mem_ = search_param.graph_mem;
@@ -223,12 +232,16 @@ void RaftCagra<T, IdxT>::set_search_param(const AnnSearchParam& param)
 template <typename T, typename IdxT>
 void RaftCagra<T, IdxT>::set_search_dataset(const T* dataset, size_t nrow)
 {
+  using ds_idx_type = decltype(index_->data().n_rows());
+  bool is_vpq =
+    dynamic_cast<const raft::neighbors::vpq_dataset<half, ds_idx_type>*>(&index_->data()) ||
+    dynamic_cast<const raft::neighbors::vpq_dataset<float, ds_idx_type>*>(&index_->data());
   // It can happen that we are re-using a previous algo object which already has
   // the dataset set. Check if we need update.
   if (static_cast<size_t>(input_dataset_v_->extent(0)) != nrow ||
       input_dataset_v_->data_handle() != dataset) {
     *input_dataset_v_    = make_device_matrix_view<const T, int64_t>(dataset, nrow, this->dim_);
-    need_dataset_update_ = true;
+    need_dataset_update_ = !is_vpq;  // ignore update if this is a VPQ dataset.
   }
 }
 
@@ -258,7 +271,7 @@ std::unique_ptr<ANN<T>> RaftCagra<T, IdxT>::copy()
 }
 
 template <typename T, typename IdxT>
-void RaftCagra<T, IdxT>::search(
+void RaftCagra<T, IdxT>::search_base(
   const T* queries, int batch_size, int k, size_t* neighbors, float* distances) const
 {
   IdxT* neighbors_IdxT;
@@ -284,6 +297,70 @@ void RaftCagra<T, IdxT>::search(
                           batch_size * k,
                           raft::cast_op<size_t>(),
                           raft::resource::get_cuda_stream(handle_));
+  }
+}
+
+template <typename T, typename IdxT>
+void RaftCagra<T, IdxT>::search(
+  const T* queries, int batch_size, int k, size_t* neighbors, float* distances) const
+{
+  auto k0                       = static_cast<size_t>(refine_ratio_ * k);
+  const bool disable_refinement = k0 <= static_cast<size_t>(k);
+  const raft::resources& res    = handle_;
+  auto stream                   = resource::get_cuda_stream(res);
+
+  if (disable_refinement) {
+    search_base(queries, batch_size, k, neighbors, distances);
+  } else {
+    auto candidate_ixs   = raft::make_device_matrix<int64_t, int64_t>(res, batch_size, k0);
+    auto candidate_dists = raft::make_device_matrix<float, int64_t>(res, batch_size, k0);
+    search_base(queries,
+                batch_size,
+                k0,
+                reinterpret_cast<size_t*>(candidate_ixs.data_handle()),
+                candidate_dists.data_handle());
+
+    if (raft::get_device_for_address(input_dataset_v_->data_handle()) >= 0) {
+      auto queries_v =
+        raft::make_device_matrix_view<const T, int64_t>(queries, batch_size, dimension_);
+      auto neighours_v = raft::make_device_matrix_view<int64_t, int64_t>(
+        reinterpret_cast<int64_t*>(neighbors), batch_size, k);
+      auto distances_v = raft::make_device_matrix_view<float, int64_t>(distances, batch_size, k);
+      raft::neighbors::refine<int64_t, T, float, int64_t>(
+        res,
+        *input_dataset_v_,
+        queries_v,
+        raft::make_const_mdspan(candidate_ixs.view()),
+        neighours_v,
+        distances_v,
+        index_->metric());
+    } else {
+      auto dataset_host = raft::make_host_matrix_view<const T, int64_t>(
+        input_dataset_v_->data_handle(), input_dataset_v_->extent(0), input_dataset_v_->extent(1));
+      auto queries_host    = raft::make_host_matrix<T, int64_t>(batch_size, dimension_);
+      auto candidates_host = raft::make_host_matrix<int64_t, int64_t>(batch_size, k0);
+      auto neighbors_host  = raft::make_host_matrix<int64_t, int64_t>(batch_size, k);
+      auto distances_host  = raft::make_host_matrix<float, int64_t>(batch_size, k);
+
+      raft::copy(queries_host.data_handle(), queries, queries_host.size(), stream);
+      raft::copy(
+        candidates_host.data_handle(), candidate_ixs.data_handle(), candidates_host.size(), stream);
+
+      raft::resource::sync_stream(res);  // wait for the queries and candidates
+      raft::neighbors::refine<int64_t, T, float, int64_t>(res,
+                                                          dataset_host,
+                                                          queries_host.view(),
+                                                          candidates_host.view(),
+                                                          neighbors_host.view(),
+                                                          distances_host.view(),
+                                                          index_->metric());
+
+      raft::copy(neighbors,
+                 reinterpret_cast<size_t*>(neighbors_host.data_handle()),
+                 neighbors_host.size(),
+                 stream);
+      raft::copy(distances, distances_host.data_handle(), distances_host.size(), stream);
+    }
   }
 }
 }  // namespace raft::bench::ann


### PR DESCRIPTION
Add the relevant options to the CAGRA parameter parser and refinement to the CAGRA ANN benchmark.
No changes to the library code.

NB: the new option won't work correctly until https://github.com/rapidsai/raft/pull/2206 is merged.