### PR TITLE
Replace `cub::Sum` and `cub::Max` with `cuda::std::plus` and `cuda::maximum`

### DIFF
--- a/cpp/include/raft/sparse/convert/detail/bitmap_to_csr.cuh
+++ b/cpp/include/raft/sparse/convert/detail/bitmap_to_csr.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
+#include <cuda/std/functional>
 #include <thrust/copy.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/discard_iterator.h>
@@ -102,7 +103,7 @@ RAFT_KERNEL __launch_bounds__(bitmap_to_csr_tpb) calc_nnz_by_rows_kernel(const b
     }
     l_sum += static_cast<nnz_t>(raft::detail::popc(l_bitmap));
   }
-  g_sum = BlockReduce(reduce_storage).Reduce(l_sum, cub::Sum());
+  g_sum = BlockReduce(reduce_storage).Reduce(l_sum, cuda::std::plus{});
   stg(g_sum, sub_col_nnz + sub_col + row * num_sub_cols, tid == 0);
 }
 

--- a/cpp/tests/linalg/map_then_reduce.cu
+++ b/cpp/tests/linalg/map_then_reduce.cu
@@ -33,14 +33,6 @@
 
 #include <limits>
 
-#if CCCL_MAJOR_VERSION >= 3
-using minimum = cuda::minimum;
-using maximum = cuda::maximum;
-#else
-using minimum = cub::Min;
-using maximum = cub::Max;
-#endif
-
 namespace raft {
 namespace linalg {
 
@@ -167,6 +159,12 @@ class MapGenericReduceTest : public ::testing::Test {
 
   void testMin()
   {
+#if CCCL_MAJOR_VERSION >= 3
+    using cuda::minimum;
+#else
+    using minimum = cub::Min;
+#endif
+
     OutType neutral  = std::numeric_limits<InType>::max();
     auto output_view = raft::make_device_scalar_view(output.data());
     auto input_view  = raft::make_device_vector_view<const InType>(
@@ -177,6 +175,11 @@ class MapGenericReduceTest : public ::testing::Test {
   }
   void testMax()
   {
+#if CCCL_MAJOR_VERSION >= 3
+    using cuda::maximum;
+#else
+    using maximum = cub::Max;
+#endif
     OutType neutral  = std::numeric_limits<InType>::min();
     auto output_view = raft::make_device_scalar_view(output.data());
     auto input_view  = raft::make_device_vector_view<const InType>(

--- a/cpp/tests/linalg/map_then_reduce.cu
+++ b/cpp/tests/linalg/map_then_reduce.cu
@@ -33,6 +33,14 @@
 
 #include <limits>
 
+#if CCCL_MAJOR_VERSION >= 3
+using minimum = cuda::minimum;
+using maximum = cuda::maximum;
+#else
+using minimum = cub::Min;
+using maximum = cub::Max;
+#endif
+
 namespace raft {
 namespace linalg {
 
@@ -163,7 +171,7 @@ class MapGenericReduceTest : public ::testing::Test {
     auto output_view = raft::make_device_scalar_view(output.data());
     auto input_view  = raft::make_device_vector_view<const InType>(
       input.data(), static_cast<std::uint32_t>(input.size()));
-    map_reduce(handle, input_view, output_view, neutral, raft::identity_op{}, cuda::minimum{});
+    map_reduce(handle, input_view, output_view, neutral, raft::identity_op{}, minimum{});
     EXPECT_TRUE(raft::devArrMatch(
       OutType(1), output.data(), 1, raft::Compare<OutType>(), resource::get_cuda_stream(handle)));
   }
@@ -173,7 +181,7 @@ class MapGenericReduceTest : public ::testing::Test {
     auto output_view = raft::make_device_scalar_view(output.data());
     auto input_view  = raft::make_device_vector_view<const InType>(
       input.data(), static_cast<std::uint32_t>(input.size()));
-    map_reduce(handle, input_view, output_view, neutral, raft::identity_op{}, cuda::maximum{});
+    map_reduce(handle, input_view, output_view, neutral, raft::identity_op{}, maximum{});
     EXPECT_TRUE(raft::devArrMatch(
       OutType(5), output.data(), 1, raft::Compare<OutType>(), resource::get_cuda_stream(handle)));
   }

--- a/cpp/tests/linalg/map_then_reduce.cu
+++ b/cpp/tests/linalg/map_then_reduce.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2018-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@
 
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
+
+#include <cuda/functional>
 
 #include <gtest/gtest.h>
 
@@ -161,7 +163,7 @@ class MapGenericReduceTest : public ::testing::Test {
     auto output_view = raft::make_device_scalar_view(output.data());
     auto input_view  = raft::make_device_vector_view<const InType>(
       input.data(), static_cast<std::uint32_t>(input.size()));
-    map_reduce(handle, input_view, output_view, neutral, raft::identity_op{}, cub::Min());
+    map_reduce(handle, input_view, output_view, neutral, raft::identity_op{}, cuda::minimum{});
     EXPECT_TRUE(raft::devArrMatch(
       OutType(1), output.data(), 1, raft::Compare<OutType>(), resource::get_cuda_stream(handle)));
   }
@@ -171,7 +173,7 @@ class MapGenericReduceTest : public ::testing::Test {
     auto output_view = raft::make_device_scalar_view(output.data());
     auto input_view  = raft::make_device_vector_view<const InType>(
       input.data(), static_cast<std::uint32_t>(input.size()));
-    map_reduce(handle, input_view, output_view, neutral, raft::identity_op{}, cub::Max());
+    map_reduce(handle, input_view, output_view, neutral, raft::identity_op{}, cuda::maximum{});
     EXPECT_TRUE(raft::devArrMatch(
       OutType(5), output.data(), 1, raft::Compare<OutType>(), resource::get_cuda_stream(handle)));
   }


### PR DESCRIPTION
The former is deprecated and will be removed in a future release of CCCL
