### PR TITLE
reduce duplication, removed unused things in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -6,22 +6,22 @@ files:
       cuda: ["11.8", "12.5"]
       arch: [x86_64, aarch64]
     includes:
-      - rapids_build
-      - build_pylibraft
+      - checks
       - cuda
       - cuda_version
+      - depends_on_cuda_python
       - depends_on_cupy
       - depends_on_distributed_ucxx
+      - depends_on_rmm
       - develop
-      - checks
-      - test_libraft
       - docs
-      - rapids_build_setuptools
+      - rapids_build
       - rapids_build_skbuild
-      - run_raft_dask
       - run_pylibraft
-      - test_python_common
+      - run_raft_dask
+      - test_libraft
       - test_pylibraft
+      - test_python_common
   test_cpp:
     output: none
     includes:
@@ -31,10 +31,10 @@ files:
     output: none
     includes:
       - cuda_version
-      - py_version
-      - test_python_common
-      - test_pylibraft
       - depends_on_cupy
+      - py_version
+      - test_pylibraft
+      - test_python_common
   checks:
     output: none
     includes:
@@ -62,8 +62,9 @@ files:
       table: tool.rapids-build-backend
       key: requires
     includes:
+      - depends_on_cuda_python
+      - depends_on_rmm
       - rapids_build
-      - build_pylibraft
   py_run_pylibraft:
     output: pyproject
     pyproject_dir: python/pylibraft
@@ -71,6 +72,8 @@ files:
       table: project
     includes:
       - cuda_wheels
+      - depends_on_cuda_python
+      - depends_on_rmm
       - run_pylibraft
   py_test_pylibraft:
     output: pyproject
@@ -79,9 +82,9 @@ files:
       table: project.optional-dependencies
       key: test
     includes:
-      - test_python_common
-      - test_pylibraft
       - depends_on_cupy
+      - test_pylibraft
+      - test_python_common
   py_build_raft_dask:
     output: pyproject
     pyproject_dir: python/raft-dask
@@ -96,16 +99,16 @@ files:
       table: tool.rapids-build-backend
       key: requires
     includes:
-      - rapids_build
       - depends_on_ucx_build
+      - rapids_build
   py_run_raft_dask:
     output: pyproject
     pyproject_dir: python/raft-dask
     extras:
       table: project
     includes:
-      - run_raft_dask
       - depends_on_distributed_ucxx
+      - run_raft_dask
   py_test_raft_dask:
     output: pyproject
     pyproject_dir: python/raft-dask
@@ -125,7 +128,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &rapids_build_backend rapids-build-backend>=0.3.0,<0.4.0.dev0
+          - rapids-build-backend>=0.3.0,<0.4.0.dev0
       - output_types: [conda]
         packages:
           - scikit-build-core>=0.10.0
@@ -180,44 +183,6 @@ dependencies:
           - matrix: {cuda: "11.2", arch: aarch64}
             packages: [nvcc_linux-aarch64=11.2]
 
-  build_pylibraft:
-    common:
-      - output_types: [conda]
-        packages:
-          - &rmm_unsuffixed rmm==25.2.*,>=0.0.0a0
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          # This index is needed for rmm-cu{11,12}.
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
-    specific:
-      - output_types: [conda, requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-            packages:
-              - &cuda_python12 cuda-python>=12.6.2,<13.0a0
-          - matrix:
-              cuda: "11.*"
-            packages:
-              - &cuda_python11 cuda-python>=11.8.5,<12.0a0
-          - matrix:
-            packages:
-              - &cuda_python cuda-python
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - &rmm_cu12 rmm-cu12==25.2.*,>=0.0.0a0
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "true"
-            packages:
-              - &rmm_cu11 rmm-cu11==25.2.*,>=0.0.0a0
-          - {matrix: null, packages: [*rmm_unsuffixed] }
   checks:
     common:
       - output_types: [conda, requirements]
@@ -398,13 +363,6 @@ dependencies:
           - recommonmark
           - sphinx-copybutton
           - sphinx-markdown-tables
-  rapids_build_setuptools:
-    common:
-      - output_types: [requirements, pyproject]
-        packages:
-          - wheel
-          - setuptools
-          - *rapids_build_backend
   py_version:
     specific:
       - output_types: conda
@@ -429,42 +387,6 @@ dependencies:
       - output_types: [conda, pyproject]
         packages:
           - numpy>=1.23,<3.0a0
-      - output_types: [conda]
-        packages:
-          - *rmm_unsuffixed
-      - output_types: requirements
-        packages:
-          # pip recognizes the index as a global option for the requirements.txt file
-          # This index is needed for cudf and rmm.
-          - --extra-index-url=https://pypi.nvidia.com
-          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
-    specific:
-      - output_types: [conda, requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-            packages:
-              - *cuda_python12
-          - matrix:
-              cuda: "11.*"
-            packages:
-              - *cuda_python11
-          - matrix:
-            packages:
-              - *cuda_python
-      - output_types: [requirements, pyproject]
-        matrices:
-          - matrix:
-              cuda: "12.*"
-              cuda_suffixed: "true"
-            packages:
-              - *rmm_cu12
-          - matrix:
-              cuda: "11.*"
-              cuda_suffixed: "true"
-            packages:
-              - *rmm_cu11
-          - {matrix: null, packages: [*rmm_unsuffixed]}
   run_raft_dask:
     common:
       - output_types: [conda, pyproject]
@@ -511,6 +433,21 @@ dependencies:
         packages:
           - scikit-learn
           - scipy
+  depends_on_cuda_python:
+    specific:
+      - output_types: [conda, requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+            packages:
+              - cuda-python>=12.6.2,<13.0a0
+          - matrix:
+              cuda: "11.*"
+            packages:
+              - cuda-python>=11.8.5,<12.0a0
+          - matrix:
+            packages:
+              - cuda-python
   depends_on_distributed_ucxx:
     common:
       - output_types: conda
@@ -537,6 +474,33 @@ dependencies:
             packages:
               - distributed-ucxx-cu11==0.42.*,>=0.0.0a0
           - {matrix: null, packages: [*distributed_ucxx_unsuffixed]}
+  depends_on_rmm:
+    common:
+      - output_types: conda
+        packages:
+          - &rmm_unsuffixed rmm==25.2.*,>=0.0.0a0
+      - output_types: requirements
+        packages:
+          # pip recognizes the index as a global option for the requirements.txt file
+          # This index is needed for rmm-cu{11,12}.
+          - --extra-index-url=https://pypi.nvidia.com
+          - --extra-index-url=https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+    specific:
+      - output_types: [requirements, pyproject]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - rmm-cu12==25.2.*,>=0.0.0a0
+          - matrix:
+              cuda: "11.*"
+              cuda_suffixed: "true"
+            packages:
+              - rmm-cu11==25.2.*,>=0.0.0a0
+          - matrix:
+            packages:
+              - *rmm_unsuffixed
   depends_on_ucx_build:
     common:
       - output_types: conda


### PR DESCRIPTION
Proposes some small cleanup for `dependencies.yaml`

* removes `rapids_build_setuptools` dependency group
  - *#2497 removed the last use of `setuptools` here*
* breaks `cuda-python` and `rmm` out into `depends_on_*` groups to reduce duplication, and for consistency with other RAPIDS projects ([docs explaining this](https://github.com/rapidsai/build-planning/blob/d9e3c606d95c835ee384ac6480a4af0ac6cb024a/docs/docs/packaging.md#L181))
* alphabetizes lists