### PR TITLE
remove cuspatial references, avoid triggering tests on clang-format config changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -79,6 +79,7 @@ jobs:
           - '!CONTRIBUTING.md'
           - '!README.md'
           - '!ci/release/update-version.sh'
+          - '!cpp/.clang-format'
           - '!docs/**'
           - '!img/**'
           - '!thirdparty/LICENSES/**'

--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -77,8 +77,6 @@ IncludeCategories:
     Priority:        1
   - Regex:           '^<(common|benchmarks|tests)/' # benchmark/test includes
     Priority:        2
-  #- Regex:           '^<(cuspatial_test|cuproj_test)/' # cuSpatial/cuProj test includes
-  #  Priority:        3
   - Regex:           '^<raft/' # RAFT includes
     Priority:        3
   - Regex:           '^<(cudf|cuml|raft|kvikio)' # Other RAPIDS includes


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/197

* removes references to `cuspatial` in `.clang-format`
* updates `changed-files` configuration, so future PRs that only touch `cpp/.clang-format` do not trigger a full run of all CI

## Notes for Reviewers

### How I tested this

Looked for references like this:

```shell
git grep -i -E 'cuproj|cuspatial'
```