### PR TITLE
Fix update-version.sh incorrectly replacing main() function names

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 ########################
 # RAFT Version Updater #


### PR DESCRIPTION
## Summary
The sed pattern `\bmain\b` was too broad and matched the C++ `main()` function in code examples within documentation files, replacing `int main(int argc, char** argv)` with `int release/26.04(int argc, ...)`.

Changed the pattern to only match `/blob/main/` in GitHub URLs, which is the actual intended target for branch reference updates.

## Test plan
- Run `ci/release/update-version.sh 26.04.00 --run-context=release`
- Verify `docs/source/developer_guide.md` no longer has `int release/26.04(...)` instead of `int main(...)`