### PR TITLE
Swap `blocks` and `threads_per_block` in `compute_graph_laplacian`

### DIFF
--- a/cpp/include/raft/sparse/linalg/detail/laplacian.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/laplacian.cuh
@@ -101,7 +101,7 @@ auto compute_graph_laplacian(
   auto static constexpr const threads_per_block = 256;
   auto blocks = std::min(int((dim + threads_per_block - 1) / threads_per_block), 65535);
   auto stream = resource::get_cuda_stream(res);
-  detail::compute_graph_laplacian_kernel<<<threads_per_block, blocks, 0, stream>>>(
+  detail::compute_graph_laplacian_kernel<<<blocks, threads_per_block, 0, stream>>>(
     result.get_elements().data(),
     result_structure.get_indices().data(),
     result_structure.get_indptr().data(),


### PR DESCRIPTION
These were incorrectly ordered before, leading to errors on larger data in `cuml.UMAP`.

Fixes https://github.com/rapidsai/cuml/issues/6370.