### PR TITLE
Disable hnswlib if not compiling shared library components of RAFT

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -602,6 +602,7 @@ if(RAFT_COMPILE_LIBRARY)
              ${RAFT_CTK_MATH_DEPENDENCIES} # TODO: Once `raft::resources` is used everywhere, this
                                            # will just be cublas
              $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX>
+             $<TARGET_NAME_IF_EXISTS:hnswlib::hnswlib>
     )
 
     # So consumers know when using libraft.so/libraft.a
@@ -616,9 +617,6 @@ if(TARGET raft_lib AND (NOT TARGET raft::raft_lib))
 endif()
 
 target_link_libraries(raft_compiled INTERFACE raft::raft $<TARGET_NAME_IF_EXISTS:raft::raft_lib>)
-if(BUILD_CAGRA_HNSWLIB)
-  target_link_libraries(raft_compiled PUBLIC hnswlib::hnswlib)
-endif()
 
 # ##################################################################################################
 # * raft_compiled_static----------------------------------------------------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -85,6 +85,10 @@ if(BUILD_CPU_ONLY)
   set(BUILD_TESTS OFF)
 endif()
 
+if(NOT RAFT_COMPILE_LIBRARY)
+  set(BUILD_CAGRA_HNSWLIB OFF)
+endif()
+
 # Needed because GoogleBenchmark changes the state of FindThreads.cmake, causing subsequent runs to
 # have different values for the `Threads::Threads` target. Setting this flag ensures
 # `Threads::Threads` is the same value across all builds so that cache hits occur
@@ -105,12 +109,8 @@ message(VERBOSE "RAFT: Disable OpenMP: ${DISABLE_OPENMP}")
 message(VERBOSE "RAFT: Enable kernel resource usage info: ${CUDA_ENABLE_KERNELINFO}")
 message(VERBOSE "RAFT: Enable lineinfo in nvcc: ${CUDA_ENABLE_LINEINFO}")
 message(VERBOSE "RAFT: Enable nvtx markers: ${RAFT_NVTX}")
-message(VERBOSE
-        "RAFT: Statically link the CUDA runtime: ${CUDA_STATIC_RUNTIME}"
-)
-message(VERBOSE
-        "RAFT: Statically link the CUDA math libraries: ${CUDA_STATIC_MATH_LIBRARIES}"
-)
+message(VERBOSE "RAFT: Statically link the CUDA runtime: ${CUDA_STATIC_RUNTIME}")
+message(VERBOSE "RAFT: Statically link the CUDA math libraries: ${CUDA_STATIC_MATH_LIBRARIES}")
 
 # Set RMM logging level
 set(RMM_LOGGING_LEVEL

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -210,9 +210,6 @@ add_library(raft::raft ALIAS raft)
 target_include_directories(
   raft INTERFACE "$<BUILD_INTERFACE:${RAFT_SOURCE_DIR}/include>" "$<INSTALL_INTERFACE:include>"
 )
-if(BUILD_CAGRA_HNSWLIB)
-  target_link_libraries(raft INTERFACE hnswlib::hnswlib)
-endif()
 
 if(NOT BUILD_CPU_ONLY)
   # Keep RAFT as lightweight as possible. Only CUDA libs and rmm should be used in global target.
@@ -619,6 +616,9 @@ if(TARGET raft_lib AND (NOT TARGET raft::raft_lib))
 endif()
 
 target_link_libraries(raft_compiled INTERFACE raft::raft $<TARGET_NAME_IF_EXISTS:raft::raft_lib>)
+if(BUILD_CAGRA_HNSWLIB)
+  target_link_libraries(raft_compiled PUBLIC hnswlib::hnswlib)
+endif()
 
 # ##################################################################################################
 # * raft_compiled_static----------------------------------------------------------------------------


### PR DESCRIPTION
As seen in https://github.com/rapidsai/cuvs/pull/465 when building newer versions of hnswlib, version conflicts are found to be not resolvable. The effect of this PR will be that `libraft-headers` conda package will not be configured with `hnswlib`.