### PR TITLE
Support < 2 element arrays in `rand_index`/`adjusted_rand_index`

### DIFF
--- a/cpp/include/raft/stats/detail/adjusted_rand_index.cuh
+++ b/cpp/include/raft/stats/detail/adjusted_rand_index.cuh
@@ -127,7 +127,10 @@ double compute_adjusted_rand_index(const T* firstClusterArray,
                                    int size,
                                    cudaStream_t stream)
 {
-  ASSERT(size >= 2, "Rand Index for size less than 2 not defined!");
+  if (size < 2) {
+    // 1 or 0 labels always have a perfect score. This also matches sklearn behavior.
+    return 1.0;
+  }
   T minFirst, maxFirst, minSecond, maxSecond;
   auto nUniqFirst      = countUnique(firstClusterArray, size, minFirst, maxFirst, stream);
   auto nUniqSecond     = countUnique(secondClusterArray, size, minSecond, maxSecond, stream);

--- a/cpp/include/raft/stats/detail/rand_index.cuh
+++ b/cpp/include/raft/stats/detail/rand_index.cuh
@@ -133,8 +133,10 @@ double compute_rand_index(const T* firstClusterArray,
                           uint64_t size,
                           cudaStream_t stream)
 {
-  // rand index for size less than 2 is not defined
-  ASSERT(size >= 2, "Rand Index for size less than 2 not defined!");
+  if (size < 2) {
+    // 1 or 0 labels always have a perfect score. This also matches sklearn behavior.
+    return 1.0;
+  }
 
   // allocating and initializing memory for a and b in the GPU
   rmm::device_uvector<uint64_t> arr_buf(2, stream);

--- a/cpp/tests/stats/rand_index.cu
+++ b/cpp/tests/stats/rand_index.cu
@@ -63,20 +63,24 @@ class randIndexTest : public ::testing::TestWithParam<randIndexParam> {
     std::generate(arr2.begin(), arr2.end(), [&]() { return intGenerator(dre); });
 
     // generating the golden output
-    int64_t a_truth = 0;
-    int64_t b_truth = 0;
+    if (size < 2) {
+      truthRandIndex = 1.0;
+    } else {
+      int64_t a_truth = 0;
+      int64_t b_truth = 0;
 
-    for (uint64_t iter = 0; iter < size; ++iter) {
-      for (uint64_t jiter = 0; jiter < iter; ++jiter) {
-        if (arr1[iter] == arr1[jiter] && arr2[iter] == arr2[jiter]) {
-          ++a_truth;
-        } else if (arr1[iter] != arr1[jiter] && arr2[iter] != arr2[jiter]) {
-          ++b_truth;
+      for (uint64_t iter = 0; iter < size; ++iter) {
+        for (uint64_t jiter = 0; jiter < iter; ++jiter) {
+          if (arr1[iter] == arr1[jiter] && arr2[iter] == arr2[jiter]) {
+            ++a_truth;
+          } else if (arr1[iter] != arr1[jiter] && arr2[iter] != arr2[jiter]) {
+            ++b_truth;
+          }
         }
       }
+      uint64_t nChooseTwo = (size * (size - 1)) / 2;
+      truthRandIndex      = (double)(((double)(a_truth + b_truth)) / (double)nChooseTwo);
     }
-    uint64_t nChooseTwo = (size * (size - 1)) / 2;
-    truthRandIndex      = (double)(((double)(a_truth + b_truth)) / (double)nChooseTwo);
 
     // allocating and initializing memory to the GPU
     stream = resource::get_cuda_stream(handle);
@@ -115,7 +119,9 @@ const std::vector<randIndexParam> inputs = {{199, 1, 10, 0.000001},
                                             {100, 1, 10000, 0.000001},
                                             {198, 1, 100, 0.000001},
                                             {300, 3, 99, 0.000001},
-                                            {2, 0, 0, 0.00001}};
+                                            {2, 0, 0, 0.00001},
+                                            {1, 0, 0, 0.00001},
+                                            {0, 0, 0, 0.00001}};
 
 // writing the test suite
 typedef randIndexTest<int> randIndexTestClass;


### PR DESCRIPTION
Previously we enforced that all input arrays to these metrics had >= 2 elements. This doesn't match sklearn's behavior, where 1 or 0 element arrays are also valid. In those cases the scores are always 1.0.

Fixes rapidsai/cuml#7202.
