### PR TITLE
Add UCXX and NCCL to `libraft` conda recipe

### DIFF
--- a/conda/recipes/libraft/conda_build_config.yaml
+++ b/conda/recipes/libraft/conda_build_config.yaml
@@ -19,6 +19,12 @@ c_stdlib_version:
 cmake_version:
   - ">=3.30.4"
 
+ucxx_version:
+  - "0.44.*"
+
+nccl_version:
+  - ">=2.19"
+
 # The CTK libraries below are missing from the conda-forge::cudatoolkit package
 # for CUDA 11. The "*_host_*" version specifiers correspond to `11.8` packages
 # and the "*_run_*" version specifiers correspond to `11.x` packages.

--- a/conda/recipes/libraft/recipe.yaml
+++ b/conda/recipes/libraft/recipe.yaml
@@ -79,8 +79,8 @@ cache:
           - libcusparse-dev
       - librmm =${{ minor_version }}
       - nccl ${{ nccl_version }}
-      - ucxx ${{ ucxx_version }}
       - rapids-logger =0.1
+      - ucxx ${{ ucxx_version }}
 
 outputs:
   - package:
@@ -105,8 +105,8 @@ outputs:
         - cuda-version =${{ cuda_version }}
         - librmm =${{ minor_version }}
         - nccl ${{ nccl_version }}
-        - ucxx ${{ ucxx_version }}
         - rapids-logger =0.1
+        - ucxx ${{ ucxx_version }}
         - if: cuda_major == "11"
           then: cudatoolkit
           else: cuda-cudart-dev
@@ -252,6 +252,8 @@ outputs:
           - libcurand
           - libcusolver
           - librmm
+          - nccl
+          - ucxx
           - if: cuda_major == "11"
             then:
               - cudatoolkit
@@ -318,6 +320,8 @@ outputs:
           - libcurand
           - libcusolver
           - librmm
+          - nccl
+          - ucxx
           - if: cuda_major == "11"
             then:
               - cudatoolkit
@@ -385,6 +389,8 @@ outputs:
           - libcurand
           - libcusolver
           - librmm
+          - nccl
+          - ucxx
           - if: cuda_major == "11"
             then:
               - cudatoolkit

--- a/conda/recipes/libraft/recipe.yaml
+++ b/conda/recipes/libraft/recipe.yaml
@@ -78,6 +78,8 @@ cache:
           - libcusolver-dev
           - libcusparse-dev
       - librmm =${{ minor_version }}
+      - nccl ${{ nccl_version }}
+      - ucxx ${{ ucxx_version }}
       - rapids-logger =0.1
 
 outputs:
@@ -102,6 +104,8 @@ outputs:
       host:
         - cuda-version =${{ cuda_version }}
         - librmm =${{ minor_version }}
+        - nccl ${{ nccl_version }}
+        - ucxx ${{ ucxx_version }}
         - rapids-logger =0.1
         - if: cuda_major == "11"
           then: cudatoolkit
@@ -122,6 +126,8 @@ outputs:
           - libcusolver
           - libcusparse
           - librmm
+          - nccl
+          - ucxx
           - if: cuda_major == "11"
             then:
               - cudatoolkit
@@ -140,11 +146,15 @@ outputs:
     requirements:
       host:
         - librmm =${{ minor_version }}
+        - nccl ${{ nccl_version }}
+        - ucxx ${{ ucxx_version }}
         - cuda-version =${{ cuda_version }}
       run:
         - ${{ pin_subpackage("libraft-headers-only", exact=True) }}
         - ${{ pin_compatible("cuda-version", upper_bound="x", lower_bound="x") }}
         - librmm =${{ minor_version }}
+        - nccl ${{ nccl_version }}
+        - ucxx ${{ ucxx_version }}
         - if: cuda_major == "11"
           then:
             - cudatoolkit
@@ -174,6 +184,8 @@ outputs:
           - libcurand
           - libcusolver
           - librmm
+          - nccl
+          - ucxx
           - if: cuda_major == "11"
             then:
               - cudatoolkit


### PR DESCRIPTION
`libraft` recipe installs the `distributed` component https://github.com/rapidsai/raft/blob/902ed56969f588cf504bd9e85ee8ee7419812c93/conda/recipes/libraft/recipe.yaml#L94 which has a build and runtime dependency on targets from `NCCL` and `ucxx` as seen here https://github.com/rapidsai/raft/blob/902ed56969f588cf504bd9e85ee8ee7419812c93/cpp/CMakeLists.txt#L392-L406

cc @gforsyth @bdice 