### PR TITLE
[Fix] the bug of `spectral` illegal memory access

### DIFF
--- a/cpp/include/raft/sparse/solver/detail/lanczos.cuh
+++ b/cpp/include/raft/sparse/solver/detail/lanczos.cuh
@@ -1815,7 +1815,7 @@ auto lanczos_smallest(
   raft::copy(&res, output.data_handle(), 1, stream);
   resource::sync_stream(handle, stream);
 
-  auto uu  = raft::make_device_matrix<ValueTypeT>(handle, 0, nEigVecs);
+  auto uu  = raft::make_device_matrix<ValueTypeT>(handle, 1, nEigVecs);
   int iter = ncv;
   while (res > tol && iter < maxIter) {
     auto beta_view = raft::make_device_matrix_view<ValueTypeT, uint32_t, raft::row_major>(


### PR DESCRIPTION
- When `β == 0`, the `y` in [cublas::gemv](https://docs.nvidia.com/cuda/cublas/#cublas-t-gemv) shouldn't be read, but older cuBLAS versions (e.g., CUDA 11.4) may still access it.
- I reproduced the issue and fixed it locally with this PR, but I'm not fully sure it works in the nightly environment. It's best to add CUDA 11.4 testing to the PR CI.