### PR TITLE
add no_libucx matrix option in dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -558,6 +558,9 @@ dependencies:
       - output_types: [requirements, pyproject]
         matrices:
           - matrix:
+              no_libucx: "true"
+            packages:
+          - matrix:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:


### PR DESCRIPTION
This option allows generating dependencies without `libucx` in the dependencies list, which is something we have to do for NVAIE/DLFW builds.