### PR TITLE
Fix nccl_comm.hpp warning: #83-D: type qualifier specified more than once

### DIFF
--- a/cpp/include/raft/core/resource/nccl_comm.hpp
+++ b/cpp/include/raft/core/resource/nccl_comm.hpp
@@ -51,7 +51,7 @@ class nccl_comm_resource_factory : public resource_factory {
  * @param res raft res object for managing resources
  * @return NCCL comm
  */
-inline ncclComm_t& get_nccl_comm(const resources const& res)
+inline ncclComm_t& get_nccl_comm(const resources& res)
 {
   if (!res.has_resource_factory(resource_type::NCCL_COMM)) {
     res.add_resource_factory(std::make_shared<nccl_comm_resource_factory>());


### PR DESCRIPTION
Warning treated as error downstream in cuVS
https://github.com/rapidsai/cuvs/actions/runs/14609667434/job/40985237074?pr=454#step:9:2675