### PR TITLE
fix(devcontainers): typo in container name

### DIFF
--- a/.devcontainer/cuda12.8-pip/devcontainer.json
+++ b/.devcontainer/cuda12.8-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "12.8",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers::25.08-cpp-cuda12.-ucx1.18.0-openmpi5.0.7-ubuntu22.04"
+      "BASE": "rapidsai/devcontainers:25.08-cpp-cuda12.8-ucx1.18.0-openmpi5.0.7-ubuntu22.04"
     }
   },
   "runArgs": [


### PR DESCRIPTION
In #2686 the devcontainer job failed and I noticed it's just a typo probably resulting from a slightly broken forward-merger.  Fixing that up here.
