### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In addition being a C++ library, RAFT also provides 2 Python libraries:
 
 ## Is RAFT right for me?
 
-RAFT contains low-level primitives for accelerating applications and workflows. Data source providers and application developers may find specific tools -- like ANN algorithms -- very useful. RAFT is not intended to be used directly by data scientists for discovery and experimentation. For data science tools, please see the [RAPIDS website](https://rapids.ai/).
+RAFT contains low-level primitives for accelerating applications and workflows. Data source providers and application developers may find specific tools very useful. RAFT is not intended to be used directly by data scientists for discovery and experimentation. For data science tools, please see the [RAPIDS website](https://rapids.ai/).
 
 ## Getting started
 

--- a/docs/source/build.md
+++ b/docs/source/build.md
@@ -180,7 +180,7 @@ The benchmarks are broken apart by algorithm category, so you will find several 
 It can take sometime to compile all of the benchmarks. You can build individual benchmarks by providing a semicolon-separated list to the `--limit-bench-prims` option in `build.sh`:
 
 ```bash
-./build.sh libraft bench-prims -n --limit-bench=NEIGHBORS_PRIMS_BENCH;MATRIX_PRIMS_BENCH;LINALG_PRIMS_BENCH
+./build.sh libraft bench-prims -n --limit-bench=MATRIX_PRIMS_BENCH;LINALG_PRIMS_BENCH
 ```
 
 ### Python libraries


### PR DESCRIPTION
This PR does the following:

1. Fix image paths: `python/pylibraft/README.md` https://github.com/rapidsai/raft/tree/main/python/pylibraft#readme doesn't render the images correctly because of relative paths. This PR changes the image paths to be absolute paths.
Same issue with https://github.com/rapidsai/raft/tree/main/python/libraft#readme and https://github.com/rapidsai/raft/tree/main/python/raft-dask#readme `README.md`
2. Shorten title to: `RAFT: Reusable Accelerated Functions and Tools`
3. Remove cpp example containing deprecated raft distance function.
4. Remove mention of `ANN` in readme and `NEIGHBORS` in build.md