### PR TITLE
Use slicing kernel to copy distances inside NN Descent

### DIFF
--- a/cpp/include/raft/neighbors/detail/nn_descent.cuh
+++ b/cpp/include/raft/neighbors/detail/nn_descent.cuh
@@ -18,11 +18,10 @@
 
 #include "../nn_descent_types.hpp"
 
+#include <raft/core/copy.cuh>
 #include <raft/core/device_mdarray.hpp>
-#include <raft/core/device_mdspan.hpp>
 #include <raft/core/error.hpp>
 #include <raft/core/host_mdarray.hpp>
-#include <raft/core/mdspan.hpp>
 #include <raft/core/operators.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resources.hpp>
@@ -1370,10 +1369,7 @@ void GNND<Data_t, Index_t, epilogue_op>::build(Data_t* data,
   if (return_distances) {
     auto graph_d_dists = raft::make_device_matrix<DistData_t, int64_t, raft::row_major>(
       res, nrow_, build_config_.node_degree);
-    raft::copy(graph_d_dists.data_handle(),
-               graph_.h_dists.data_handle(),
-               nrow_ * build_config_.node_degree,
-               raft::resource::get_cuda_stream(res));
+    raft::copy(res, graph_d_dists.view(), graph_.h_dists.view());
 
     auto output_dist_view = raft::make_device_matrix_view<DistData_t, int64_t, raft::row_major>(
       output_distances, nrow_, build_config_.output_graph_degree);

--- a/cpp/include/raft/neighbors/detail/nn_descent.cuh
+++ b/cpp/include/raft/neighbors/detail/nn_descent.cuh
@@ -23,7 +23,6 @@
 #include <raft/core/error.hpp>
 #include <raft/core/host_mdarray.hpp>
 #include <raft/core/mdspan.hpp>
-#include <raft/core/mdspan_types.hpp>
 #include <raft/core/operators.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resources.hpp>
@@ -49,7 +48,6 @@
 #include <mma.h>
 #include <omp.h>
 
-#include <cstdint>
 #include <limits>
 #include <optional>
 #include <queue>
@@ -1370,21 +1368,21 @@ void GNND<Data_t, Index_t, epilogue_op>::build(Data_t* data,
   static_assert(sizeof(decltype(*(graph_.h_dists.data_handle()))) >= sizeof(Index_t));
 
   if (return_distances) {
-    auto graph_d_dists = raft::make_device_matrix<DistData_t, int64_t, row_major>(
+    auto graph_d_dists = raft::make_device_matrix<DistData_t, int64_t, raft::row_major>(
       res, nrow_, build_config_.node_degree);
     raft::copy(graph_d_dists.data_handle(),
                graph_.h_dists.data_handle(),
                nrow_ * build_config_.node_degree,
                raft::resource::get_cuda_stream(res));
 
-    auto output_dist_view = raft::make_device_matrix_view<DistData_t, int64_t, row_major>(
+    auto output_dist_view = raft::make_device_matrix_view<DistData_t, int64_t, raft::row_major>(
       output_distances, nrow_, build_config_.output_graph_degree);
 
     raft::matrix::slice_coordinates coords{static_cast<int64_t>(0),
                                            static_cast<int64_t>(0),
                                            static_cast<int64_t>(nrow_),
                                            static_cast<int64_t>(build_config_.output_graph_degree)};
-    raft::matrix::slice<DistData_t, int64_t, row_major>(
+    raft::matrix::slice<DistData_t, int64_t, raft::row_major>(
       res, raft::make_const_mdspan(graph_d_dists.view()), output_dist_view, coords);
   }
 

--- a/cpp/include/raft/neighbors/detail/nn_descent.cuh
+++ b/cpp/include/raft/neighbors/detail/nn_descent.cuh
@@ -18,7 +18,6 @@
 
 #include "../nn_descent_types.hpp"
 
-#include <raft/core/copy.cuh>
 #include <raft/core/device_mdarray.hpp>
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/error.hpp>
@@ -1369,7 +1368,7 @@ void GNND<Data_t, Index_t, epilogue_op>::build(Data_t* data,
   static_assert(sizeof(decltype(*(graph_.h_dists.data_handle()))) >= sizeof(Index_t));
 
   if (return_distances) {
-    auto graph_d_dists = raft::make_device_matrix<DistData_t, size_t, raft::row_major>(
+    auto graph_d_dists = raft::make_device_matrix<DistData_t, int64_t, raft::row_major>(
       res, nrow_, build_config_.node_degree);
     raft::copy(graph_d_dists.data_handle(),
                graph_.h_dists.data_handle(),

--- a/cpp/include/raft/neighbors/detail/nn_descent.cuh
+++ b/cpp/include/raft/neighbors/detail/nn_descent.cuh
@@ -1236,17 +1236,6 @@ void GNND<Data_t, Index_t, epilogue_op>::local_join(cudaStream_t stream,
     distance_epilogue);
 }
 
-template <typename T>
-RAFT_KERNEL copy_first_k_cols(T* out, T* in, size_t out_k, size_t in_k, size_t nrow)
-{
-  size_t row = blockIdx.x * blockDim.x + threadIdx.x;
-  if (row < nrow) {
-    for (size_t i = 0; i < out_k; i++) {
-      out[row * out_k + i] = in[row * in_k + i];
-    }
-  }
-}
-
 template <typename Data_t, typename Index_t, typename epilogue_op>
 void GNND<Data_t, Index_t, epilogue_op>::build(Data_t* data,
                                                const Index_t nrow,

--- a/cpp/include/raft/neighbors/detail/nn_descent.cuh
+++ b/cpp/include/raft/neighbors/detail/nn_descent.cuh
@@ -20,6 +20,7 @@
 
 #include <raft/core/copy.cuh>
 #include <raft/core/device_mdarray.hpp>
+#include <raft/core/device_mdspan.hpp>
 #include <raft/core/error.hpp>
 #include <raft/core/host_mdarray.hpp>
 #include <raft/core/operators.hpp>
@@ -1367,19 +1368,21 @@ void GNND<Data_t, Index_t, epilogue_op>::build(Data_t* data,
   static_assert(sizeof(decltype(*(graph_.h_dists.data_handle()))) >= sizeof(Index_t));
 
   if (return_distances) {
-    auto graph_d_dists = raft::make_device_matrix<DistData_t, int64_t, raft::row_major>(
+    auto graph_d_dists = raft::make_device_matrix<DistData_t, size_t, raft::row_major>(
       res, nrow_, build_config_.node_degree);
     raft::copy(res, graph_d_dists.view(), graph_.h_dists.view());
 
     auto output_dist_view = raft::make_device_matrix_view<DistData_t, int64_t, raft::row_major>(
       output_distances, nrow_, build_config_.output_graph_degree);
-
+    auto graph_d_dists_const_view =
+      raft::make_device_matrix_view<DistData_t, int64_t, raft::row_major>(
+        graph_d_dists.data_handle(), nrow_, build_config_.node_degree);
     raft::matrix::slice_coordinates coords{static_cast<int64_t>(0),
                                            static_cast<int64_t>(0),
                                            static_cast<int64_t>(nrow_),
                                            static_cast<int64_t>(build_config_.output_graph_degree)};
     raft::matrix::slice<DistData_t, int64_t, raft::row_major>(
-      res, raft::make_const_mdspan(graph_d_dists.view()), output_dist_view, coords);
+      res, graph_d_dists_const_view, output_dist_view, coords);
   }
 
   Index_t* graph_shrink_buffer = (Index_t*)graph_.h_dists.data_handle();

--- a/cpp/include/raft/neighbors/detail/nn_descent.cuh
+++ b/cpp/include/raft/neighbors/detail/nn_descent.cuh
@@ -1375,7 +1375,6 @@ void GNND<Data_t, Index_t, epilogue_op>::build(Data_t* data,
   // Reuse graph_.h_dists as the buffer for shrink the lists in graph
   static_assert(sizeof(decltype(*(graph_.h_dists.data_handle()))) >= sizeof(Index_t));
 
-  nvtxRangePushA("copying distances inside build");
   if (return_distances) {
     auto graph_d_dists = raft::make_device_matrix<DistData_t, size_t, raft::row_major>(
       res, nrow_, build_config_.node_degree);
@@ -1392,15 +1391,7 @@ void GNND<Data_t, Index_t, epilogue_op>::build(Data_t* data,
       build_config_.output_graph_degree,
       build_config_.node_degree,
       nrow_);
-
-    // for (size_t i = 0; i < (size_t)nrow_; i++) {
-    //   raft::copy(output_distances + i * build_config_.output_graph_degree,
-    //              graph_.h_dists.data_handle() + i * build_config_.node_degree,
-    //              build_config_.output_graph_degree,
-    //              raft::resource::get_cuda_stream(res));
-    // }
   }
-  nvtxRangePop();
 
   Index_t* graph_shrink_buffer = (Index_t*)graph_.h_dists.data_handle();
 

--- a/cpp/include/raft/neighbors/detail/nn_descent.cuh
+++ b/cpp/include/raft/neighbors/detail/nn_descent.cuh
@@ -1390,7 +1390,8 @@ void GNND<Data_t, Index_t, epilogue_op>::build(Data_t* data,
     auto output_dist_view =
       raft::make_device_matrix_view(output_distances, nrow_, build_config_.output_graph_degree);
 
-    raft::matrix::slice_coordinates coords{0lu, 0lu, nrow_, build_config_.output_graph_degree};
+    raft::matrix::slice_coordinates coords{
+      0, 0, static_cast<int>(nrow_), static_cast<int>(build_config_.output_graph_degree)};
     raft::matrix::slice<DistData_t, size_t, row_major>(
       res, raft::make_const_mdspan(graph_d_dists.view()), output_dist_view, coords);
   }


### PR DESCRIPTION
### Description
This make use of raft's slicing kernel within NN Descent build.
I found that my previous implementation was inefficient (merged in [this PR](https://github.com/rapidsai/raft/pull/2345)).

### Improvements
Time to call NN Descent `build()` with `return_distances=True` before and after using this kernel
| Dataset | Before |After|
| ------------- | ------------- |---|
| mnist (60000, 784)  | 1550ms  | 1020ms|
| sift (1M, 128)  | 11342ms  |5546ms|
| gist (1M, 960)  | 13508ms |9278ms|