### PR TITLE
Fix raft-dask dependency on pylibraft.

### DIFF
--- a/conda/environments/all_cuda-118_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-118_arch-aarch64.yaml
@@ -44,6 +44,7 @@ dependencies:
 - nvcc_linux-aarch64=11.8
 - pre-commit
 - pydata-sphinx-theme
+- pylibraft==24.8.*,>=0.0.0a0
 - pytest-cov
 - pytest==7.*
 - rapids-build-backend>=0.3.0,<0.4.0.dev0

--- a/conda/environments/all_cuda-118_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-118_arch-x86_64.yaml
@@ -44,6 +44,7 @@ dependencies:
 - nvcc_linux-64=11.8
 - pre-commit
 - pydata-sphinx-theme
+- pylibraft==24.8.*,>=0.0.0a0
 - pytest-cov
 - pytest==7.*
 - rapids-build-backend>=0.3.0,<0.4.0.dev0

--- a/conda/environments/all_cuda-122_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-122_arch-aarch64.yaml
@@ -40,6 +40,7 @@ dependencies:
 - numpydoc
 - pre-commit
 - pydata-sphinx-theme
+- pylibraft==24.8.*,>=0.0.0a0
 - pytest-cov
 - pytest==7.*
 - rapids-build-backend>=0.3.0,<0.4.0.dev0

--- a/conda/environments/all_cuda-122_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-122_arch-x86_64.yaml
@@ -40,6 +40,7 @@ dependencies:
 - numpydoc
 - pre-commit
 - pydata-sphinx-theme
+- pylibraft==24.8.*,>=0.0.0a0
 - pytest-cov
 - pytest==7.*
 - rapids-build-backend>=0.3.0,<0.4.0.dev0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -478,10 +478,8 @@ dependencies:
           - ucx-py==0.39.*
       - output_types: conda
         packages:
-          - &ucx_py_conda ucx-py==0.39.*
-      - output_types: pyproject
-        packages:
           - &pylibraft_conda pylibraft==24.8.*,>=0.0.0a0
+          - &ucx_py_conda ucx-py==0.39.*
       - output_types: requirements
         packages:
           # pip recognizes the index as a global option for the requirements.txt file


### PR DESCRIPTION
This PR fixes an issue where `raft-dask-cu12` wheels had a dependency on both `pylibraft-cu12` and `pylibraft`. The latter should not exist.
