### PR TITLE
Relax max duplicates in batched NN Descent

### DIFF
--- a/cpp/tests/neighbors/ann_nn_descent.cu
+++ b/cpp/tests/neighbors/ann_nn_descent.cu
@@ -137,7 +137,8 @@ class AnnNNDescentBatchTest : public ::testing::TestWithParam<AnnNNDescentBatchI
                                   ps.graph_degree,
                                   0.01,
                                   min_recall,
-                                  true));
+                                  true,
+                                  static_cast<size_t>(ps.graph_degree)));
     }
   }
 


### PR DESCRIPTION
As discussed, relaxing max duplicates for batch NN Descent for now to not block other PRs.

Related fix and issue in cuVS
- https://github.com/rapidsai/cuvs/pull/770
- https://github.com/rapidsai/cuvs/issues/771