### PR TITLE
resolve dependency-file-generator warning, other rapids-build-backend followup

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -13,10 +13,8 @@ export CMAKE_GENERATOR=Ninja
 
 rapids-print-env
 
-version=$(rapids-generate-version)
-
 rapids-logger "Begin cpp build"
 
-RAPIDS_PACKAGE_VERSION=${version} rapids-conda-retry mambabuild conda/recipes/libraft
+RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry mambabuild conda/recipes/libraft
 
 rapids-upload-conda-to-s3 cpp

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -8,7 +8,7 @@ rapids-logger "Create test conda environment"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key docs \
+  --file-key docs \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n docs

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -8,7 +8,7 @@ rapids-logger "Create checks conda environment"
 
 rapids-dependency-file-generator \
   --output conda \
-  --file_key checks \
+  --file-key checks \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n checks

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 rapids-logger "Generate C++ testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_cpp \
+  --file-key test_cpp \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch)" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -11,7 +11,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \
   --output conda \
-  --file_key test_python \
+  --file-key test_python \
   --matrix "cuda=${RAPIDS_CUDA_VERSION%.*};arch=$(arch);py=${RAPIDS_PY_VERSION}" | tee env.yaml
 
 rapids-mamba-retry env create --yes -f env.yaml -n test

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -6,7 +6,6 @@ files:
       cuda: ["11.8", "12.2"]
       arch: [x86_64, aarch64]
     includes:
-      - build
       - rapids_build
       - build_pylibraft
       - cuda
@@ -15,9 +14,10 @@ files:
       - depends_on_distributed_ucxx
       - develop
       - checks
-      - build_wheels
       - test_libraft
       - docs
+      - rapids_build_setuptools
+      - rapids_build_skbuild
       - run_raft_dask
       - run_pylibraft
       - test_python_common
@@ -28,13 +28,13 @@ files:
       cuda: ["11.8", "12.0"]
       arch: [x86_64, aarch64]
     includes:
-      - build
       - rapids_build
       - cuda
       - cuda_version
       - develop
       - nn_bench
       - nn_bench_python
+      - rapids_build_skbuild
   test_cpp:
     output: none
     includes:
@@ -67,7 +67,7 @@ files:
     extras:
       table: build-system
     includes:
-      - build
+      - rapids_build_skbuild
   py_rapids_build_pylibraft:
     output: pyproject
     pyproject_dir: python/pylibraft
@@ -100,7 +100,7 @@ files:
     extras:
       table: build-system
     includes:
-      - build
+      - rapids_build_skbuild
   py_rapids_build_raft_dask:
     output: pyproject
     pyproject_dir: python/raft-dask
@@ -132,7 +132,7 @@ files:
     extras:
       table: build-system
     includes:
-      - build_wheels
+      - rapids_build_setuptools
   py_run_raft_ann_bench:
     output: pyproject
     pyproject_dir: python/raft-ann-bench
@@ -147,11 +147,11 @@ channels:
   - conda-forge
   - nvidia
 dependencies:
-  build:
+  rapids_build_skbuild:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - rapids-build-backend>=0.3.0,<0.4.0.dev0
+          - &rapids_build_backend rapids-build-backend>=0.3.0,<0.4.0.dev0
       - output_types: [conda]
         packages:
           - scikit-build-core>=0.7.0
@@ -404,13 +404,13 @@ dependencies:
           - recommonmark
           - sphinx-copybutton
           - sphinx-markdown-tables
-  build_wheels:
+  rapids_build_setuptools:
     common:
       - output_types: [requirements, pyproject]
         packages:
           - wheel
           - setuptools
-          - rapids-build-backend>=0.3.0,<0.4.0.dev0
+          - *rapids_build_backend
   py_version:
     specific:
       - output_types: conda


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/31
Contributes to https://github.com/rapidsai/dependency-file-generator/issues/89

Since #2331 was merged, we've made some small adjustments to the approach for `rapids-build-backend`. This catches `raft` up with those changes:

* consolidates version-handling in `ci/` scripts
* uses `--file-key` instead of `--file_key` in `rapids-dependency-file-generator` calls
* reduces duplication of `rapids-build-backend` version constraint in `dependencies.yaml`, and renames some lists there to match the patterns used in other projects (e.g. `rapids_build_skbuild` instead of `build`)