### PR TITLE
Temporarily increase `max_days_without_success`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -50,6 +50,7 @@ jobs:
         uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: raft
+          # Tracking Issue: https://github.com/rapidsai/raft/issues/2951
           max_days_without_success: 30
   changed-files:
     secrets: inherit


### PR DESCRIPTION
Tracking Issue https://github.com/rapidsai/raft/issues/2951

In the meantime we need to increase the `max_days_without_success` to unblock development for raft.
We need to merge this PR https://github.com/rapidsai/raft/pull/2949 to unblock downstream repos (cuvs and cugraph).