### PR TITLE
Revert "Add `compile-library` by default on pylibraft build"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -305,7 +305,7 @@ if hasArg --allgpuarch; then
     BUILD_ALL_GPU_ARCH=1
 fi
 
-if hasArg --compile-lib || hasArg pylibraft || (( ${NUMARGS} == 0 )); then
+if hasArg --compile-lib || (( ${NUMARGS} == 0 )); then
     COMPILE_LIBRARY=ON
     CMAKE_TARGET="${CMAKE_TARGET};raft_lib"
 fi
@@ -397,7 +397,7 @@ fi
 
 ################################################################################
 # Configure for building all C++ targets
-if (( ${NUMARGS} == 0 )) || hasArg libraft || hasArg docs || hasArg tests || hasArg bench-prims || hasArg bench-ann || [[ ${COMPILE_LIBRARY} == ON ]]; then
+if (( ${NUMARGS} == 0 )) || hasArg libraft || hasArg docs || hasArg tests || hasArg bench-prims || hasArg bench-ann; then
     if (( ${BUILD_ALL_GPU_ARCH} == 0 )); then
         RAFT_CMAKE_CUDA_ARCHITECTURES="NATIVE"
         echo "Building for the architecture of the GPU in the system..."


### PR DESCRIPTION
Partial reversion of rapidsai/raft#2090

The unintended consequence of this PR was to cause conda builds of pylibraft to rebuild libraft. As a result, since mid-24.04 we've seen the following: pylibraft conda builds have gone from 15-30 mins to 75-90 mins; pylibraft conda packages are fully repackaging libraft; and therefore, pylibraft conda packages have gone from ~2-3MB to ~300MB. A future PR may attempt to improve the developer experience again, at which point we should keep an eye out for similar regressions.