### PR TITLE
Make thrust nosync execution policy the default thrust policy

### DIFF
--- a/cpp/include/raft/core/device_resources.hpp
+++ b/cpp/include/raft/core/device_resources.hpp
@@ -121,7 +121,7 @@ class device_resources : public resources {
 
   cusparseHandle_t get_cusparse_handle() const { return resource::get_cusparse_handle(*this); }
 
-  rmm::exec_policy& get_thrust_policy() const { return resource::get_thrust_policy(*this); }
+  rmm::exec_policy_nosync& get_thrust_policy() const { return resource::get_thrust_policy(*this); }
 
   /**
    * @brief synchronize a stream on the current container

--- a/cpp/include/raft/core/resource/thrust_policy.hpp
+++ b/cpp/include/raft/core/resource/thrust_policy.hpp
@@ -24,7 +24,7 @@ namespace raft::resource {
 class thrust_policy_resource : public resource {
  public:
   thrust_policy_resource(rmm::cuda_stream_view stream_view)
-    : thrust_policy_(std::make_unique<rmm::exec_policy>(stream_view))
+    : thrust_policy_(std::make_unique<rmm::exec_policy_nosync>(stream_view))
   {
   }
   void* get_resource() override { return thrust_policy_.get(); }
@@ -32,7 +32,7 @@ class thrust_policy_resource : public resource {
   ~thrust_policy_resource() override {}
 
  private:
-  std::unique_ptr<rmm::exec_policy> thrust_policy_;
+  std::unique_ptr<rmm::exec_policy_nosync> thrust_policy_;
 };
 
 /**
@@ -60,13 +60,13 @@ class thrust_policy_resource_factory : public resource_factory {
  * @param res raft res object for managing resources
  * @return thrust execution policy
  */
-inline rmm::exec_policy& get_thrust_policy(resources const& res)
+inline rmm::exec_policy_nosync& get_thrust_policy(resources const& res)
 {
   if (!res.has_resource_factory(resource_type::THRUST_POLICY)) {
     rmm::cuda_stream_view stream = get_cuda_stream(res);
     res.add_resource_factory(std::make_shared<thrust_policy_resource_factory>(stream));
   }
-  return *res.get_resource<rmm::exec_policy>(resource_type::THRUST_POLICY);
+  return *res.get_resource<rmm::exec_policy_nosync>(resource_type::THRUST_POLICY);
 };
 
 /**

--- a/cpp/include/raft/spectral/detail/matrix_wrappers.hpp
+++ b/cpp/include/raft/spectral/detail/matrix_wrappers.hpp
@@ -129,7 +129,7 @@ class vector_t {
  private:
   using thrust_exec_policy_t =
     thrust::detail::execute_with_allocator<rmm::mr::thrust_allocator<char>,
-                                           thrust::cuda_cub::execute_on_stream_base>;
+                                           thrust::cuda_cub::execute_on_stream_nosync_base>;
   rmm::device_uvector<value_type> buffer_;
   const thrust_exec_policy_t thrust_policy;
 };


### PR DESCRIPTION
Testing. Do not merge. 

Based on the discussions from https://github.com/rapidsai/raft/pull/2293, it's a good idea to test if we could use nosync thrust calls by default. This PR changes the current `rmm::exec_policy` to its async version `rmm::exec_policy_nosync`. 