### PR TITLE
Add RAFT wrappers around current_device_resource functions

### DIFF
--- a/cpp/bench/ann/src/faiss/faiss_gpu_benchmark.cu
+++ b/cpp/bench/ann/src/faiss/faiss_gpu_benchmark.cu
@@ -183,10 +183,10 @@ int main(int argc, char** argv)
   rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource> pool_mr{
     &cuda_mr, rmm::percent_of_free_device_memory(50)};
   // Updates the current device resource pointer to `pool_mr`
-  auto old_mr = rmm::mr::set_current_device_resource(&pool_mr);
+  auto old_mr = raft::resource::set_current_device_resource(&pool_mr);
   auto ret    = raft::bench::ann::run_main(argc, argv);
   // Restores the current device resource pointer to its previous value
-  rmm::mr::set_current_device_resource(old_mr);
+  raft::resource::set_current_device_resource(old_mr);
   return ret;
 }
 #endif

--- a/cpp/bench/ann/src/raft/raft_ann_bench_utils.h
+++ b/cpp/bench/ann/src/raft/raft_ann_bench_utils.h
@@ -80,7 +80,7 @@ class shared_raft_resources {
   using large_mr_type = rmm::mr::managed_memory_resource;
 
   shared_raft_resources()
-  try : orig_resource_{rmm::mr::get_current_device_resource()},
+  try : orig_resource_{raft::resource::get_current_device_resource_ref()},
     pool_resource_(orig_resource_, 1024 * 1024 * 1024ull),
     resource_(&pool_resource_, rmm_oom_callback, nullptr), large_mr_() {
     rmm::mr::set_current_device_resource(&resource_);

--- a/cpp/bench/ann/src/raft/raft_ann_bench_utils.h
+++ b/cpp/bench/ann/src/raft/raft_ann_bench_utils.h
@@ -80,10 +80,10 @@ class shared_raft_resources {
   using large_mr_type = rmm::mr::managed_memory_resource;
 
   shared_raft_resources()
-  try : orig_resource_{raft::resource::get_current_device_resource_ref()},
+  try : orig_resource_{raft::resource::get_current_device_resource()},
     pool_resource_(orig_resource_, 1024 * 1024 * 1024ull),
     resource_(&pool_resource_, rmm_oom_callback, nullptr), large_mr_() {
-    rmm::mr::set_current_device_resource(&resource_);
+    raft::resource::set_current_device_resource(&resource_);
   } catch (const std::exception& e) {
     auto cuda_status = cudaGetLastError();
     size_t free      = 0;
@@ -103,7 +103,7 @@ class shared_raft_resources {
   shared_raft_resources(const shared_raft_resources& res)              = delete;
   shared_raft_resources& operator=(const shared_raft_resources& other) = delete;
 
-  ~shared_raft_resources() noexcept { rmm::mr::set_current_device_resource(orig_resource_); }
+  ~shared_raft_resources() noexcept { raft::resource::set_current_device_resource(orig_resource_); }
 
   auto get_large_memory_resource() noexcept
   {

--- a/cpp/bench/ann/src/raft/raft_cagra_hnswlib.cu
+++ b/cpp/bench/ann/src/raft/raft_cagra_hnswlib.cu
@@ -91,10 +91,10 @@ int main(int argc, char** argv)
   rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource> pool_mr{
     &cuda_mr, rmm::percent_of_free_device_memory(50)};
   // Updates the current device resource pointer to `pool_mr`
-  auto old_mr = rmm::mr::set_current_device_resource(&pool_mr);
+  auto old_mr = raft::resource::set_current_device_resource(&pool_mr);
   auto ret    = raft::bench::ann::run_main(argc, argv);
   // Restores the current device resource pointer to its previous value
-  rmm::mr::set_current_device_resource(old_mr);
+  raft::resource::set_current_device_resource(old_mr);
   return ret;
 }
 #endif

--- a/cpp/bench/ann/src/raft/raft_cagra_wrapper.h
+++ b/cpp/bench/ann/src/raft/raft_cagra_wrapper.h
@@ -153,7 +153,7 @@ class RaftCagra : public ANN<T>, public AnnGPU {
     switch (mem_type) {
       case (AllocatorType::HostPinned): return &mr_pinned_;
       case (AllocatorType::HostHugePage): return &mr_huge_page_;
-      default: return rmm::mr::get_current_device_resource();
+      default: return raft::resource::get_current_device_resource_ref();
     }
   }
 };

--- a/cpp/bench/prims/common/benchmark.hpp
+++ b/cpp/bench/prims/common/benchmark.hpp
@@ -50,14 +50,14 @@ struct using_pool_memory_res {
 
  public:
   using_pool_memory_res(size_t initial_size, size_t max_size)
-    : orig_res_(rmm::mr::get_current_device_resource()),
+    : orig_res_(raft::resource::get_current_device_resource_ref()),
       pool_res_(&cuda_res_, initial_size, max_size)
   {
     rmm::mr::set_current_device_resource(&pool_res_);
   }
 
   using_pool_memory_res()
-    : orig_res_(rmm::mr::get_current_device_resource()),
+    : orig_res_(raft::resource::get_current_device_resource_ref()),
       pool_res_(&cuda_res_, rmm::percent_of_free_device_memory(50))
   {
     rmm::mr::set_current_device_resource(&pool_res_);

--- a/cpp/bench/prims/common/benchmark.hpp
+++ b/cpp/bench/prims/common/benchmark.hpp
@@ -51,14 +51,14 @@ struct using_pool_memory_res {
 
  public:
   using_pool_memory_res(size_t initial_size, size_t max_size)
-    : orig_res_(raft::resource::get_current_device_resource_ref()),
+    : orig_res_(raft::resource::get_current_device_resource()),
       pool_res_(&cuda_res_, initial_size, max_size)
   {
     raft::resource::set_current_device_resource(&pool_res_);
   }
 
   using_pool_memory_res()
-    : orig_res_(raft::resource::get_current_device_resource_ref()),
+    : orig_res_(raft::resource::get_current_device_resource()),
       pool_res_(&cuda_res_, rmm::percent_of_free_device_memory(50))
   {
     raft::resource::set_current_device_resource(&pool_res_);

--- a/cpp/bench/prims/common/benchmark.hpp
+++ b/cpp/bench/prims/common/benchmark.hpp
@@ -21,6 +21,7 @@
 #include <raft/core/device_resources.hpp>
 #include <raft/core/interruptible.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
+#include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/random/make_blobs.cuh>
 #include <raft/util/cudart_utils.hpp>
 
@@ -53,17 +54,17 @@ struct using_pool_memory_res {
     : orig_res_(raft::resource::get_current_device_resource_ref()),
       pool_res_(&cuda_res_, initial_size, max_size)
   {
-    rmm::mr::set_current_device_resource(&pool_res_);
+    raft::resource::set_current_device_resource(&pool_res_);
   }
 
   using_pool_memory_res()
     : orig_res_(raft::resource::get_current_device_resource_ref()),
       pool_res_(&cuda_res_, rmm::percent_of_free_device_memory(50))
   {
-    rmm::mr::set_current_device_resource(&pool_res_);
+    raft::resource::set_current_device_resource(&pool_res_);
   }
 
-  ~using_pool_memory_res() { rmm::mr::set_current_device_resource(orig_res_); }
+  ~using_pool_memory_res() { raft::resource::set_current_device_resource(orig_res_); }
 };
 
 /**

--- a/cpp/bench/prims/matrix/gather.cu
+++ b/cpp/bench/prims/matrix/gather.cu
@@ -46,7 +46,7 @@ template <typename T, typename MapT, typename IdxT, bool Conditional = false>
 struct Gather : public fixture {
   Gather(const GatherParams<IdxT>& p)
     : params(p),
-      old_mr(raft::resource::get_current_device_resource_ref()),
+      old_mr(raft::resource::get_current_device_resource()),
       pool_mr(raft::resource::get_current_device_resource_ref(), 2 * (1ULL << 30)),
       matrix(this->handle),
       map(this->handle),

--- a/cpp/bench/prims/matrix/gather.cu
+++ b/cpp/bench/prims/matrix/gather.cu
@@ -54,10 +54,10 @@ struct Gather : public fixture {
       stencil(this->handle),
       matrix_h(this->handle)
   {
-    rmm::mr::set_current_device_resource(&pool_mr);
+    raft::resource::set_current_device_resource(&pool_mr);
   }
 
-  ~Gather() { rmm::mr::set_current_device_resource(old_mr); }
+  ~Gather() { raft::resource::set_current_device_resource(old_mr); }
 
   void allocate_data(const ::benchmark::State& state) override
   {

--- a/cpp/bench/prims/matrix/gather.cu
+++ b/cpp/bench/prims/matrix/gather.cu
@@ -46,8 +46,8 @@ template <typename T, typename MapT, typename IdxT, bool Conditional = false>
 struct Gather : public fixture {
   Gather(const GatherParams<IdxT>& p)
     : params(p),
-      old_mr(rmm::mr::get_current_device_resource()),
-      pool_mr(rmm::mr::get_current_device_resource(), 2 * (1ULL << 30)),
+      old_mr(raft::resource::get_current_device_resource_ref()),
+      pool_mr(raft::resource::get_current_device_resource_ref(), 2 * (1ULL << 30)),
       matrix(this->handle),
       map(this->handle),
       out(this->handle),

--- a/cpp/bench/prims/neighbors/knn.cuh
+++ b/cpp/bench/prims/neighbors/knn.cuh
@@ -91,13 +91,9 @@ inline auto operator<<(std::ostream& os, const Scope& s) -> std::ostream&
 struct device_resource {
  public:
   explicit device_resource(bool managed)
-    : managed_(managed ? std::make_shared<rmm::mr::managed_memory_resource>() : nullptr)
+    : managed_(managed ? std::make_shared<rmm::mr::managed_memory_resource>() : nullptr),
+      res_(managed ? managed.get() : raft::resource::get_current_device_resource_ref())
   {
-    if (managed) {
-      res_ = managed.get();
-    } else {
-      res_ = raft::resource::get_current_device_resource_ref();
-    }
   }
 
   ~device_resource() {}

--- a/cpp/bench/prims/neighbors/knn.cuh
+++ b/cpp/bench/prims/neighbors/knn.cuh
@@ -96,7 +96,7 @@ struct device_resource {
   {
   }
 
-  ~device_resource() {}
+  ~device_resource() = default;
 
   [[nodiscard]] auto get() const -> rmm::device_async_resource_ref { return res_; }
 

--- a/cpp/bench/prims/neighbors/knn.cuh
+++ b/cpp/bench/prims/neighbors/knn.cuh
@@ -92,7 +92,7 @@ struct device_resource {
  public:
   explicit device_resource(bool managed)
     : managed_(managed ? std::make_shared<rmm::mr::managed_memory_resource>() : nullptr),
-      res_(managed ? managed.get() : raft::resource::get_current_device_resource_ref())
+      res_(managed ? managed_.get() : raft::resource::get_current_device_resource_ref())
   {
   }
 

--- a/cpp/bench/prims/neighbors/knn.cuh
+++ b/cpp/bench/prims/neighbors/knn.cuh
@@ -32,6 +32,7 @@
 #include <rmm/mr/device/managed_memory_resource.hpp>
 #include <rmm/mr/host/new_delete_resource.hpp>
 #include <rmm/mr/host/pinned_memory_resource.hpp>
+#include <rmm/resource_ref.hpp>
 
 #include <thrust/sequence.h>
 
@@ -105,7 +106,7 @@ struct device_resource {
 
  private:
   std::shared_ptr<rmm::mr::device_memory_resource> managed_;
-  raft::device_async_resource_ref res_;
+  rmm::device_async_resource_ref res_;
 };
 
 template <typename T>

--- a/cpp/bench/prims/neighbors/refine.cuh
+++ b/cpp/bench/prims/neighbors/refine.cuh
@@ -58,7 +58,7 @@ class RefineAnn : public fixture {
     label_stream << data.p;
     state.SetLabel(label_stream.str());
 
-    auto old_mr = rmm::mr::get_current_device_resource();
+    auto old_mr = raft::resource::get_current_device_resource_ref();
     rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr(
       old_mr, rmm::percent_of_free_device_memory(50));
     rmm::mr::set_current_device_resource(&pool_mr);
@@ -84,7 +84,7 @@ class RefineAnn : public fixture {
                                                               data.p.metric);
       });
     }
-    rmm::mr::set_current_device_resource(old_mr);
+    raft::set_current_device_resource(old_mr);
   }
 
  private:

--- a/cpp/bench/prims/neighbors/refine.cuh
+++ b/cpp/bench/prims/neighbors/refine.cuh
@@ -59,7 +59,7 @@ class RefineAnn : public fixture {
     label_stream << data.p;
     state.SetLabel(label_stream.str());
 
-    auto old_mr = raft::resource::get_current_device_resource_ref();
+    auto old_mr = raft::resource::get_current_device_resource();
     rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr(
       old_mr, rmm::percent_of_free_device_memory(50));
     raft::resource::set_current_device_resource(&pool_mr);

--- a/cpp/bench/prims/neighbors/refine.cuh
+++ b/cpp/bench/prims/neighbors/refine.cuh
@@ -61,7 +61,7 @@ class RefineAnn : public fixture {
     auto old_mr = raft::resource::get_current_device_resource_ref();
     rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr(
       old_mr, rmm::percent_of_free_device_memory(50));
-    rmm::mr::set_current_device_resource(&pool_mr);
+    raft::resource::set_current_device_resource(&pool_mr);
 
     if (data.p.host_data) {
       loop_on_state(state, [this]() {

--- a/cpp/bench/prims/neighbors/refine.cuh
+++ b/cpp/bench/prims/neighbors/refine.cuh
@@ -20,6 +20,7 @@
 
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/device_resources.hpp>
+#include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/distance/distance_types.hpp>
 #include <raft/neighbors/detail/refine.cuh>
 #include <raft/neighbors/refine.cuh>
@@ -84,7 +85,7 @@ class RefineAnn : public fixture {
                                                               data.p.metric);
       });
     }
-    raft::set_current_device_resource(old_mr);
+    raft::resource::set_current_device_resource(old_mr);
   }
 
  private:

--- a/cpp/bench/prims/random/subsample.cu
+++ b/cpp/bench/prims/random/subsample.cu
@@ -69,7 +69,7 @@ struct sample : public fixture {
       in(make_device_vector<T, int64_t>(res, p.n_samples)),
       out(make_device_vector<T, int64_t>(res, p.n_train))
   {
-    rmm::mr::set_current_device_resource(&pool_mr);
+    raft::resource::set_current_device_resource(&pool_mr);
     raft::random::RngState r(123456ULL);
   }
 

--- a/cpp/bench/prims/random/subsample.cu
+++ b/cpp/bench/prims/random/subsample.cu
@@ -20,6 +20,7 @@
 #include <raft/core/device_resources.hpp>
 #include <raft/core/host_mdarray.hpp>
 #include <raft/core/operators.hpp>
+#include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/random/permute.cuh>
 #include <raft/random/rng.cuh>
 #include <raft/random/sample_without_replacement.cuh>
@@ -73,7 +74,7 @@ struct sample : public fixture {
     raft::random::RngState r(123456ULL);
   }
 
-  ~sample() { raft::set_current_device_resource(old_mr); }
+  ~sample() { raft::resource::set_current_device_resource(old_mr); }
   void run_benchmark(::benchmark::State& state) override
   {
     std::ostringstream label_stream;

--- a/cpp/bench/prims/random/subsample.cu
+++ b/cpp/bench/prims/random/subsample.cu
@@ -64,8 +64,8 @@ template <typename T>
 struct sample : public fixture {
   sample(const sample_inputs& p)
     : params(p),
-      old_mr(rmm::mr::get_current_device_resource()),
-      pool_mr(rmm::mr::get_current_device_resource(), 2 * GiB),
+      old_mr(raft::resource::get_current_device_resource()),
+      pool_mr(raft::resource::get_current_device_resource(), 2 * GiB),
       in(make_device_vector<T, int64_t>(res, p.n_samples)),
       out(make_device_vector<T, int64_t>(res, p.n_train))
   {
@@ -73,7 +73,7 @@ struct sample : public fixture {
     raft::random::RngState r(123456ULL);
   }
 
-  ~sample() { rmm::mr::set_current_device_resource(old_mr); }
+  ~sample() { raft::set_current_device_resource(old_mr); }
   void run_benchmark(::benchmark::State& state) override
   {
     std::ostringstream label_stream;

--- a/cpp/include/raft/core/device_container_policy.hpp
+++ b/cpp/include/raft/core/device_container_policy.hpp
@@ -31,8 +31,6 @@
 
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_uvector.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
-#include <rmm/resource_ref.hpp>
 
 #include <thrust/device_ptr.h>
 
@@ -185,7 +183,7 @@ class device_uvector_policy {
   [[nodiscard]] auto make_accessor_policy() const noexcept { return const_accessor_policy{}; }
 
  private:
-  rmm::device_async_resource_ref mr_{rmm::mr::get_current_device_resource()};
+  rmm::device_async_resource_ref mr_{raft::resource::get_current_device_resource_ref()};
 };
 
 }  // namespace raft

--- a/cpp/include/raft/core/device_resources_manager.hpp
+++ b/cpp/include/raft/core/device_resources_manager.hpp
@@ -17,12 +17,12 @@
 #pragma once
 #include <raft/core/device_resources.hpp>
 #include <raft/core/device_setter.hpp>
+#include <raft/core/resource/device_memory_resource.hpp>
 
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_pool.hpp>
 #include <rmm/mr/device/cuda_memory_resource.hpp>
-#include <rmm/mr/device/per_device_resource.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -169,7 +169,7 @@ struct device_resources_manager {
           // resource
           if (params.max_mem_pool_size.value_or(1) != 0) {
             auto* upstream =
-              dynamic_cast<rmm::mr::cuda_memory_resource*>(rmm::mr::get_current_device_resource());
+              dynamic_cast<rmm::mr::cuda_memory_resource*>(resource::get_current_device_resource());
             if (upstream != nullptr) {
               result =
                 std::make_shared<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>>(

--- a/cpp/include/raft/core/device_resources_manager.hpp
+++ b/cpp/include/raft/core/device_resources_manager.hpp
@@ -176,7 +176,7 @@ struct device_resources_manager {
                   upstream,
                   params.init_mem_pool_size.value_or(rmm::percent_of_free_device_memory(50)),
                   params.max_mem_pool_size);
-              rmm::mr::set_current_device_resource(result.get());
+              raft::resource::set_current_device_resource(result.get());
             } else {
               RAFT_LOG_WARN(
                 "Pool allocation requested, but other memory resource has already been set and "

--- a/cpp/include/raft/core/resource/device_memory_resource.hpp
+++ b/cpp/include/raft/core/resource/device_memory_resource.hpp
@@ -37,42 +37,6 @@ namespace raft::resource {
  */
 
 /**
- * @brief Alias for a `cuda::mr::resource_ref` with the property
- * `cuda::mr::device_accessible`.
- */
-using device_resource_ref = rmm::device_resource_ref;
-
-/**
- * @brief Alias for a `cuda::mr::async_resource_ref` with the property
- * `cuda::mr::device_accessible`.
- */
-using device_async_resource_ref = rmm::device_async_resource_ref;
-
-/**
- * @brief Alias for a `cuda::mr::resource_ref` with the property
- * `cuda::mr::host_accessible`.
- */
-using host_resource_ref = rmm::host_resource_ref;
-
-/**
- * @brief Alias for a `cuda::mr::async_resource_ref` with the property
- * `cuda::mr::host_accessible`.
- */
-using host_async_resource_ref = rmm::host_async_resource_ref;
-
-/**
- * @brief Alias for a `cuda::mr::resource_ref` with the properties
- * `cuda::mr::host_accessible` and `cuda::mr::device_accessible`.
- */
-using host_device_resource_ref = rmm::host_device_resource_ref;
-
-/**
- * @brief Alias for a `cuda::mr::async_resource_ref` with the properties
- * `cuda::mr::host_accessible` and `cuda::mr::device_accessible`.
- */
-using host_device_async_resource_ref = rmm::host_device_async_resource_ref;
-
-/**
  * @brief Get the current device memory resource.
  *
  * @return The current device memory resource.
@@ -87,7 +51,7 @@ inline rmm::mr::device_memory_resource* get_current_device_resource()
  *
  * @return The current device memory resource reference.
  */
-inline device_async_resource_ref get_current_device_resource_ref()
+inline rmm::device_async_resource_ref get_current_device_resource_ref()
 {
   // For now, match current behavior which is to return current resource pointer
   return rmm::mr::get_current_device_resource();
@@ -111,7 +75,8 @@ inline rmm::mr::device_memory_resource* set_current_device_resource(
  * @param mr The new device memory resource reference.
  * @return The previous device memory resource reference.
  */
-inline device_async_resource_ref set_current_device_resource_ref(device_async_resource_ref mr)
+inline rmm::device_async_resource_ref set_current_device_resource_ref(
+  rmm::device_async_resource_ref mr)
 {
   return rmm::mr::set_current_device_resource_ref(mr);
 }
@@ -121,7 +86,7 @@ inline device_async_resource_ref set_current_device_resource_ref(device_async_re
  *
  * @return The previous device memory resource reference.
  */
-inline device_async_resource_ref reset_current_device_resource_ref()
+inline rmm::device_async_resource_ref reset_current_device_resource_ref()
 {
   return rmm::mr::reset_current_device_resource_ref();
 }

--- a/cpp/include/raft/neighbors/detail/cagra/utils.hpp
+++ b/cpp/include/raft/neighbors/detail/cagra/utils.hpp
@@ -258,10 +258,11 @@ class host_matrix_view_from_device {
 
 // Copy matrix src to dst. pad rows with 0 if necessary to make them 16 byte aligned.
 template <typename T, typename data_accessor>
-void copy_with_padding(raft::resources const& res,
-                       raft::device_matrix<T, int64_t, row_major>& dst,
-                       mdspan<const T, matrix_extent<int64_t>, row_major, data_accessor> src,
-                       rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
+void copy_with_padding(
+  raft::resources const& res,
+  raft::device_matrix<T, int64_t, row_major>& dst,
+  mdspan<const T, matrix_extent<int64_t>, row_major, data_accessor> src,
+  rmm::device_async_resource_ref mr = raft::resource::get_current_device_resource_ref())
 {
   size_t padded_dim = round_up_safe<size_t>(src.extent(1) * sizeof(T), 16) / sizeof(T);
 

--- a/cpp/include/raft/neighbors/detail/ivf_flat_search-inl.cuh
+++ b/cpp/include/raft/neighbors/detail/ivf_flat_search-inl.cuh
@@ -268,16 +268,17 @@ void search_impl(raft::resources const& handle,
 template <typename T,
           typename IdxT,
           typename IvfSampleFilterT = raft::neighbors::filtering::none_ivf_sample_filter>
-inline void search(raft::resources const& handle,
-                   const search_params& params,
-                   const index<T, IdxT>& index,
-                   const T* queries,
-                   uint32_t n_queries,
-                   uint32_t k,
-                   IdxT* neighbors,
-                   float* distances,
-                   rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource(),
-                   IvfSampleFilterT sample_filter    = IvfSampleFilterT())
+inline void search(
+  raft::resources const& handle,
+  const search_params& params,
+  const index<T, IdxT>& index,
+  const T* queries,
+  uint32_t n_queries,
+  uint32_t k,
+  IdxT* neighbors,
+  float* distances,
+  rmm::device_async_resource_ref mr = raft::resource::get_current_device_resource_ref(),
+  IvfSampleFilterT sample_filter    = IvfSampleFilterT())
 {
   common::nvtx::range<common::nvtx::domain::raft> fun_scope(
     "ivf_flat::search(k = %u, n_queries = %u, dim = %zu)", k, n_queries, index.dim());

--- a/cpp/include/raft/neighbors/detail/vpq_dataset.cuh
+++ b/cpp/include/raft/neighbors/detail/vpq_dataset.cuh
@@ -365,7 +365,7 @@ auto process_and_fill_codes(const raft::resources& res,
                                                         dim,
                                                         max_batch_size,
                                                         stream,
-                                                        rmm::mr::get_current_device_resource())) {
+                                                        resource::get_current_device_resource())) {
     auto batch_view = raft::make_device_matrix_view(batch.data(), ix_t(batch.size()), dim);
     auto labels     = predict_vq<label_t>(res, batch_view, vq_centers);
     dim3 blocks(div_rounding_up_safe<ix_t>(n_rows, kBlockSize / threads_per_vec), 1, 1);

--- a/cpp/include/raft/neighbors/ivf_flat-inl.cuh
+++ b/cpp/include/raft/neighbors/ivf_flat-inl.cuh
@@ -416,7 +416,7 @@ void extend(raft::resources const& handle,
  *   ...
  *   // Create a pooling memory resource with a pre-defined initial size.
  *   rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> mr(
- *     rmm::mr::get_current_device_resource(), 1024 * 1024);
+ *     raft::resource::get_current_device_resource(), 1024 * 1024);
  *   // use default search parameters
  *   ivf_flat::search_params search_params;
  *   filtering::none_ivf_sample_filter filter;
@@ -482,7 +482,7 @@ void search_with_filtering(raft::resources const& handle,
  *   ...
  *   // Create a pooling memory resource with a pre-defined initial size.
  *   rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> mr(
- *     rmm::mr::get_current_device_resource(), 1024 * 1024);
+ *     raft::resource::get_current_device_resource(), 1024 * 1024);
  *   // use default search parameters
  *   ivf_flat::search_params search_params;
  *   // Use the same allocator across multiple searches to reduce the number of

--- a/cpp/include/raft/random/multi_variable_gaussian.cuh
+++ b/cpp/include/raft/random/multi_variable_gaussian.cuh
@@ -52,7 +52,7 @@ void multi_variable_gaussian(raft::resources const& handle,
                              const multi_variable_gaussian_decomposition_method method)
 {
   detail::compute_multi_variable_gaussian_impl(
-    handle, rmm::mr::get_current_device_resource(), x, P, X, method);
+    handle, raft::resource::get_current_device_resource_ref(), x, P, X, method);
 }
 
 /** @} */

--- a/cpp/include/raft/spatial/knn/detail/ann_utils.cuh
+++ b/cpp/include/raft/spatial/knn/detail/ann_utils.cuh
@@ -498,12 +498,13 @@ struct batch_load_iterator {
    * @param stream the ordering for the host->device copies, if applicable.
    * @param mr a custom memory resource for the intermediate buffer, if applicable.
    */
-  batch_load_iterator(const T* source,
-                      size_type n_rows,
-                      size_type row_width,
-                      size_type batch_size,
-                      rmm::cuda_stream_view stream,
-                      rmm::device_async_resource_ref mr = rmm::mr::get_current_device_resource())
+  batch_load_iterator(
+    const T* source,
+    size_type n_rows,
+    size_type row_width,
+    size_type batch_size,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr = raft::resource::get_current_device_resource_ref())
     : cur_batch_(new batch(source, n_rows, row_width, batch_size, stream, mr)), cur_pos_(0)
   {
   }

--- a/cpp/template/src/cagra_example.cu
+++ b/cpp/template/src/cagra_example.cu
@@ -67,8 +67,8 @@ int main()
 
   // Set pool memory resource with 1 GiB initial pool size. All allocations use the same pool.
   rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr(
-    rmm::mr::get_current_device_resource(), 1024 * 1024 * 1024ull);
-  rmm::mr::set_current_device_resource(&pool_mr);
+    raft::resource::get_current_device_resource(), 1024 * 1024 * 1024ull);
+  raft::resource::set_current_device_resource(&pool_mr);
 
   // Alternatively, one could define a pool allocator for temporary arrays (used within RAFT
   // algorithms). In that case only the internal arrays would use the pool, any other allocation

--- a/cpp/template/src/ivf_flat_example.cu
+++ b/cpp/template/src/ivf_flat_example.cu
@@ -18,6 +18,7 @@
 
 #include <raft/core/device_mdarray.hpp>
 #include <raft/core/device_resources.hpp>
+#include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/core/resource/thrust_policy.hpp>
 #include <raft/neighbors/ivf_flat.cuh>
 #include <raft/util/cudart_utils.hpp>
@@ -133,7 +134,7 @@ int main()
   // Set pool memory resource with 1 GiB initial pool size. All allocations use the same pool.
   rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr(
     raft::resource::get_current_device_resource(), 1024 * 1024 * 1024ull);
-  raft::set_current_device_resource(&pool_mr);
+  raft::resource::set_current_device_resource(&pool_mr);
 
   // Alternatively, one could define a pool allocator for temporary arrays (used within RAFT
   // algorithms). In that case only the internal arrays would use the pool, any other allocation

--- a/cpp/template/src/ivf_flat_example.cu
+++ b/cpp/template/src/ivf_flat_example.cu
@@ -132,8 +132,8 @@ int main()
 
   // Set pool memory resource with 1 GiB initial pool size. All allocations use the same pool.
   rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr(
-    rmm::mr::get_current_device_resource(), 1024 * 1024 * 1024ull);
-  rmm::mr::set_current_device_resource(&pool_mr);
+    raft::resource::get_current_device_resource(), 1024 * 1024 * 1024ull);
+  raft::set_current_device_resource(&pool_mr);
 
   // Alternatively, one could define a pool allocator for temporary arrays (used within RAFT
   // algorithms). In that case only the internal arrays would use the pool, any other allocation

--- a/cpp/template/src/ivf_pq_example.cu
+++ b/cpp/template/src/ivf_pq_example.cu
@@ -18,6 +18,7 @@
 
 #include <raft/core/device_mdarray.hpp>
 #include <raft/core/device_resources.hpp>
+#include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/neighbors/ivf_pq.cuh>
 #include <raft/neighbors/refine.cuh>
 
@@ -93,7 +94,7 @@ int main()
   // Set pool memory resource with 1 GiB initial pool size. All allocations use the same pool.
   rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr(
     raft::resource::get_current_device_resource(), 1024 * 1024 * 1024ull);
-  raft::set_current_device_resource(&pool_mr);
+  raft::resource::set_current_device_resource(&pool_mr);
 
   // Alternatively, one could define a pool allocator for temporary arrays (used within RAFT
   // algorithms). In that case only the internal arrays would use the pool, any other allocation

--- a/cpp/template/src/ivf_pq_example.cu
+++ b/cpp/template/src/ivf_pq_example.cu
@@ -92,8 +92,8 @@ int main()
 
   // Set pool memory resource with 1 GiB initial pool size. All allocations use the same pool.
   rmm::mr::pool_memory_resource<rmm::mr::device_memory_resource> pool_mr(
-    rmm::mr::get_current_device_resource(), 1024 * 1024 * 1024ull);
-  rmm::mr::set_current_device_resource(&pool_mr);
+    raft::resource::get_current_device_resource(), 1024 * 1024 * 1024ull);
+  raft::set_current_device_resource(&pool_mr);
 
   // Alternatively, one could define a pool allocator for temporary arrays (used within RAFT
   // algorithms). In that case only the internal arrays would use the pool, any other allocation

--- a/cpp/test/core/device_resources_manager.cpp
+++ b/cpp/test/core/device_resources_manager.cpp
@@ -114,7 +114,7 @@ TEST(DeviceResourcesManager, ObeysSetters)
     EXPECT_EQ(streams_per_pool, pool.get_pool_size());
 
     auto* mr = dynamic_cast<rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource>*>(
-      rmm::mr::get_current_device_resource());
+      resource::get_current_device_resource());
 
     if (upstream_mrs[i % devices.size()] != nullptr) {
       // Expect that the current memory resource is a pool memory resource as requested

--- a/cpp/test/core/handle.cpp
+++ b/cpp/test/core/handle.cpp
@@ -287,7 +287,7 @@ TEST(Raft, WorkspaceResource)
 
   // Let's create a pooled resource
   auto pool_mr = std::shared_ptr<rmm::mr::device_memory_resource>{new rmm::mr::pool_memory_resource(
-    rmm::mr::get_current_device_resource(), rmm::percent_of_free_device_memory(50))};
+    raft::resource::get_current_device_resource(), rmm::percent_of_free_device_memory(50))};
 
   // A tiny workspace of 1MB
   size_t max_size = 1024 * 1024;
@@ -326,7 +326,7 @@ TEST(Raft, WorkspaceResourceCopy)
     resource::set_workspace_resource(
       tmp_res,
       std::shared_ptr<rmm::mr::device_memory_resource>{new rmm::mr::pool_memory_resource(
-        rmm::mr::get_current_device_resource(), rmm::percent_of_free_device_memory(50))},
+        raft::resource::get_current_device_resource(), rmm::percent_of_free_device_memory(50))},
       orig_size * 2);
 
     ASSERT_EQ(orig_mr, resource::get_workspace_resource(res));

--- a/cpp/test/mr/device/buffer.cpp
+++ b/cpp/test/mr/device/buffer.cpp
@@ -58,13 +58,12 @@ TEST(Raft, DeviceBufferAlloc)
 TEST(Raft, DeviceBufferZeroResize)
 {
   // Create a limiting_resource_adaptor to track allocations
-  auto curr_mr =
-    dynamic_cast<rmm::mr::cuda_memory_resource*>(rmm::mr::get_current_device_resource());
+  auto curr_mr = dynamic_cast<rmm::mr::cuda_memory_resource*>(raft::resource::get_current_device_resource());
   auto limit_mr =
     std::make_shared<rmm::mr::limiting_resource_adaptor<rmm::mr::cuda_memory_resource>>(curr_mr,
                                                                                         1000);
 
-  rmm::mr::set_current_device_resource(limit_mr.get());
+  raft::set_current_device_resource(limit_mr.get());
 
   cudaStream_t stream;
   RAFT_CUDA_TRY(cudaStreamCreate(&stream));
@@ -84,7 +83,7 @@ TEST(Raft, DeviceBufferZeroResize)
   // Now check that there is no memory left. (Used to not be true)
   ASSERT_EQ(0, limit_mr->get_allocated_bytes());
 
-  rmm::mr::set_current_device_resource(curr_mr);
+  raft::set_current_device_resource(curr_mr);
 
   RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
   RAFT_CUDA_TRY(cudaStreamDestroy(stream));

--- a/cpp/test/mr/device/buffer.cpp
+++ b/cpp/test/mr/device/buffer.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <raft/core/resource/device_memory_resource.hpp>
 #include <raft/util/cudart_utils.hpp>
 
 #include <rmm/device_uvector.hpp>
@@ -64,7 +65,7 @@ TEST(Raft, DeviceBufferZeroResize)
     std::make_shared<rmm::mr::limiting_resource_adaptor<rmm::mr::cuda_memory_resource>>(curr_mr,
                                                                                         1000);
 
-  raft::set_current_device_resource(limit_mr.get());
+  raft::resource::set_current_device_resource(limit_mr.get());
 
   cudaStream_t stream;
   RAFT_CUDA_TRY(cudaStreamCreate(&stream));
@@ -84,7 +85,7 @@ TEST(Raft, DeviceBufferZeroResize)
   // Now check that there is no memory left. (Used to not be true)
   ASSERT_EQ(0, limit_mr->get_allocated_bytes());
 
-  raft::set_current_device_resource(curr_mr);
+  raft::resource::set_current_device_resource(curr_mr);
 
   RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
   RAFT_CUDA_TRY(cudaStreamDestroy(stream));

--- a/cpp/test/mr/device/buffer.cpp
+++ b/cpp/test/mr/device/buffer.cpp
@@ -58,7 +58,8 @@ TEST(Raft, DeviceBufferAlloc)
 TEST(Raft, DeviceBufferZeroResize)
 {
   // Create a limiting_resource_adaptor to track allocations
-  auto curr_mr = dynamic_cast<rmm::mr::cuda_memory_resource*>(raft::resource::get_current_device_resource());
+  auto curr_mr =
+    dynamic_cast<rmm::mr::cuda_memory_resource*>(raft::resource::get_current_device_resource());
   auto limit_mr =
     std::make_shared<rmm::mr::limiting_resource_adaptor<rmm::mr::cuda_memory_resource>>(curr_mr,
                                                                                         1000);

--- a/cpp/test/random/multi_variable_gaussian.cu
+++ b/cpp/test/random/multi_variable_gaussian.cu
@@ -289,7 +289,7 @@ class MVGMdspanTest : public ::testing::TestWithParam<MVGInputs<T>> {
     raft::device_matrix_view<T, int, raft::col_major> X_view(X_d.data(), dim, nPoints);
 
     raft::random::multi_variable_gaussian(
-      handle, rmm::mr::get_current_device_resource(), x_view, P_view, X_view, method);
+      handle, raft::resource::get_current_device_resource_ref(), x_view, P_view, X_view, method);
 
     // saving the mean of the randoms in Rand_mean
     //@todo can be swapped with a API that calculates mean

--- a/docs/source/vector_search_tutorial.md
+++ b/docs/source/vector_search_tutorial.md
@@ -368,6 +368,7 @@ The RAPIDS software ecosystem makes heavy use of the [RAPIDS Memory Manager](htt
 
 As an example, the following code snippet creates a `pool_memory_resource` and sets it as the default memory resource, which means all other libraries that use RMM will now allocate their device memory from this same pool:
 ```c++
+#include <raft/core/resource/device_memory_resource.hpp>
 #include <rmm/mr/device/pool_memory_resource.hpp>
 
 rmm::mr::cuda_memory_resource cuda_mr;

--- a/docs/source/vector_search_tutorial.md
+++ b/docs/source/vector_search_tutorial.md
@@ -375,7 +375,7 @@ rmm::mr::cuda_memory_resource cuda_mr;
 // set the initial size to half of the free device memory
 auto init_size = rmm::percent_of_free_device_memory(50);
 rmm::mr::pool_memory_resource<rmm::mr::cuda_memory_resource> pool_mr{&cuda_mr, init_size};
-rmm::mr::set_current_device_resource(&pool_mr); // Updates the current device resource pointer to `pool_mr`
+raft::resource::set_current_device_resource(&pool_mr); // Updates the current device resource pointer to `pool_mr`
 ```
 
 The `raft::device_resources` object will now also use the `rmm::current_device_resource`.  This isn't limited to C++, however. Often a user will be interacting with PyTorch, RAPIDS, or Tensorflow through Python and so they can set and use RMM's `current_device_resource` [right in Python](https://github.com/rapidsai/rmm#using-rmm-in-python-code).


### PR DESCRIPTION
Fixes #2423

Adds local RAFT wrappers around `rmm::mr::get/set_current_device_resource` and `resource_ref` aliases. The idea is to localize changes needed to keep up with RMM refactoring.

The wrappers are added in cpp/include/raft/core/resource/device_memory_resource.hpp

I've marked this PR as breaking because it breaks the ABI, however the API is compatible.