### PR TITLE
Fix laplacian scaling coefficients

### DIFF
--- a/cpp/include/raft/sparse/linalg/detail/laplacian.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/laplacian.cuh
@@ -7,7 +7,6 @@
 #include <raft/core/device_csr_matrix.hpp>
 #include <raft/core/device_mdarray.hpp>
 #include <raft/core/resources.hpp>
-#include <raft/linalg/map.cuh>
 #include <raft/sparse/matrix/diagonal.cuh>
 
 #include <type_traits>
@@ -146,7 +145,7 @@ auto laplacian_normalized(
   raft::linalg::unary_op(
     res, raft::make_const_mdspan(diagonal.view()), diagonal.view(), raft::sqrt_op());
 
-  raft::linalg::map(
+  raft::linalg::unary_op(
     res, raft::make_const_mdspan(diagonal.view()), diagonal.view(), zero_to_one_functor{});
 
   raft::sparse::matrix::scale_by_diagonal_symmetric(res, diagonal.view(), laplacian.view());


### PR DESCRIPTION
Resolves https://github.com/rapidsai/cuml/issues/7488

In a normalized laplacian scaling coefficients are the sqrt of the laplacian diagonal.
These coefficients are then used to scale all elements of the laplacian which ensure diagonal elements are set to 1 and off diagonal elements are scaled appropriately.
`(1/scaling)*L*(1/scaling)`

However, when the scaling coefficients are 0, it will cause a divide by 0 issue as seen above. This caused `nan` values to appear in the umap embedding output in cuml. The way to handle this is to substitute any 0 scaling values with 1 instead which ensures scaling will have no effect.

For more details see https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csgraph.laplacian.html and scroll to the `normed=True` section.

This PR adds a elementwise operation to replace the scaling zeros with ones.