### PR TITLE
Add workaround for syevd in CUDA 12.0

### DIFF
--- a/cpp/test/linalg/eig.cu
+++ b/cpp/test/linalg/eig.cu
@@ -156,6 +156,19 @@ class EigTest : public ::testing::TestWithParam<EigInputs<T>> {
     eig_vals_large, eig_vals_jacobi_large;
 };
 
+TEST(Raft, EigStream)
+{
+  // Separate test to check eig_dc stream workaround for CUDA 12+
+  raft::resources handle;
+  auto n_rows = 5000;
+  auto cov_matrix_large = raft::make_device_matrix<float, std::uint32_t, raft::col_major>(handle, n_rows, n_rows);
+  auto eig_vectors_large = raft::make_device_matrix<float, std::uint32_t, raft::col_major>(handle, n_rows, n_rows);
+  auto eig_vals_large = raft::make_device_vector<float, std::uint32_t>(handle, n_rows);
+
+  raft::linalg::eig_dc(handle, raft::make_const_mdspan(cov_matrix_large.view()), eig_vectors_large.view(), eig_vals_large.view());
+  raft::resource::sync_stream(handle, raft::resource::get_cuda_stream(handle)); 
+}
+
 const std::vector<EigInputs<float>> inputsf2 = {{0.001f, 4 * 4, 4, 4, 1234ULL, 256}};
 
 const std::vector<EigInputs<double>> inputsd2 = {{0.001, 4 * 4, 4, 4, 1234ULL, 256}};


### PR DESCRIPTION
Bug 4580093 of cusolver is causing an issue with `cusolverDnXsyevd`. This bug has been seen in https://github.com/rapidsai/cuml/issues/5555 and impact PCA and Linear Regression with CUDA 12.0+. Setting the stream to a different value than `cudaStreamPerThread` seems to solve it as a workaround.