### PR TITLE
Use current system architecture in conda environment creation command

### DIFF
--- a/docs/source/build.md
+++ b/docs/source/build.md
@@ -100,7 +100,7 @@ In addition to the libraries included with cudatoolkit 12.2+, there are some oth
 
 Conda environment scripts are provided for installing the necessary dependencies to build both the C++ and Python libraries from source. It is preferred to use `mamba`, as it provides significant speedup over `conda`:
 ```bash
-mamba env create --name rapids_raft -f conda/environments/all_cuda-130_arch-$(arch).yaml
+mamba env create --name rapids_raft -f conda/environments/all_cuda-130_arch-$(uname -m).yaml
 mamba activate rapids_raft
 ```
 


### PR DESCRIPTION
This fixes a conda environment creation command to support both `x86_64` and `aarch64` systems.