### PR TITLE
Fix is_exhaustive, no longer constexpr

### DIFF
--- a/cpp/tests/core/mdarray.cu
+++ b/cpp/tests/core/mdarray.cu
@@ -401,7 +401,8 @@ template <typename T, typename Index, typename LayoutPolicy>
 void check_matrix_layout(device_matrix_view<T, Index, LayoutPolicy> in)
 {
   static_assert(in.rank() == 2);
-  static_assert(in.is_exhaustive());
+  // is_exhaustive() is not constexpr for dynamic extents in CCCL 3.2+
+  EXPECT_TRUE(in.is_exhaustive());
 
   bool constexpr kIsCContiguous = std::is_same_v<LayoutPolicy, layout_c_contiguous>;
   bool constexpr kIsFContiguous = std::is_same_v<LayoutPolicy, layout_f_contiguous>;


### PR DESCRIPTION
This PR fixes an error observed with CCCL 3.2, where `is_exhaustive` is no longer `constexpr` for mdspans with dynamic extents. We must use `EXPECT_TRUE` to evaluate this at runtime, rather than `static_assert` at compile time.
