### PR TITLE
Optimize euclidian distance in raft refine phase

### DIFF
--- a/cpp/include/raft/neighbors/detail/refine_host-inl.hpp
+++ b/cpp/include/raft/neighbors/detail/refine_host-inl.hpp
@@ -208,6 +208,145 @@ inline float euclidean_distance_squared<distance_comp_l2, float, ::std::uint8_t>
   return dsum;
 }
 
+template<>
+inline float euclidean_distance_squared<distance_comp_inner, float, float>(
+  float const* a, float const* b, size_t n) {
+
+  int n_rounded = n - (n % 4);
+
+  float32x4_t vreg_dsum = vdupq_n_f32(0.f);
+  for (int i = 0; i < n_rounded; i += 4) {
+    float32x4_t vreg_a = vld1q_f32(&a[i]);
+    float32x4_t vreg_b = vld1q_f32(&b[i]);
+    vreg_a = vnegq_f32(vreg_a);
+    vreg_dsum = vfmaq_f32(vreg_dsum, vreg_a, vreg_b);
+  }
+
+  float dsum = vaddvq_f32(vreg_dsum);
+  for (int i = n_rounded; i < n; ++i) {
+      dsum += -a[i] * b[i];
+  }
+
+  return dsum;
+}
+
+template<>
+inline float euclidean_distance_squared<distance_comp_inner, float, ::std::int8_t>(
+  ::std::int8_t const* a, ::std::int8_t const* b, size_t n) {
+
+  int n_rounded = n - (n % 16);
+  float dsum = 0.f;
+
+  if (n_rounded > 0) {
+    float32x4_t vreg_dsum_fp32_0 = vdupq_n_f32(0.f);
+    float32x4_t vreg_dsum_fp32_1 = vreg_dsum_fp32_0;
+    float32x4_t vreg_dsum_fp32_2 = vreg_dsum_fp32_0;
+    float32x4_t vreg_dsum_fp32_3 = vreg_dsum_fp32_0;
+
+    for (int i = 0; i < n_rounded; i += 16) {
+      int8x16_t vreg_a = vld1q_s8(&a[i]);
+      int16x8_t vreg_a_s16_0 = vmovl_s8(vget_low_s8(vreg_a));
+      int16x8_t vreg_a_s16_1 = vmovl_s8(vget_high_s8(vreg_a));
+
+      int8x16_t vreg_b = vld1q_s8(&b[i]);
+      int16x8_t vreg_b_s16_0 = vmovl_s8(vget_low_s8(vreg_b));
+      int16x8_t vreg_b_s16_1 = vmovl_s8(vget_high_s8(vreg_b));
+
+      # if 1
+      vreg_a_s16_0 = vmulq_s16(vreg_a_s16_0, vreg_b_s16_0);
+      vreg_a_s16_1 = vmulq_s16(vreg_a_s16_1, vreg_b_s16_1);
+
+      float32x4_t vreg_res_fp32_0 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(vreg_a_s16_0)));
+      float32x4_t vreg_res_fp32_1 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(vreg_a_s16_0)));
+      float32x4_t vreg_res_fp32_2 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(vreg_a_s16_1)));
+      float32x4_t vreg_res_fp32_3 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(vreg_a_s16_1)));
+
+      vreg_dsum_fp32_0 = vsubq_f32(vreg_dsum_fp32_0, vreg_res_fp32_0);
+      vreg_dsum_fp32_1 = vsubq_f32(vreg_dsum_fp32_1, vreg_res_fp32_1);
+      vreg_dsum_fp32_2 = vsubq_f32(vreg_dsum_fp32_2, vreg_res_fp32_2);
+      vreg_dsum_fp32_3 = vsubq_f32(vreg_dsum_fp32_3, vreg_res_fp32_3);
+      #else
+      // TODO: WILL BE REMOVED BEFORE MERGE
+      vreg_a_s16_0 = vnegq_s16(vreg_a_s16_0);
+      vreg_a_s16_1 = vnegq_s16(vreg_a_s16_1);
+
+      float32x4_t vreg_a_fp32_0 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(vreg_a_s16_0)));
+      float32x4_t vreg_b_fp32_0 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(vreg_b_s16_0)));
+      vreg_dsum_fp32_0 = vfmaq_f32(vreg_dsum_fp32_0, vreg_a_fp32_0, vreg_b_fp32_0);
+      float32x4_t vreg_a_fp32_1 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(vreg_a_s16_0)));
+      float32x4_t vreg_b_fp32_1 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(vreg_b_s16_0)));
+      vreg_dsum_fp32_1 = vfmaq_f32(vreg_dsum_fp32_1, vreg_a_fp32_1, vreg_b_fp32_1);
+      float32x4_t vreg_a_fp32_2 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(vreg_a_s16_1)));
+      float32x4_t vreg_b_fp32_2 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(vreg_b_s16_1)));
+      vreg_dsum_fp32_2 = vfmaq_f32(vreg_dsum_fp32_2, vreg_a_fp32_2, vreg_b_fp32_2);
+      float32x4_t vreg_a_fp32_3 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(vreg_a_s16_1)));
+      float32x4_t vreg_b_fp32_3 = vcvtq_f32_s32(vmovl_s16(vget_high_s16(vreg_b_s16_1)));
+      vreg_dsum_fp32_3 = vfmaq_f32(vreg_dsum_fp32_3, vreg_a_fp32_3, vreg_b_fp32_3);
+      #endif
+    }
+
+    vreg_dsum_fp32_0 = vaddq_f32(vreg_dsum_fp32_0, vreg_dsum_fp32_1);
+    vreg_dsum_fp32_2 = vaddq_f32(vreg_dsum_fp32_2, vreg_dsum_fp32_3);
+    vreg_dsum_fp32_0 = vaddq_f32(vreg_dsum_fp32_0, vreg_dsum_fp32_2);
+
+    dsum = vaddvq_f32(vreg_dsum_fp32_0); // faddp
+  }
+
+  for (int i = n_rounded; i < n; ++i) {
+      dsum += -a[i] * b[i];
+  }
+
+  return dsum;
+}
+
+template<>
+inline float euclidean_distance_squared<distance_comp_inner, float, ::std::uint8_t>(::std::uint8_t const* a, ::std::uint8_t const* b, size_t n) {
+  int n_rounded = n - (n % 16);
+  float dsum = 0.f;
+
+  if (n_rounded > 0) {
+    float32x4_t vreg_dsum_fp32_0 = vdupq_n_f32(0.f);
+    float32x4_t vreg_dsum_fp32_1 = vreg_dsum_fp32_0;
+    float32x4_t vreg_dsum_fp32_2 = vreg_dsum_fp32_0;
+    float32x4_t vreg_dsum_fp32_3 = vreg_dsum_fp32_0;
+
+    for (int i = 0; i < n_rounded; i += 16) {
+      uint8x16_t vreg_a = vld1q_u8(&a[i]);
+      uint16x8_t vreg_a_u16_0 = vmovl_u8(vget_low_u8(vreg_a));
+      uint16x8_t vreg_a_u16_1 = vmovl_u8(vget_high_u8(vreg_a));
+
+      uint8x16_t vreg_b = vld1q_u8(&b[i]);
+      uint16x8_t vreg_b_u16_0 = vmovl_u8(vget_low_u8(vreg_b));
+      uint16x8_t vreg_b_u16_1 = vmovl_u8(vget_high_u8(vreg_b));
+
+      vreg_a_u16_0 = vmulq_u16(vreg_a_u16_0, vreg_b_u16_0);
+      vreg_a_u16_1 = vmulq_u16(vreg_a_u16_1, vreg_b_u16_1);
+
+      float32x4_t vreg_res_fp32_0 = vcvtq_f32_u32(vmovl_u16(vget_low_u16(vreg_a_u16_0)));
+      float32x4_t vreg_res_fp32_1 = vcvtq_f32_u32(vmovl_u16(vget_high_u16(vreg_a_u16_0)));
+      float32x4_t vreg_res_fp32_2 = vcvtq_f32_u32(vmovl_u16(vget_low_u16(vreg_a_u16_1)));
+      float32x4_t vreg_res_fp32_3 = vcvtq_f32_u32(vmovl_u16(vget_high_u16(vreg_a_u16_1)));
+
+      vreg_dsum_fp32_0 = vsubq_f32(vreg_dsum_fp32_0, vreg_res_fp32_0);
+      vreg_dsum_fp32_1 = vsubq_f32(vreg_dsum_fp32_1, vreg_res_fp32_1);
+      vreg_dsum_fp32_2 = vsubq_f32(vreg_dsum_fp32_2, vreg_res_fp32_2);
+      vreg_dsum_fp32_3 = vsubq_f32(vreg_dsum_fp32_3, vreg_res_fp32_3);
+    }
+
+    vreg_dsum_fp32_0 = vaddq_f32(vreg_dsum_fp32_0, vreg_dsum_fp32_1);
+    vreg_dsum_fp32_2 = vaddq_f32(vreg_dsum_fp32_2, vreg_dsum_fp32_3);
+    vreg_dsum_fp32_0 = vaddq_f32(vreg_dsum_fp32_0, vreg_dsum_fp32_2);
+
+    dsum = vaddvq_f32(vreg_dsum_fp32_0); // faddp
+  }
+
+  for (int i = n_rounded; i < n; ++i) {
+      dsum += -a[i] * b[i];
+  }
+
+  return dsum;
+}
+
 #endif // defined(__arm__) || defined(__aarch64__)
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
<!--

