### PR TITLE
Dask 2025.4.1 compatibility

### DIFF
--- a/python/raft-dask/raft_dask/common/comms.py
+++ b/python/raft-dask/raft_dask/common/comms.py
@@ -182,7 +182,7 @@ class Comms:
 
         self.worker_addresses = list(
             OrderedDict.fromkeys(
-                self.client.scheduler_info()["workers"].keys()
+                self.client.scheduler_info(n_workers=-1)["workers"].keys()
                 if workers is None
                 else workers
             )

--- a/python/raft-dask/raft_dask/tests/test_comms.py
+++ b/python/raft-dask/raft_dask/tests/test_comms.py
@@ -193,7 +193,7 @@ def _test_nccl_root_placement(client, root_location):
         cb.init()
 
         worker_addresses = list(
-            OrderedDict.fromkeys(client.scheduler_info()["workers"].keys())
+            OrderedDict.fromkeys(client.scheduler_info(n_workers=-1)["workers"].keys())
         )
 
         if root_location in ("worker",):
@@ -500,6 +500,6 @@ def test_comm_init_worker_subset(client, subset):
     # Basic test that initializing a subset of workers is fine
     cb = Comms(comms_p2p=True, verbose=True)
 
-    workers = list(client.scheduler_info()["workers"].keys())
+    workers = list(client.scheduler_info(n_workers=-1)["workers"].keys())
     workers = workers[subset]
     cb.init(workers=workers)


### PR DESCRIPTION
This updates raft-dask for changes made between dask 2025.2.0 and dask 2025.4.1, which was bumped in https://github.com/rapidsai/rapids-dask-dependency/pull/95.

This should fix (some of) the failures in https://github.com/rapidsai/cugraph/pull/5076.