### PR TITLE
Update Cython lower bound pin to 3.2.2

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-version=12.9
 - cupy>=13.6.0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - distributed-ucxx==0.49.*,>=0.0.0a0
 - doxygen>=1.8.20

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-version=12.9
 - cupy>=13.6.0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - distributed-ucxx==0.49.*,>=0.0.0a0
 - doxygen>=1.8.20

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-version=13.1
 - cupy>=13.6.0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - distributed-ucxx==0.49.*,>=0.0.0a0
 - doxygen>=1.8.20

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -17,7 +17,7 @@ dependencies:
 - cuda-version=13.1
 - cupy>=13.6.0
 - cxx-compiler
-- cython>=3.0.0,<3.2.0
+- cython>=3.2.2
 - dask-cuda==26.4.*,>=0.0.0a0
 - distributed-ucxx==0.49.*,>=0.0.0a0
 - doxygen>=1.8.20

--- a/conda/recipes/pylibraft/recipe.yaml
+++ b/conda/recipes/pylibraft/recipe.yaml
@@ -72,7 +72,7 @@ requirements:
     - ${{ stdlib("c") }}
   host:
     - cuda-version =${{ cuda_version }}
-    - cython >=3.0.0,<3.2.0
+    - cython >=3.2.2
     - libraft =${{ version }}
     - libraft-headers =${{ version }}
     - pip

--- a/conda/recipes/raft-dask/recipe.yaml
+++ b/conda/recipes/raft-dask/recipe.yaml
@@ -73,7 +73,7 @@ requirements:
     - ${{ stdlib("c") }}
   host:
     - cuda-version =${{ cuda_version }}
-    - cython >=3.0.0,<3.2.0
+    - cython >=3.2.2
     - nccl ${{ nccl_version }}
     - pip
     - pylibraft =${{ version }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -216,7 +216,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - cython>=3.0.0,<3.2.0
+          - cython>=3.2.2
   checks:
     common:
       - output_types: [conda, requirements]

--- a/python/pylibraft/pyproject.toml
+++ b/python/pylibraft/pyproject.toml
@@ -86,7 +86,7 @@ build-backend = "scikit_build_core.build"
 requires = [
     "cmake>=3.30.4",
     "cuda-python>=13.0.1,<14.0",
-    "cython>=3.0.0,<3.2.0",
+    "cython>=3.2.2",
     "libraft==26.4.*,>=0.0.0a0",
     "librmm==26.4.*,>=0.0.0a0",
     "ninja",

--- a/python/raft-dask/pyproject.toml
+++ b/python/raft-dask/pyproject.toml
@@ -84,7 +84,7 @@ regex = "(?P<value>.*)"
 build-backend = "scikit_build_core.build"
 requires = [
     "cmake>=3.30.4",
-    "cython>=3.0.0,<3.2.0",
+    "cython>=3.2.2",
     "libraft==26.4.*,>=0.0.0a0",
     "librmm==26.4.*,>=0.0.0a0",
     "libucx>=1.19.0,<1.19.1",


### PR DESCRIPTION
## Summary

Refs https://github.com/rapidsai/build-planning/issues/229

Updates the Cython lower bound pin to `>=3.2.2`. The `<3.2.0` upper bound was added as a workaround for a code-generation bug introduced in Cython 3.2.0. That bug was fixed in Cython 3.2.1 (https://github.com/cython/cython/pull/7313) and additional related fixes landed in Cython 3.2.2 (https://github.com/cython/cython/pull/7320). Cython 3.2.2 has been released, so we can now raise the lower bound and remove the upper bound cap.

Changes:
- Update `dependencies.yaml`: set `cython>=3.2.2` (no upper bound), remove the old workaround comment
- Update `conda/recipes/*/recipe.yaml`: same pin change (not managed by `rapids-dependency-file-generator`)
- Regenerate all derived files via `rapids-dependency-file-generator`