Thank you for contributing to RAFT :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

### Initial issue

Originally written code (below) generated serial assembly and used strictly-ordered `fadda` instructions (at least on gcc & clang). That resulted in suboptimal performance.
```c++
for (size_t k = 0; k < dim; k++) {
  distance += DC::template eval<DistanceT>(query[k], row[k]);
}
```

### Proposed solution

This PR provides optimized generic reduction using used partial vector sum (below), that helps vectorization but looses strcictly-ordered limitation.
```c++
template <typename DC, typename DistanceT, typename DataT>
DistanceT euclidean_distance_squared_generic(DataT const* a, DataT const* b, size_t n) {
  // vector register capacity in elements
  size_t constexpr vreg_len = (128 / 8) / sizeof(DistanceT);
  // unroll factor = vector register capacity * number of ports;
  size_t constexpr unroll_factor = vreg_len * 4;

  // unroll factor is a power of two
  size_t n_rounded = n & (0xFFFFFFFF ^ (unroll_factor - 1));
  DistanceT distance[unroll_factor] = {0};

  for (size_t i = 0; i < n_rounded; i += unroll_factor) {
    for (size_t j = 0; j < unroll_factor; ++j) {
      distance[j] += DC::template eval<DistanceT>(a[i + j], b[i + j]);
    }
  }

  for (size_t i = n_rounded; i < n; ++i) {
    distance[i] += DC::template eval<DistanceT>(a[i], b[i]);
  }

  for (size_t i = 1; i < unroll_factor; ++i) {
    distance[0] += distance[i];
  }

  return distance[0];
}
```
Also it adds NEON implementation with intrinsics which provided further speedup on certain test cases (can be removed if arch-specific code is undesired).

### Results
![image](https://github.com/user-attachments/assets/24131d06-fd75-4490-b758-20a21f376ea9)

