### PR TITLE
Missing header `<cassert>` in `core/math.hpp`

### DIFF
--- a/cpp/include/raft/core/math.hpp
+++ b/cpp/include/raft/core/math.hpp
@@ -19,6 +19,7 @@
 #include <raft/core/detail/macros.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <type_traits>
 


### PR DESCRIPTION
As noted by @trxcllnt in PR comment https://github.com/rapidsai/raft/pull/2718#issuecomment-3029261268