### PR TITLE
Include `<thrust/for_each.h>` where it is used

### DIFF
--- a/cpp/include/raft/matrix/detail/gather_inplace.cuh
+++ b/cpp/include/raft/matrix/detail/gather_inplace.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -9,6 +9,7 @@
 #include <raft/linalg/map.cuh>
 #include <raft/util/fast_int_div.cuh>
 
+#include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
 namespace raft {

--- a/cpp/include/raft/matrix/detail/scatter_inplace.cuh
+++ b/cpp/include/raft/matrix/detail/scatter_inplace.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -10,6 +10,7 @@
 #include <raft/util/cuda_dev_essentials.cuh>
 #include <raft/util/fast_int_div.cuh>
 
+#include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
 #include <cstdint>

--- a/cpp/include/raft/neighbors/detail/knn_brute_force.cuh
+++ b/cpp/include/raft/neighbors/detail/knn_brute_force.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -29,6 +29,7 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/device_uvector.hpp>
 
+#include <thrust/for_each.h>
 #include <thrust/iterator/transform_iterator.h>
 
 #include <cstdint>

--- a/cpp/tests/core/bitmap.cu
+++ b/cpp/tests/core/bitmap.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -10,6 +10,8 @@
 #include <raft/linalg/init.cuh>
 #include <raft/linalg/map.cuh>
 #include <raft/random/rng.cuh>
+
+#include <thrust/for_each.h>
 
 #include <gtest/gtest.h>
 

--- a/cpp/tests/matrix/linewise_op.cu
+++ b/cpp/tests/matrix/linewise_op.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -18,6 +18,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <cuda_profiler_api.h>
+#include <thrust/for_each.h>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
There were several files where `thrust::for_each` was used without including the corresponding header.

This fixes some compilation issues observed with CCCL 3.2.
