### PR TITLE
Register bfloat16/bfloat162 in util/vectorized.cuh

### DIFF
--- a/cpp/include/raft/util/vectorized.cuh
+++ b/cpp/include/raft/util/vectorized.cuh
@@ -134,6 +134,22 @@ struct IOType<__half, 8> {
   typedef uint4 Type;
 };
 template <>
+struct IOType<__nv_bfloat16, 1> {
+  typedef __nv_bfloat16 Type;
+};
+template <>
+struct IOType<__nv_bfloat16, 2> {
+  typedef __nv_bfloat162 Type;
+};
+template <>
+struct IOType<__nv_bfloat16, 4> {
+  typedef uint2 Type;
+};
+template <>
+struct IOType<__nv_bfloat16, 8> {
+  typedef uint4 Type;
+};
+template <>
 struct IOType<__half2, 1> {
   typedef __half2 Type;
 };
@@ -143,6 +159,18 @@ struct IOType<__half2, 2> {
 };
 template <>
 struct IOType<__half2, 4> {
+  typedef uint4 Type;
+};
+template <>
+struct IOType<__nv_bfloat162, 1> {
+  typedef __nv_bfloat162 Type;
+};
+template <>
+struct IOType<__nv_bfloat162, 2> {
+  typedef uint2 Type;
+};
+template <>
+struct IOType<__nv_bfloat162, 4> {
   typedef uint4 Type;
 };
 template <>


### PR DESCRIPTION
Register bfloat16/bfloat162 in util/vectorized.cuh

Related issue: https://github.com/rapidsai/raft/issues/2768