### PR TITLE
[WIP] add telemetry

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -179,4 +179,4 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         with:
-          cert_concat: join(fromJSON('["${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }}", "${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }}", "${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"]'), ';')
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,6 +10,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  telemetry-setup:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+        OTEL_SERVICE_NAME: "pr-raft"
+    steps:
+      - name: Telemetry setup
+        uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
   pr-builder:
     needs:
       - changed-files
@@ -24,6 +32,7 @@ jobs:
       - wheel-tests-pylibraft
       - wheel-build-raft-dask
       - wheel-tests-raft-dask
+      - telemetry-setup
       - devcontainer
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.12
@@ -32,6 +41,7 @@ jobs:
       needs: ${{ toJSON(needs) }}
   changed-files:
     secrets: inherit
+    needs: telemetry-setup
     uses: rapidsai/shared-workflows/.github/workflows/changed-files.yaml@branch-24.12
     with:
       files_yaml: |
@@ -65,9 +75,11 @@ jobs:
           - '!thirdparty/LICENSES/**'
   checks:
     secrets: inherit
+    needs: telemetry-setup
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.12
     with:
       enable_check_generated_files: false
+      ignored_pr_jobs: telemetry-summarize
   conda-cpp-build:
     needs: checks
     secrets: inherit
@@ -145,6 +157,7 @@ jobs:
       script: ci/test_wheel_raft_dask.sh
   devcontainer:
     secrets: inherit
+    needs: telemetry-setup
     uses: rapidsai/shared-workflows/.github/workflows/build-in-devcontainer.yaml@branch-24.12
     with:
       arch: '["amd64"]'
@@ -153,3 +166,17 @@ jobs:
         sccache -z;
         build-all -DBUILD_PRIMS_BENCH=ON -DBUILD_ANN_BENCH=ON --verbose;
         sccache -s;
+  telemetry-summarize:
+    runs-on: ubuntu-latest
+    needs: pr-builder
+    if: always()
+    continue-on-error: true
+    steps:
+      - name: Load stashed telemetry env vars
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        with:
+            load_service_name: true
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        with:
+          cert_concat: join(fromJSON('["${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }}", "${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }}", "${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"]'), ';')


### PR DESCRIPTION
Adds telemetry that will send timing information about each step in the build process to a time series database, for later viewing and analytics.

Tracking issue: https://github.com/rapidsai/build-infra/issues/139

This is not expected to work right now. We are in flux regarding a time series database that is in the same private network as the build machines. @ajschmidt8 has restricted the mTLS certificates that are used for the current database to specific repos. Either he will enable those here, or we'll make the switch to the new server, and then this mechanism should work.