### PR TITLE
Add missing `#include <cstdint>`

### DIFF
--- a/cpp/include/raft/util/integer_utils.hpp
+++ b/cpp/include/raft/util/integer_utils.hpp
@@ -25,6 +25,7 @@
 
 #include <raft/core/detail/macros.hpp>
 
+#include <cstdint>
 #include <limits>
 #include <stdexcept>
 #include <type_traits>


### PR DESCRIPTION
This is needed to define `uint64_t` later on.