### PR TITLE
Properly guard usage of openmp function calls

### DIFF
--- a/cpp/include/raft/matrix/detail/gather.cuh
+++ b/cpp/include/raft/matrix/detail/gather.cuh
@@ -580,7 +580,9 @@ void gather(raft::resources const& res,
   auto out_tmp2 = raft::make_pinned_matrix<T, MatIdxT>(res, max_batch_size, n_dim);
 
   // Usually a limited number of threads provide sufficient bandwidth for gathering data.
+#if defined(_OPENMP)
   int n_threads = std::min(omp_get_max_threads(), 32);
+#endif
 
   // The gather_buff function has a parallel for loop. We start the the omp parallel
   // region here, to avoid repeated overhead within the device_offset loop.

--- a/cpp/include/raft/neighbors/detail/cagra/graph_core.cuh
+++ b/cpp/include/raft/neighbors/detail/cagra/graph_core.cuh
@@ -561,9 +561,11 @@ void optimize(raft::resources const& res,
                           num_shift);
         output_graph_ptr[num_protected_edges + (output_graph_degree * j)] = i;
       }
+#if defined(_OPENMP)
       if ((omp_get_thread_num() == 0) && ((j % _omp_chunk) == 0)) {
         RAFT_LOG_DEBUG("# Replacing reverse edges: %lu / %lu    ", j, graph_size);
       }
+#endif
     }
     RAFT_LOG_DEBUG("\n");
 


### PR DESCRIPTION
Proper support to disable OpenMP also requires that any calls to functions like `omp_get_max_threads` need to be guarded by a `_OPENMP` check.


Required to fix https://github.com/rapidsai/cuvs/issues/1322