### PR TITLE
Use default init in reduction

### DIFF
--- a/cpp/include/raft/util/reduction.cuh
+++ b/cpp/include/raft/util/reduction.cuh
@@ -98,7 +98,7 @@ DI T blockReduce(T val, char* smem, ReduceLambda reduce_op = raft::add_op{})
   val         = warpReduce(val, reduce_op);
   if (lid == 0) sTemp[wid] = val;
   __syncthreads();
-  val = lid < nWarps ? sTemp[lid] : T(0);
+  val = lid < nWarps ? sTemp[lid] : T();
   return warpReduce(val, reduce_op);
 }
 


### PR DESCRIPTION
During reduction in device code (reduction.cuh), the value assigned in the residual threads during last stage are zero initilized. However, if we want to reduce some custom type, it might not have the appropriate constructor. Thus, this PR makes the change so that we call the default constructor for the residual values. 