### PR TITLE
[DO NOT MERGE] Test CCCL version bump

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -11,6 +11,9 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
+
+set(rapids-cmake-url "https://github.com/sleeepyjack/rapids-cmake/archive/refs/heads/bugfix/cccl-span.zip")
+
 include(../rapids_config.cmake)
 include(rapids-cmake)
 include(rapids-cpm)


### PR DESCRIPTION
This PR tests an upcoming CCCL version bump (https://github.com/rapidsai/rapids-cmake/pull/631) and should not be merged.