### PR TITLE
pre-commit: consolidate duplicate entries, bump some versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,11 @@
 
 repos:
       - repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v5.0.0
+        rev: v6.0.0
         hooks:
               - id: trailing-whitespace
               - id: end-of-file-fixer
+              - id: check-json
       - repo: https://github.com/astral-sh/ruff-pre-commit
         rev: v0.14.1
         hooks:
@@ -83,10 +84,6 @@ repos:
                 exclude: |
                   (?x)
                     ^CHANGELOG[.]md$|
-      - repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v5.0.0
-        hooks:
-              - id: check-json
       - repo: https://github.com/rapidsai/pre-commit-hooks
         rev: v1.4.2
         hooks:
@@ -182,7 +179,7 @@ repos:
               (?x)
                 ^pyproject[.]toml$
       - repo: https://github.com/rapidsai/dependency-file-generator
-        rev: v1.20.0
+        rev: v1.20.2
         hooks:
             - id: rapids-dependency-file-generator
               args: ["--clean", "--warn-all", "--strict"]


### PR DESCRIPTION
To adapt to recent changes in other RAPIDS projects, we need to produce new nightly wheels from this project (https://github.com/rapidsai/cugraph/pull/5479#issuecomment-4163555737).

Today, that requires merging a new commit (https://github.com/rapidsai/build-planning/issues/218 documents why). Given that we need that anyway, this at least tries to make it a useful one... bumping a few `pre-commit` hook versions and consolidating duplicate uses of `pre-commit/pre-commit-hooks`.