### PR TITLE
Update pip devcontainers to UCX v1.17.0

### DIFF
--- a/.devcontainer/cuda11.8-pip/devcontainer.json
+++ b/.devcontainer/cuda11.8-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "11.8",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:24.10-cpp-cuda11.8-ubuntu22.04"
+      "BASE": "rapidsai/devcontainers:24.10-cpp-cuda11.8-ucx1.17.0-openmpi-ubuntu22.04"
     }
   },
   "runArgs": [
@@ -15,9 +15,6 @@
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
-    "ghcr.io/rapidsai/devcontainers/features/ucx:24.10": {
-      "version": "1.17.0"
-    },
     "ghcr.io/rapidsai/devcontainers/features/cuda:24.10": {
       "version": "11.8",
       "installcuBLAS": true,

--- a/.devcontainer/cuda11.8-pip/devcontainer.json
+++ b/.devcontainer/cuda11.8-pip/devcontainer.json
@@ -16,7 +16,7 @@
   "hostRequirements": {"gpu": "optional"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/ucx:24.10": {
-      "version": "1.15.0"
+      "version": "1.17.0"
     },
     "ghcr.io/rapidsai/devcontainers/features/cuda:24.10": {
       "version": "11.8",

--- a/.devcontainer/cuda12.5-pip/devcontainer.json
+++ b/.devcontainer/cuda12.5-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "12.5",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:24.10-cpp-cuda12.5-ubuntu22.04"
+      "BASE": "rapidsai/devcontainers:24.10-cpp-cuda12.5-ucx1.17.0-openmpi-ubuntu22.04"
     }
   },
   "runArgs": [
@@ -15,9 +15,6 @@
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
-    "ghcr.io/rapidsai/devcontainers/features/ucx:24.10": {
-      "version": "1.17.0"
-    },
     "ghcr.io/rapidsai/devcontainers/features/cuda:24.10": {
       "version": "12.5",
       "installcuBLAS": true,

--- a/.devcontainer/cuda12.5-pip/devcontainer.json
+++ b/.devcontainer/cuda12.5-pip/devcontainer.json
@@ -16,7 +16,7 @@
   "hostRequirements": {"gpu": "optional"},
   "features": {
     "ghcr.io/rapidsai/devcontainers/features/ucx:24.10": {
-      "version": "1.15.0"
+      "version": "1.17.0"
     },
     "ghcr.io/rapidsai/devcontainers/features/cuda:24.10": {
       "version": "12.5",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/77.

Follow-up to https://github.com/rapidsai/devcontainers/pull/338

Proposes updating the pip devcontainers to use v1.17.0, as part of an effort to use that version across RAPIDS.