### PR TITLE
refactor(limited api): add explicit `wheel.py-api` to `pyproject.toml`


### DIFF
--- a/python/pylibraft/pyproject.toml
+++ b/python/pylibraft/pyproject.toml
@@ -73,6 +73,7 @@ ninja.make-fallback = false
 sdist.exclude = ["*tests*"]
 sdist.reproducible = true
 wheel.packages = ["pylibraft"]
+wheel.py-api = "cp311" # overridden in CI builds by arguments from `ci/build_wheel_*.sh` scripts.
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"

--- a/python/raft-dask/pyproject.toml
+++ b/python/raft-dask/pyproject.toml
@@ -72,6 +72,7 @@ ninja.make-fallback = false
 sdist.exclude = ["*tests*"]
 sdist.reproducible = true
 wheel.packages = ["raft_dask"]
+wheel.py-api = "cp311" # overridden in CI builds by arguments from `ci/build_wheel_*.sh` scripts.
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"


### PR DESCRIPTION
## Description
As part of https://github.com/rapidsai/build-planning/issues/42 I added support for building limited API wheels and conda packages.

To enable a RAPIDS-wide bump of the lower-bound of the limited API version we use (currently `cp311`), the flags that set these options are passed in via environment variables.

This leads us to an issue where local developer builds, either in devcontainers or otherwise, will build without the limited API, unless devs have set an (otherwise unnecessary) environment variable.

So here, I set the `py-api` version explicitly, so that local builds will always produce limited API wheels and so better reflect what we build and test in CI.

We retain the ability to bump all of RAPIDS to a different `cp3xx` value because the flag passed in by our scripts overrides the value set in the `pyproject.toml`.  There may be short periods where the flags we are building with and the flags set in `pyproject.toml` differ, but that should happen infrequently at best.
