### PR TITLE
Add missing `#include <cassert>` in `cpp/include/raft/core/math.hpp`

### DIFF
--- a/cpp/include/raft/core/math.hpp
+++ b/cpp/include/raft/core/math.hpp
@@ -19,6 +19,7 @@
 #include <raft/core/detail/macros.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <type_traits>
 


### PR DESCRIPTION
Fixes this error after https://github.com/rapidsai/raft/pull/2718 was merged:
```
raft/cpp/include/raft/core/math.hpp(85): error: identifier "assert" is undefined
    assert(false); return T{};;
    ^
```