### PR TITLE
[REVIEW] Reenable raft-dask wheel tests requiring UCX-Py

### DIFF
--- a/ci/test_wheel_raft_dask.sh
+++ b/ci/test_wheel_raft_dask.sh
@@ -15,11 +15,11 @@ python -m pip install "raft_dask-${RAPIDS_PY_CUDA_SUFFIX}[test]>=0.0.0a0" --find
 
 test_dir="python/raft-dask/raft_dask/test"
 
-# rapids-logger "pytest raft-dask"
-# python -m pytest --import-mode=append ${test_dir}
+rapids-logger "pytest raft-dask"
+python -m pytest --import-mode=append ${test_dir}
 
-# rapids-logger "pytest raft-dask (ucx-py only)"
-# python -m pytest --import-mode=append ${test_dir} --run_ucx
+rapids-logger "pytest raft-dask (ucx-py only)"
+python -m pytest --import-mode=append ${test_dir} --run_ucx
 
 rapids-logger "pytest raft-dask (ucxx only)"
 python -m pytest --import-mode=append ${test_dir} --run_ucxx


### PR DESCRIPTION
With https://github.com/rapidsai/ucx-py/pull/1041 merged, UCX wheels are now fixed and thus reenabling raft-dask wheel tests that require UCX-Py should be safe.