### PR TITLE
Update protocol name for UCX-Py tests

### DIFF
--- a/python/raft-dask/raft_dask/tests/conftest.py
+++ b/python/raft-dask/raft_dask/tests/conftest.py
@@ -28,7 +28,7 @@ def ucx_cluster():
         yield scheduler_file
     else:
         cluster = LocalCUDACluster(
-            protocol="ucx",
+            protocol="ucx-old",
         )
         yield cluster
         cluster.close()


### PR DESCRIPTION
https://github.com/rapidsai/rapids-dask-dependency/pull/116 changes the meaning of `protocol="ucx"`. To restore the old behavior, we use `"ucx-old"`.

UCX-Py, which the protocol `"ucx-old"` uses, is being deprecated in favor of UCXX (https://github.com/rapidsai/ucx-py/pull/1151) and is scheduled for removal in 25.10, allowing us to then remove UCX-Py tests entirely.