### PR TITLE
Fix 0 recall issue in `raft_cagra_hnswlib` ANN benchmark

### DIFF
--- a/cpp/bench/ann/src/raft/raft_cagra_hnswlib_wrapper.h
+++ b/cpp/bench/ann/src/raft/raft_cagra_hnswlib_wrapper.h
@@ -31,7 +31,7 @@ class RaftCagraHnswlib : public ANN<T>, public AnnGPU {
 
   RaftCagraHnswlib(Metric metric, int dim, const BuildParam& param, int concurrent_searches = 1)
     : ANN<T>(metric, dim),
-      cagra_build_{metric, dim, param, concurrent_searches},
+      cagra_build_{metric, dim, param, concurrent_searches, true},
       // HnswLib param values don't matter since we don't build with HnswLib
       hnswlib_search_{metric, dim, typename HnswLib<T>::BuildParam{50, 100}}
   {


### PR DESCRIPTION
`raft_cagra` wrapper stopped including the dataset in the index to save memory, but this adversely affected `raft_cagra_hnswlib` wrapper because the dataset needed to be included in the index. The need for inclusion of the dataset is because we need the dataset to be serialized when writing to the `hnswlib` format.