### PR TITLE
[BUGFIX] Fixed quoting in wheel paths in pylibraft and raft_dask wheel tests

### DIFF
--- a/ci/test_wheel_pylibraft.sh
+++ b/ci/test_wheel_pylibraft.sh
@@ -11,7 +11,7 @@ PYLIBRAFT_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="pylibraft_${RAPIDS_PY_CUDA_SUFFIX}"
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install \
-    "${LIBRAFT_WHEELHOUSE}/libraft*.whl" \
+    "${LIBRAFT_WHEELHOUSE}"/libraft*.whl \
     "$(echo "${PYLIBRAFT_WHEELHOUSE}"/pylibraft*.whl)[test]"
 
 python -m pytest ./python/pylibraft/pylibraft/tests

--- a/ci/test_wheel_raft_dask.sh
+++ b/ci/test_wheel_raft_dask.sh
@@ -17,8 +17,8 @@ RAFT_DASK_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="raft_dask_${RAPIDS_PY_CUDA_SUFFIX}"
 
 # echo to expand wildcard before adding `[extra]` requires for pip
 rapids-pip-retry install -v \
-    "${LIBRAFT_WHEELHOUSE}/libraft*.whl" \
-    "${PYLIBRAFT_WHEELHOUSE}/pylibraft*.whl" \
+    "${LIBRAFT_WHEELHOUSE}"/libraft*.whl \
+    "${PYLIBRAFT_WHEELHOUSE}"/pylibraft*.whl \
     "$(echo "${RAFT_DASK_WHEELHOUSE}"/raft_dask_"${RAPIDS_PY_CUDA_SUFFIX}"*.whl)[test]"
 
 test_dir="python/raft-dask/raft_dask/tests"


### PR DESCRIPTION
Fixes the `libraft*.whl is not a valid wheel filename.` bug in the wheel test steps of `pylibraft` and `raft_dask` on Github CI