### PR TITLE
Use SPDX license identifier in pyproject.toml

### DIFF
--- a/python/libraft/pyproject.toml
+++ b/python/libraft/pyproject.toml
@@ -28,7 +28,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "librmm==25.4.*,>=0.0.0a0",

--- a/python/pylibraft/pyproject.toml
+++ b/python/pylibraft/pyproject.toml
@@ -28,7 +28,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "cuda-python",

--- a/python/raft-dask/pyproject.toml
+++ b/python/raft-dask/pyproject.toml
@@ -28,7 +28,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "NVIDIA Corporation" },
 ]
-license = { text = "Apache 2.0" }
+license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "dask-cuda==25.4.*,>=0.0.0a0",


### PR DESCRIPTION
This uses an SPDX identifier for the project `license` field in `pyproject.toml`.

xref: https://github.com/rapidsai/build-planning/issues/152
