### PR TITLE
Change compile-time assertion to runtime assertion on is_strided

### DIFF
--- a/cpp/tests/core/mdarray.cu
+++ b/cpp/tests/core/mdarray.cu
@@ -425,6 +425,7 @@ TEST(MDArray, FuncArg)
 
     auto slice =
       cuda::std::submdspan(d_matrix.view(), cuda::std::tuple{2ul, 4ul}, cuda::std::tuple{2ul, 5ul});
+    ASSERT_TRUE(slice.is_strided());
     ASSERT_EQ(slice.extent(0), 2);
     ASSERT_EQ(slice.extent(1), 3);
     // is using device_accessor mixin.


### PR DESCRIPTION
In newer CCCL versions, `is_strided` is not known at compile time. This updates a `static_assert` to `ASSERT_TRUE`. 

This fixes a compilation error [observed in CCCL/RAPIDS nightly tests](https://github.com/NVIDIA/cccl/actions/runs/20588215653/job/59128411815#step:6:3688).
```
FAILED: tests/CMakeFiles/CORE_TEST.dir/core/mdarray.cu.o 
/usr/bin/sccache /home/coder/.conda/envs/rapids/bin/nvcc -forward-unknown-to-host-compiler -ccbin=/home/coder/.conda/envs/rapids/bin/x86_64-conda-linux-gnu-c++ -DCCCL_DISABLE_PDL -DCUB_DISABLE_NAMESPACE_MAGIC -DCUB_IGNORE_NAMESPACE_MAGIC_ERROR -DCUTLASS_NAMESPACE=raft_cutlass -DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE -DRAFT_COMPILED -DRAFT_EXPLICIT_INSTANTIATE_ONLY -DRAFT_LOG_ACTIVE_LEVEL=RAPIDS_LOGGER_LOG_LEVEL_INFO -DRAFT_SYSTEM_LITTLE_ENDIAN=1 -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CUDA -DTHRUST_DISABLE_ABI_NAMESPACE -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP -DTHRUST_IGNORE_ABI_NAMESPACE_ERROR -I/home/coder/raft/cpp/tests -I/home/coder/raft/cpp/include -I/home/coder/raft/cpp/build/conda/cuda-13.0/release/include -I/home/coder/raft/cpp/build/conda/cuda-13.0/release/_deps/cccl-src/lib/cmake/thrust/../../../thrust -I/home/coder/raft/cpp/build/conda/cuda-13.0/release/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include -I/home/coder/raft/cpp/build/conda/cuda-13.0/release/_deps/cccl-src/lib/cmake/cub/../../../cub -I/home/coder/raft/cpp/build/conda/cuda-13.0/release/_deps/cuco-src/include -I/home/coder/raft/cpp/build/conda/cuda-13.0/release/_deps/nvidiacutlass-src/include -I/home/coder/raft/cpp/build/conda/cuda-13.0/release/_deps/nvidiacutlass-build/include -I/home/coder/raft/cpp/internal -isystem /home/coder/rmm/cpp/include -isystem /home/coder/rmm/cpp/build/conda/cuda-13.0/release/include -isystem /home/coder/.conda/envs/rapids/targets/x86_64-linux/include -isystem /home/coder/.conda/envs/rapids/targets/x86_64-linux/include/cccl -isystem /home/coder/raft/cpp/build/conda/cuda-13.0/release/_deps/gtest-src/googletest/include -isystem /home/coder/raft/cpp/build/conda/cuda-13.0/release/_deps/gtest-src/googletest -t=1 -O3 -DNDEBUG -std=c++20 "--generate-code=arch=compute_75,code=[sm_75]" -Xcompiler=-fPIE -Xcompiler=-Wno-deprecated-declarations -DRAFT_HIDE_DEPRECATION_WARNINGS -Xcompiler=-Wall,-Werror,-Wno-error=deprecated-declarations -Werror=all-warnings --expt-extended-lambda --expt-relaxed-constexpr -DCUDA_API_PER_THREAD_DEFAULT_STREAM -Xfatbin=-compress-all --compress-mode=size -Xcompiler=-fopenmp -Xcompiler -pthread -MD -MT tests/CMakeFiles/CORE_TEST.dir/core/mdarray.cu.o -MF tests/CMakeFiles/CORE_TEST.dir/core/mdarray.cu.o.d -x cu -c /home/coder/raft/cpp/tests/core/mdarray.cu -o tests/CMakeFiles/CORE_TEST.dir/core/mdarray.cu.o
/home/coder/raft/cpp/tests/core/mdarray.cu(428): error: expression must have a constant value
      static_assert(slice.is_strided());
                    ^
/home/coder/raft/cpp/build/conda/cuda-13.0/release/_deps/cccl-src/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__mdspan/mdspan.h(463): note #2701-D: attempt to access run-time storage
      auto __tmp = mapping();
                          ^

1 error detected in the compilation of "/home/coder/raft/cpp/tests/core/mdarray.cu".
```

Validated locally with CCCL commit https://github.com/NVIDIA/cccl/commits/bf1b0394a4b868d148fc375d32c480441fc44d27.