### PR TITLE
Use conda-build instead of conda-mambabuild

### DIFF
--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -17,7 +17,7 @@ rapids-logger "Begin cpp build"
 
 sccache --zero-stats
 
-RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry mambabuild \
+RAPIDS_PACKAGE_VERSION=$(rapids-generate-version) rapids-conda-retry build \
   conda/recipes/libraft
 
 sccache --show-adv-stats

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -25,7 +25,7 @@ sccache --zero-stats
 
 # TODO: Remove `--no-test` flags once importing on a CPU
 # node works correctly
-rapids-conda-retry mambabuild \
+rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   conda/recipes/pylibraft
@@ -33,7 +33,7 @@ rapids-conda-retry mambabuild \
 sccache --show-adv-stats
 sccache --zero-stats
 
-rapids-conda-retry mambabuild \
+rapids-conda-retry build \
   --no-test \
   --channel "${CPP_CHANNEL}" \
   --channel "${RAPIDS_CONDA_BLD_OUTPUT_DIR}" \


### PR DESCRIPTION
This changes from `conda mambabuild` to `conda build`. Conda now uses the mamba solver so no performance regressions are expected.

This is a temporary change as we plan to migrate to `rattler-build` in the near future. However, this is needed sooner to drop `boa` and unblock Python 3.13 migrations.

xref: https://github.com/rapidsai/build-infra/issues/149
