### PR TITLE
Fix the constructor for `coordinate_structure` for non-zero `nnz`.

### DIFF
--- a/cpp/include/raft/core/coo_matrix.hpp
+++ b/cpp/include/raft/core/coo_matrix.hpp
@@ -130,8 +130,8 @@ class coordinate_structure : public coordinate_structure_t<RowType, ColType, NZT
     : coordinate_structure_t<RowType, ColType, NZType, is_device>(n_rows, n_cols, nnz),
       cp_rows_{},
       cp_cols_{},
-      c_rows_{cp_rows_.create(handle, 0)},
-      c_cols_{cp_cols_.create(handle, 0)} {};
+      c_rows_{cp_rows_.create(handle, nnz)},
+      c_cols_{cp_cols_.create(handle, nnz)} {};
 
   coordinate_structure(coordinate_structure const&) noexcept(
     std::is_nothrow_copy_constructible_v<row_container_type>) = default;

--- a/cpp/tests/core/sparse_matrix.cu
+++ b/cpp/tests/core/sparse_matrix.cu
@@ -143,6 +143,21 @@ void test_device_csr_matrix()
   test_device_csr_sparsity_preserving_ref(sparsity_preserving, d_preserving);
 }
 
+TEST(DeviceCoordinateStructure, Initialization)
+{
+  raft::resources handle;
+
+  auto uninitialized = raft::make_device_coordinate_structure(handle, 5, 5, 0);
+  // Note: the behaviour of calling `view` on an uninitialized structure is
+  // undefined, this is testing an implementation detail.
+  EXPECT_EQ(uninitialized.view().get_rows().size(), 0);
+  EXPECT_EQ(uninitialized.view().get_rows().data(), nullptr);
+
+  auto initialized = raft::make_device_coordinate_structure(handle, 5, 5, 5);
+  EXPECT_EQ(initialized.view().get_rows().size(), 5);
+  EXPECT_NE(initialized.view().get_rows().data(), nullptr);
+}
+
 TEST(DeviceSparseCOOMatrix, Basic) { test_device_coo_matrix(); }
 
 TEST(DeviceSparseCSRMatrix, Basic) { test_device_csr_matrix(); }


### PR DESCRIPTION
The class fails to allocate the right storage for `c_rows_` and `c_cols_` when `nnz` is non-zero.

```
resources handle;
auto m = make_device_coordinate_structure(handlei, 5, 5, /*nnz*/5);
m.view();  // crash: creates a span on `c_rows_.data()` (`nullptr` with
`size` = 5).
```

To reproduce, run `cpp/tests/core/sparse_matrix.cu` with assertions enabled.

