### PR TITLE
Revert "Temporarily increase `max_days_without_success` (#2602)"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,8 +56,6 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: raft
-          # Tracking Issue: https://github.com/rapidsai/raft/issues/2601
-          max_days_without_success: 30
   changed-files:
     secrets: inherit
     needs: telemetry-setup


### PR DESCRIPTION
This PR adds the nightly CI check back and removes the temporarily increase length.