### PR TITLE
Update all `conda_build_config.yaml`s RAPIDS UCX version

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -73,8 +73,11 @@ for FILE in python/*/pyproject.toml; do
   done
 done
 
-sed_runner "/^ucx_py_version:$/ {n;s/.*/  - \"${NEXT_UCXX_SHORT_TAG_PEP440}.*\"/}" conda/recipes/raft-dask/conda_build_config.yaml
-sed_runner "/^ucxx_version:$/ {n;s/.*/  - \"${NEXT_UCXX_SHORT_TAG_PEP440}.*\"/}" conda/recipes/raft-dask/conda_build_config.yaml
+# RAPIDS UCX version
+for FILE in conda/recipes/*/conda_build_config.yaml; do
+  sed_runner "/^ucx_py_version:$/ {n;s/.*/  - \"${NEXT_UCXX_SHORT_TAG_PEP440}.*\"/}" "${FILE}"
+  sed_runner "/^ucxx_version:$/ {n;s/.*/  - \"${NEXT_UCXX_SHORT_TAG_PEP440}.*\"/}" "${FILE}"
+done
 
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"


### PR DESCRIPTION
Instead of hard-coding a few `conda_build_config.yaml`s to replace RAPIDS UCX versions in, glob all of them and replace in each one. This will be robust to package additions, renames, and RAPIDS UCX dependencies added in different places.