### PR TITLE
check-nightly-ci: update to new version

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -54,7 +54,7 @@ jobs:
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
       - name: Check if nightly CI is passing
-        uses: rapidsai/shared-actions/check_nightly_success/dispatch@check-nightly-success
+        uses: rapidsai/shared-actions/check_nightly_success/dispatch@main
         with:
           repo: ${{ github.repository }}
           target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-actions/issues/94

Uses the updated `check_nightly_success` check from https://github.com/rapidsai/shared-actions/pull/96 . Now that CI check will only ever consider the branch a PR targets, which should prevent issues related to release timing in the future.

## Notes for Reviewers

I've intentionally cancelled all other CI here after `check-nightly-ci` and `checks` ran, as this only affects `check-nightly-ci`.

### Merging plan:

1. [x] get this PR approved
2. [x] get https://github.com/rapidsai/shared-actions/pull/96 approved and merge it
3. [x] update branch reference to `@main` here
4. [x] immediately admin-merge this