### PR TITLE
Fix several issues that breaks LLVM

### DIFF
--- a/cpp/include/raft/core/bitmap.hpp
+++ b/cpp/include/raft/core/bitmap.hpp
@@ -119,7 +119,7 @@ struct bitmap_view : public bitset_view<bitmap_t, index_t> {
    * @param col Col index of the bit to set
    * @param new_value Value to set the bit to (true or false)
    */
-  inline _RAFT_HOST_DEVICE void set(const index_t row, const index_t col, bool new_value) const;
+  inline _RAFT_DEVICE void set(const index_t row, const index_t col, bool new_value) const;
 
   /**
    * @brief Get the total number of rows

--- a/cpp/include/raft/core/bitset.hpp
+++ b/cpp/include/raft/core/bitset.hpp
@@ -96,7 +96,7 @@ struct bitset_view {
    * @param sample_index index to set
    * @param set_value Value to set the bit to (true or false)
    */
-  inline _RAFT_HOST_DEVICE void set(const index_t sample_index, bool set_value) const;
+  inline _RAFT_DEVICE void set(const index_t sample_index, bool set_value) const;
 
   /**
    * @brief Get the device pointer to the bitset.

--- a/cpp/include/raft/distance/detail/pairwise_matrix/dispatch_layout.cuh
+++ b/cpp/include/raft/distance/detail/pairwise_matrix/dispatch_layout.cuh
@@ -57,7 +57,7 @@ int determine_vec_len(pairwise_matrix_params<IdxT, DataT, OutT, FinOpT> params)
 {
   size_t align_x        = alignment_of_2d_array(params.x, params.ldx);
   size_t align_y        = alignment_of_2d_array(params.y, params.ldy);
-  size_t byte_alignment = min(align_x, align_y);
+  size_t byte_alignment = std::min(align_x, align_y);
 
   // Since alignment is in bytes, it could be smaller than sizeof(DataT).
   // Handle this (unlikely) case here.

--- a/cpp/include/raft/spectral/detail/matrix_wrappers.hpp
+++ b/cpp/include/raft/spectral/detail/matrix_wrappers.hpp
@@ -86,12 +86,12 @@ struct vector_view_t {
 
   vector_view_t(value_type* buffer, size_type sz) : buffer_(buffer), size_(sz) {}
 
-  vector_view_t(vector_view_t&& other) : buffer_(other.raw()), size_(other.size()) {}
+  vector_view_t(vector_view_t&& other) : buffer_(other.buffer_), size_(other.size_) {}
 
   vector_view_t& operator=(vector_view_t&& other)
   {
-    buffer_ = other.raw();
-    size_   = other.size();
+    buffer_ = other.buffer_;
+    size_   = other.size_;
   }
 };
 

--- a/cpp/include/raft/util/integer_utils.hpp
+++ b/cpp/include/raft/util/integer_utils.hpp
@@ -25,6 +25,7 @@
 
 #include <raft/core/detail/macros.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <stdexcept>


### PR DESCRIPTION
Fix several issues that breaks LLVM:
- do not declare a function _RAFT_HOST_DEVICE if it has no host implementation;
- use std::min() instead of min();
- avoid usign non-existent methods on templated class;
- add missing include.
