### PR TITLE
Update leftover CUDA 12.8 to 12.9 in docs

### DIFF
--- a/docs/source/build.md
+++ b/docs/source/build.md
@@ -50,7 +50,7 @@ Note that the above commands will also install `libraft-headers` and `libraft`.
 You can also install the conda packages individually using the `mamba` command above. For example, if you'd like to install RAFT's headers to use in your project:
 ```bash
 # for CUDA 12
-mamba install -c rapidsai -c conda-forge -c nvidia libraft-headers cuda-version=12.8
+mamba install -c rapidsai -c conda-forge -c nvidia libraft-headers cuda-version=12.9
 ```
 
 ## Installing Python through Pip


### PR DESCRIPTION
Follow up to PR:
* https://github.com/rapidsai/raft/pull/2721

Addressing issues:
* https://github.com/rapidsai/build-planning/issues/195
* https://github.com/rapidsai/build-planning/issues/173

## Description

Update leftover doc reference of CUDA 12.8 to 12.9.