### PR TITLE
Fix building cutlass

### DIFF
--- a/cpp/cmake/thirdparty/get_cutlass.cmake
+++ b/cpp/cmake/thirdparty/get_cutlass.cmake
@@ -43,7 +43,7 @@ function(find_and_configure_cutlass)
   rapids_cpm_package_details(cutlass version repository tag shallow exclude)
 
   include("${rapids-cmake-dir}/cpm/detail/generate_patch_command.cmake")
-  rapids_cpm_generate_patch_command(cutlass ${version} patch_command)
+  rapids_cpm_generate_patch_command(cutlass ${version} patch_command False)
 
   rapids_cpm_find(
     NvidiaCutlass ${version}


### PR DESCRIPTION
rapids-cmake [recently](https://github.com/rapidsai/rapids-cmake/pull/801) changed the signature of `rapids_cpm_generate_patch_command`, adding a third argument.

This is currently [breaking](https://github.com/NVIDIA/cccl/actions/runs/14054872547/job/39352044153?pr=4253#step:6:9536) CCCL CI 