### PR TITLE
Update to clang 20.1.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
                 additional_dependencies: [toml]
                 args: ["--config=pyproject.toml"]
       - repo: https://github.com/pre-commit/mirrors-clang-format
-        rev: v20.1.4
+        rev: v20.1.8
         hooks:
               - id: clang-format
                 types_or: [c, c++, cuda]

--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - breathe
 - c-compiler
-- clang-tools=20.1.4
-- clang==20.1.4
+- clang-tools=20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - breathe
 - c-compiler
-- clang-tools=20.1.4
-- clang==20.1.4
+- clang-tools=20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-131_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-131_arch-aarch64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - breathe
 - c-compiler
-- clang-tools=20.1.4
-- clang==20.1.4
+- clang-tools=20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-131_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-131_arch-x86_64.yaml
@@ -7,8 +7,8 @@ channels:
 dependencies:
 - breathe
 - c-compiler
-- clang-tools=20.1.4
-- clang==20.1.4
+- clang-tools=20.1.8
+- clang==20.1.8
 - cmake>=3.30.4
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/cpp/scripts/run-clang-tidy.py
+++ b/cpp/scripts/run-clang-tidy.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2020-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2020-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -17,7 +17,7 @@ import shutil
 import subprocess
 
 
-EXPECTED_VERSIONS = ("20.1.4",)
+EXPECTED_VERSIONS = ("20.1.8",)
 VERSION_REGEX = re.compile(r"clang version ([0-9.]+)")
 CMAKE_COMPILER_REGEX = re.compile(
     r"^\s*CMAKE_CXX_COMPILER:FILEPATH=(.+)\s*$", re.MULTILINE

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -226,8 +226,8 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - clang==20.1.4
-          - clang-tools=20.1.4
+          - clang==20.1.8
+          - clang-tools=20.1.8
   # 'cuda_version' intentionally does not contain fallback entries... we want
   # a loud error if an unsupported 'cuda' value is passed
   cuda_version:


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/267

This PR updates the clang version to 20.1.8.
