### PR TITLE
Fix CCCL 3.2 mdspan constexpr issues

### DIFF
--- a/cmake/rapids_config.cmake
+++ b/cmake/rapids_config.cmake
@@ -1,12 +1,9 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
-set(rapids-cmake-repo "bdice/rapids-cmake")
-set(rapids-cmake-branch "cccl-3.2.x-mdspan-fix")
-
 file(READ "${CMAKE_CURRENT_LIST_DIR}/../VERSION" _rapids_version)
 if(_rapids_version MATCHES [[^([0-9][0-9])\.([0-9][0-9])\.([0-9][0-9])]])
   set(RAPIDS_VERSION_MAJOR "${CMAKE_MATCH_1}")


### PR DESCRIPTION
This PR reverts some code that was needed to work around a `constexpr` bug in CCCL 3.2, now that it has been fixed and updated in rapids-cmake: https://github.com/rapidsai/rapids-cmake/pull/959