### PR TITLE
Skip gtests for Rmat Lanczos tests with cuda <= 11.4

### DIFF
--- a/cpp/test/sparse/solver/lanczos.cu
+++ b/cpp/test/sparse/solver/lanczos.cu
@@ -109,6 +109,18 @@ class rmat_lanczos_tests
 
   void Run()
   {
+    int runtimeVersion;
+    cudaError_t result = cudaRuntimeGetVersion(&runtimeVersion);
+
+    if (result == cudaSuccess) {
+      int major = runtimeVersion / 1000;
+      int minor = (runtimeVersion % 1000) / 10;
+
+      // Skip gtests for CUDA 11.4.x and below because hard-coded results are causing issues.
+      // See https://github.com/rapidsai/raft/issues/2519 for more information.
+      if (major == 11 && minor <= 4) { GTEST_SKIP(); }
+    }
+
     uint64_t n_edges   = sparsity * ((long long)(1 << r_scale) * (long long)(1 << c_scale));
     uint64_t n_nodes   = 1 << std::max(r_scale, c_scale);
     uint64_t theta_len = std::max(r_scale, c_scale) * 4;


### PR DESCRIPTION
Similar to #2520, also skip gtests for cuda 11.4 on the RmatLanczosTest as well

