### PR TITLE
Fix for STD comm waitall function

### DIFF
--- a/cpp/include/raft/comms/detail/std_comms.hpp
+++ b/cpp/include/raft/comms/detail/std_comms.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Closes [#7341](https://github.com/rapidsai/cuml/issues/7341)

When UCXX progress thread was active, the waitall() implementation used CallbackNotifier with registerGenericPre/Post which would block indefinitely waiting for callbacks that the progress thread couldn't service in this context. The solution is to simply yield the CPU with std::this_thread::yield() and let the background progress thread complete requests while the main thread polls isCompleted().