### PR TITLE
fix verify-hardcoded-versions issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,9 +150,31 @@ repos:
           - id: verify-codeowners
             args: [--fix, --project-prefix=raft]
           - id: verify-hardcoded-version
+            exclude: |
+              (?x)
+                (^|/)devcontainer[.]json$|
+                (^|/)dependencies[.]yaml$|
+                ^[.]github/(workflows|ISSUE_TEMPLATE)/|
+                (^|/)pom[.]xml$|
+                ^[.]pre-commit-config[.]yaml$|
+                ^conda/environments/|
+                (^|/)UCXX_BRANCH$|
+                (^|/)RAPIDS_BRANCH$|
+                [.](md|rst)$
           - id: verify-hardcoded-version
             name: verify-hardcoded-version-ucxx
             args: [--fix, --version-file=UCXX_VERSION]
+            exclude: |
+              (?x)
+                (^|/)devcontainer[.]json$|
+                (^|/)dependencies[.]yaml$|
+                ^[.]github/(workflows|ISSUE_TEMPLATE)/|
+                (^|/)pom[.]xml$|
+                ^[.]pre-commit-config[.]yaml$|
+                ^conda/environments/|
+                (^|/)UCXX_BRANCH$|
+                (^|/)RAPIDS_BRANCH$|
+                [.](md|rst)$
           - id: verify-pyproject-license
             # ignore the top-level pyproject.toml, which doesn't
             # have or need a [project] table


### PR DESCRIPTION
Fixes these `pre-commit` errors

```text
In file RAPIDS_BRANCH:1:9:
 release/26.04
warning: do not hard-code version, read from VERSION file instead

In file RAPIDS_BRANCH:1:9:
 release/26.04

verify-hardcoded-version-ucxx............................................Failed
- hook id: verify-hardcoded-version
- exit code: 1

In file UCXX_BRANCH:1:9:
 release/0.49
warning: do not hard-code version, read from UCXX_VERSION file instead

In file UCXX_BRANCH:1:9:
 release/0.49
```

See https://github.com/rapidsai/pre-commit-hooks/issues/121 for details