### PR TITLE
Fix a bug where the wrong API is used to free the memory

### DIFF
--- a/cpp/test/core/memory_type.cpp
+++ b/cpp/test/core/memory_type.cpp
@@ -49,7 +49,7 @@ TEST(MemoryTypeFromPointer, Host)
   auto ptr1 = static_cast<void*>(nullptr);
   cudaMallocHost(&ptr1, 1);
   EXPECT_EQ(memory_type_from_pointer(ptr1), memory_type::host);
-  cudaFree(ptr1);
+  cudaFreeHost(ptr1);
   auto ptr2 = static_cast<void*>(nullptr);
   EXPECT_EQ(memory_type_from_pointer(ptr2), memory_type::host);
 }


### PR DESCRIPTION
This PR fixes a bug uncovered by CCCL version bump #2358 