### PR TITLE
[REVIEW] Fix: skip default_allocation_limit() if unnecessary

### DIFF
--- a/cpp/include/raft/core/resource/device_memory_resource.hpp
+++ b/cpp/include/raft/core/resource/device_memory_resource.hpp
@@ -110,7 +110,8 @@ class workspace_resource_factory : public resource_factory {
     std::optional<std::size_t> allocation_limit         = std::nullopt,
     std::optional<std::size_t> alignment                = std::nullopt)
     // default_allocation_limit() is relatively heavy, skip it while unnecessary
-    : allocation_limit_(allocation_limit.has_value() ? allocation_limit.value() : default_allocation_limit()),
+    : allocation_limit_(allocation_limit.has_value() ? allocation_limit.value()
+                                                     : default_allocation_limit()),
       alignment_(alignment),
       mr_(mr ? mr : default_plain_resource())
   {

--- a/cpp/include/raft/core/resource/device_memory_resource.hpp
+++ b/cpp/include/raft/core/resource/device_memory_resource.hpp
@@ -109,7 +109,8 @@ class workspace_resource_factory : public resource_factory {
     std::shared_ptr<rmm::mr::device_memory_resource> mr = {nullptr},
     std::optional<std::size_t> allocation_limit         = std::nullopt,
     std::optional<std::size_t> alignment                = std::nullopt)
-    : allocation_limit_(allocation_limit.value_or(default_allocation_limit())),
+    // default_allocation_limit() is relatively heavy, skip it while unnecessary
+    : allocation_limit_(allocation_limit.has_value() ? allocation_limit.value() : default_allocation_limit()),
       alignment_(alignment),
       mr_(mr ? mr : default_plain_resource())
   {


### PR DESCRIPTION
`workspace_resource_factory` will call `default_allocation_limit()` regardless of whether the `allocation_limit` parameter is passed in.

The `default_allocation_limit()` calls `cudaMemGetInfo()`, which is a relatively heavy CUDA API; 
the first call in a CUDA context can take up to 800 ms, while subsequent calls average 20 us (still longer than some small kernels).
This pull request makes `workspace_resource_factory` no longer request `default_allocation_limit()` when the `allocation_limit` parameter is given.