### PR TITLE
Always convert warnings to errors

### DIFF
--- a/cpp/cmake/modules/ConfigureCUDA.cmake
+++ b/cpp/cmake/modules/ConfigureCUDA.cmake
@@ -16,7 +16,9 @@ endif()
 # clang)
 if(CMAKE_COMPILER_IS_GNUCXX)
   list(APPEND RAFT_CXX_FLAGS -Wall -Werror -Wno-unknown-pragmas -Wno-error=deprecated-declarations)
-  list(APPEND RAFT_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations -Werror=all-warnings)
+  list(APPEND RAFT_CUDA_FLAGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations
+       -Werror=all-warnings
+  )
 
 endif()
 


### PR DESCRIPTION
Follows up on this comment: https://github.com/rapidsai/raft/issues/2741#issuecomment-3120151254

As CUDA 12 is a minimum requirement, drop the CUDA 11.2 check.

<hr>

Part of issues:
* https://github.com/rapidsai/build-planning/issues/223
* https://github.com/rapidsai/build-planning/issues/184