### PR TITLE
Remove CUDA whole compilation ODR violations

### DIFF
--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -30,11 +30,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     list(APPEND RAFT_CUDA_FLAGS -Werror=all-warnings)
   endif()
 
-  # Allow invalid CUDA kernels in the short term
-  if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8.0)
-    list(APPEND RAFT_CUDA_FLAGS -static-global-template-stub=false)
-  endif()
-
 endif()
 
 if(CUDA_LOG_COMPILE_TIME)

--- a/cpp/include/raft/core/detail/macros.hpp
+++ b/cpp/include/raft/core/detail/macros.hpp
@@ -86,33 +86,7 @@
 // as a weak symbol rather than a global."
 #define RAFT_WEAK_FUNCTION __attribute__((weak))
 
-// The RAFT_HIDDEN_FUNCTION specificies that the function will be hidden
-// and therefore not callable by consumers of raft when compiled as
-// a shared library.
-//
-// Hidden visibility also ensures that the linker doesn't de-duplicate the
-// symbol across multiple `.so`. This allows multiple libraries to embed raft
-// without issue
-#define RAFT_HIDDEN_FUNCTION __attribute__((visibility("hidden")))
-
-// The RAFT_KERNEL specificies that a kernel has hidden visibility
-//
-// Raft needs to ensure that the visibility of its __global__ function
-// templates have hidden visibility ( default is weak visibility).
-//
-// When kernls have weak visibility it means that if two dynamic libraries
-// both contain identical instantiations of a RAFT template, then the linker
-// will discard one of the two instantiations and use only one of them.
-//
-// Do to unique requirements of how the CUDA works this de-deduplication
-// can lead to the wrong kernels being called ( SM version being wrong ),
-// silently no kernel being called at all, or cuda runtime errors being
-// thrown.
-//
-// https://github.com/rapidsai/raft/issues/1722
-#if defined(__CUDACC_RDC__)
-#define RAFT_KERNEL RAFT_HIDDEN_FUNCTION __global__ void
-#elif defined(_RAFT_HAS_CUDA)
+#if defined(_RAFT_HAS_CUDA)
 #define RAFT_KERNEL static __global__ void
 #else
 #define RAFT_KERNEL static void

--- a/cpp/include/raft/core/detail/macros.hpp
+++ b/cpp/include/raft/core/detail/macros.hpp
@@ -86,7 +86,33 @@
 // as a weak symbol rather than a global."
 #define RAFT_WEAK_FUNCTION __attribute__((weak))
 
-#if defined(_RAFT_HAS_CUDA)
+// The RAFT_HIDDEN_FUNCTION specificies that the function will be hidden
+// and therefore not callable by consumers of raft when compiled as
+// a shared library.
+//
+// Hidden visibility also ensures that the linker doesn't de-duplicate the
+// symbol across multiple `.so`. This allows multiple libraries to embed raft
+// without issue
+#define RAFT_HIDDEN_FUNCTION __attribute__((visibility("hidden")))
+
+// The RAFT_KERNEL specificies that a kernel has hidden visibility
+//
+// Raft needs to ensure that the visibility of its __global__ function
+// templates have hidden visibility ( default is weak visibility).
+//
+// When kernls have weak visibility it means that if two dynamic libraries
+// both contain identical instantiations of a RAFT template, then the linker
+// will discard one of the two instantiations and use only one of them.
+//
+// Do to unique requirements of how the CUDA works this de-deduplication
+// can lead to the wrong kernels being called ( SM version being wrong ),
+// silently no kernel being called at all, or cuda runtime errors being
+// thrown.
+//
+// https://github.com/rapidsai/raft/issues/1722
+#if defined(__CUDACC_RDC__)
+#define RAFT_KERNEL RAFT_HIDDEN_FUNCTION __global__ void
+#elif defined(_RAFT_HAS_CUDA)
 #define RAFT_KERNEL static __global__ void
 #else
 #define RAFT_KERNEL static void


### PR DESCRIPTION
Reference https://github.com/rapidsai/build-infra/issues/38

It turns out there were no ODR violations. There might have been some possibly when the original issue was created, but it's likely those kernels ended up moving to cuVS between then and now.