### PR TITLE
Pin FAISS Version for raft-ann-bench

### DIFF
--- a/cpp/cmake/patches/faiss_override.json
+++ b/cpp/cmake/patches/faiss_override.json
@@ -1,9 +1,9 @@
 {
   "packages" : {
     "faiss" : {
-      "version": "1.7.4",
+      "version": "1.9.0",
       "git_url": "https://github.com/facebookresearch/faiss.git",
-      "git_tag": "main"
+      "git_tag": "v1.9.0"
     }
   }
 }


### PR DESCRIPTION
A simple PR for pinning the FAISS version to fetch the compatible tag for raft-ann-bench