### PR TITLE
Add copy_vectorized to RAFT

### DIFF
--- a/cpp/include/raft/util/vectorized.cuh
+++ b/cpp/include/raft/util/vectorized.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Taken from cuvs IVF-Flat. Adding this copy_vectorized function to RAFT allow it to be used without unnecessary code duplication.
It would also be used in the future rapidsai/cuvs#1278