### PR TITLE
`#include <numeric>` for `std::iota`

### DIFF
--- a/cpp/bench/prims/core/copy.cu
+++ b/cpp/bench/prims/core/copy.cu
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include <common/benchmark.hpp>
 
 #include <raft/core/copy.cuh>
@@ -26,6 +25,7 @@
 #include <raft/thirdparty/mdspan/include/experimental/mdspan>
 
 #include <cstdint>
+#include <numeric>
 
 namespace raft::bench::core {
 

--- a/cpp/include/raft/comms/nccl_clique.hpp
+++ b/cpp/include/raft/comms/nccl_clique.hpp
@@ -21,6 +21,8 @@
 
 #include <nccl.h>
 
+#include <numeric>
+
 /**
  * @brief Error checking macro for NCCL runtime API functions.
  *

--- a/cpp/include/raft/neighbors/detail/nn_descent.cuh
+++ b/cpp/include/raft/neighbors/detail/nn_descent.cuh
@@ -50,6 +50,7 @@
 #include <omp.h>
 
 #include <limits>
+#include <numeric>
 #include <optional>
 #include <queue>
 #include <random>


### PR DESCRIPTION
I'm seeing CI failures in cuvs over

```
/home/coder/.conda/envs/rapids/include/raft/comms/nccl_clique.hpp(68): error: namespace "std" has no member "iota"
      std::iota(device_ids_.begin(), device_ids_.end(), 0);
```

This seems to be be cause we're using `std::iota` without including the header. Fix.

