### PR TITLE
remove unnecessary 'setuptools' dependencies

### DIFF
--- a/conda/recipes/pylibraft/meta.yaml
+++ b/conda/recipes/pylibraft/meta.yaml
@@ -55,7 +55,6 @@ requirements:
     - python x.x
     - rmm ={{ minor_version }}
     - scikit-build-core >=0.7.0
-    - setuptools
     - rapids-build-backend>=0.3.0,<0.4.0.dev0
   run:
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}

--- a/conda/recipes/raft-dask/meta.yaml
+++ b/conda/recipes/raft-dask/meta.yaml
@@ -55,7 +55,6 @@ requirements:
     - python x.x
     - rmm ={{ minor_version }}
     - scikit-build-core >=0.7.0
-    - setuptools
     - ucx-py {{ ucx_py_version }}
     - ucxx {{ ucxx_version }}
     - rapids-build-backend>=0.3.0,<0.4.0.dev0


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/62.

It looks like this some of this project's `conda` recipes have unnecessary dependencies on `setuptools`. I suspect those are left over from before the project was cut over to `scikit-build-core`.

## Notes for Reviewers

How I confirmed there were no direct uses of `setuptools` in `pylibraft` and `raft-dask`:

```shell
git grep -i setuptools
```