### PR TITLE
Fix sparse select_k: don't write beyond min(input_len, k)

### DIFF
--- a/cpp/include/raft/matrix/detail/select_warpsort.cuh
+++ b/cpp/include/raft/matrix/detail/select_warpsort.cuh
@@ -766,6 +766,25 @@ __launch_bounds__(256) RAFT_KERNEL block_kernel(const T* in,
                                                 T* out,
                                                 IdxT* out_idx)
 {
+  // * per-block output
+  {
+    const int block_id = blockIdx.x + gridDim.x * blockIdx.y;
+    out += block_id * k;
+    out_idx += block_id * k;
+  }
+  // * per-block input
+  {
+    const size_t batch_id = blockIdx.y;
+    const IdxT l_offset   = in_indptr ? in_indptr[batch_id] : (offset + batch_id) * len;
+    const IdxT l_len      = in_indptr ? (in_indptr[batch_id + 1] - in_indptr[batch_id]) : len;
+    in += l_offset;
+    if (in_idx != nullptr) { in_idx += l_offset; }
+    len = l_len;
+  }
+  // * trim k if the input is too short
+  k = std::min<int>(k, len);
+
+  // * set up the queue
   extern __shared__ __align__(256) uint8_t smem_buf_bytes[];
   // Map the value type T to an appropriate uint type using cub traits.
   // This gives us two advantages:
@@ -776,28 +795,22 @@ __launch_bounds__(256) RAFT_KERNEL block_kernel(const T* in,
   using bq_t         = block_sort<WarpSortClass, Capacity, Ascending, bits_t, IdxT>;
   uint8_t* warp_smem = bq_t::queue_t::mem_required(blockDim.x) > 0 ? smem_buf_bytes : nullptr;
   bq_t queue(k, warp_smem);
-  const size_t batch_id = blockIdx.y;
 
-  const IdxT l_len    = in_indptr ? (in_indptr[batch_id + 1] - in_indptr[batch_id]) : len;
-  const IdxT l_offset = in_indptr ? in_indptr[batch_id] : (offset + batch_id) * len;
-
-  in += l_offset;
-  if (in_idx != nullptr) { in_idx += l_offset; }
-
+  // * main loop
   const IdxT stride         = gridDim.x * blockDim.x;
-  const IdxT per_thread_lim = l_len + laneId();
+  const IdxT per_thread_lim = len + laneId();
   for (IdxT i = threadIdx.x + blockIdx.x * blockDim.x; i < per_thread_lim; i += stride) {
     // Twiddle the input value to ensure proper comparison of floating-point and signed int values
-    queue.add(i < l_len ? cub::Traits<T>::TwiddleIn(__ldcs(reinterpret_cast<const bits_t*>(in) + i))
-                        : WarpSortClass<Capacity, Ascending, bits_t, IdxT>::kDummy,
-              (i < l_len && in_idx != nullptr) ? __ldcs(in_idx + i) : i);
+    queue.add(i < len ? cub::Traits<T>::TwiddleIn(__ldcs(reinterpret_cast<const bits_t*>(in) + i))
+                      : WarpSortClass<Capacity, Ascending, bits_t, IdxT>::kDummy,
+              (i < len && in_idx != nullptr) ? __ldcs(in_idx + i) : i);
   }
 
+  // * write out the result
   queue.done(smem_buf_bytes);
-  const int block_id = blockIdx.x + gridDim.x * blockIdx.y;
-  queue.store(reinterpret_cast<bits_t*>(out) + block_id * k,
-              out_idx + block_id * k,
-              cub::Traits<T>::TwiddleOut);  // Restore the FP / signed int representation.
+  queue.store(reinterpret_cast<bits_t*>(out),
+              out_idx,
+              cub::Traits<T>::TwiddleOut /* Restore the FP / signed int representation.*/);
 }
 
 struct launch_params {

--- a/cpp/tests/sparse/select_k_csr.cu
+++ b/cpp/tests/sparse/select_k_csr.cu
@@ -56,7 +56,7 @@ struct CompareApproxWithInf {
   CompareApproxWithInf(T eps_) : eps(eps_) {}
   bool operator()(const T& a, const T& b) const
   {
-    if ((std::isinf(a) || std::isnan(a)) && (std::isinf(b) || std::isnan(b))) return true;
+    if (std::isinf(a) && std::isinf(b)) return true;
     T diff  = std::abs(a - b);
     T m     = std::max(std::abs(a), std::abs(b));
     T ratio = diff > eps ? diff / m : diff;


### PR DESCRIPTION
The sparse select-k API accepts inputs in the form of a CSR matrix and produces a dense output matrix (with k columns). Naturally, some lines in CSR representation can be shorter than `k` elements. [The public API declares that padding elements in the output matrices are left untouched](https://github.com/rapidsai/raft/blob/505d8513ab4bc8f33df238cd9cb72a111d719cb8/cpp/include/raft/sparse/matrix/select_k.cuh#L44-L45).
This behavior hasn't been implemented in the warpsort select-k, but relied upon in downstream code, such as [cuVS bruteforce tests](https://github.com/rapidsai/cuvs/blob/8fc4a2ad134f2d2d7763b026d0965b328ecc8db8/python/cuvs/cuvs/tests/test_brute_force.py#L151-L209). The issue was not discovered until recently, because we'd been using the same sentinel value 'infinitity' across raft and cuVS codebases. PR https://github.com/rapidsai/raft/pull/2807 exposed the issue by using a different sentinel within warpsort (all-one-bits-mask, which falls under NaN range).

This PR fixes the issue by modifying the warpsort kernel to select `min(input_line_len, k)` elements for each line.