### PR TITLE
Predictable raft::resources

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -191,7 +191,7 @@ target_include_directories(
 # Keep RAFT as lightweight as possible. Only CUDA libs and rmm should be used in global target.
 target_link_libraries(raft INTERFACE rapids_logger::rapids_logger rmm::rmm CCCL::CCCL)
 
-target_compile_features(raft INTERFACE cxx_std_17 $<BUILD_INTERFACE:cuda_std_17>)
+target_compile_features(raft INTERFACE cxx_std_20 $<BUILD_INTERFACE:cuda_std_20>)
 target_compile_options(
   raft INTERFACE $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-extended-lambda
                  --expt-relaxed-constexpr>

--- a/cpp/include/raft/core/device_resources.hpp
+++ b/cpp/include/raft/core/device_resources.hpp
@@ -36,10 +36,8 @@
 #include <cusparse.h>
 
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -59,9 +57,10 @@ class device_resources : public resources {
     resource::set_workspace_resource(*this, std::move(workspace_resource), allocation_limit);
   }
 
-  device_resources(const device_resources& handle) : resources{handle} {}
-  device_resources(device_resources&&)            = delete;
-  device_resources& operator=(device_resources&&) = delete;
+  device_resources(const device_resources&)            = default;
+  device_resources(device_resources&&)                 = default;
+  device_resources& operator=(const device_resources&) = default;
+  device_resources& operator=(device_resources&&)      = default;
 
   /**
    * @brief Construct a resources instance with a stream view and stream pool

--- a/cpp/include/raft/core/handle.hpp
+++ b/cpp/include/raft/core/handle.hpp
@@ -26,10 +26,10 @@ class handle_t : public raft::device_resources {
   {
   }
 
-  handle_t(const handle_t& handle) : device_resources{handle} {}
-
-  handle_t(handle_t&&)            = delete;
-  handle_t& operator=(handle_t&&) = delete;
+  handle_t(const handle_t&)            = default;
+  handle_t(handle_t&&)                 = default;
+  handle_t& operator=(const handle_t&) = default;
+  handle_t& operator=(handle_t&&)      = default;
 
   /**
    * @brief Construct a resources instance with a stream view and stream pool

--- a/cpp/include/raft/core/resource/comms.hpp
+++ b/cpp/include/raft/core/resource/comms.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -56,7 +56,7 @@ inline comms::comms_t const& get_comms(resources const& res)
   return *(*res.get_resource<std::shared_ptr<comms::comms_t>>(resource_type::COMMUNICATOR));
 }
 
-inline void set_comms(resources const& res, std::shared_ptr<comms::comms_t> communicator)
+inline void set_comms(resources& res, std::shared_ptr<comms::comms_t> communicator)
 {
   res.add_resource_factory(std::make_shared<comms_resource_factory>(communicator));
 }

--- a/cpp/include/raft/core/resource/cublas_handle.hpp
+++ b/cpp/include/raft/core/resource/cublas_handle.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -57,10 +57,7 @@ class cublas_resource_factory : public resource_factory {
  */
 inline cublasHandle_t get_cublas_handle(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::CUBLAS_HANDLE)) {
-    cudaStream_t stream = get_cuda_stream(res);
-    res.add_resource_factory(std::make_shared<cublas_resource_factory>(stream));
-  }
+  res.ensure_default_factory(std::make_shared<cublas_resource_factory>(get_cuda_stream(res)));
   auto ret = *res.get_resource<cublasHandle_t>(resource_type::CUBLAS_HANDLE);
   RAFT_CUBLAS_TRY(cublasSetStream(ret, get_cuda_stream(res)));
   return ret;

--- a/cpp/include/raft/core/resource/cublaslt_handle.hpp
+++ b/cpp/include/raft/core/resource/cublaslt_handle.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -44,11 +44,8 @@ class cublaslt_resource_factory : public resource_factory {
  */
 inline auto get_cublaslt_handle(resources const& res) -> cublasLtHandle_t
 {
-  if (!res.has_resource_factory(resource_type::CUBLASLT_HANDLE)) {
-    res.add_resource_factory(std::make_shared<cublaslt_resource_factory>());
-  }
-  auto ret = *res.get_resource<cublasLtHandle_t>(resource_type::CUBLASLT_HANDLE);
-  return ret;
+  res.ensure_default_factory(std::make_shared<cublaslt_resource_factory>());
+  return *res.get_resource<cublasLtHandle_t>(resource_type::CUBLASLT_HANDLE);
 };
 
 /**

--- a/cpp/include/raft/core/resource/cuda_stream.hpp
+++ b/cpp/include/raft/core/resource/cuda_stream.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -57,9 +57,7 @@ class cuda_stream_resource_factory : public resource_factory {
  */
 inline rmm::cuda_stream_view get_cuda_stream(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::CUDA_STREAM_VIEW)) {
-    res.add_resource_factory(std::make_shared<cuda_stream_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<cuda_stream_resource_factory>());
   return *res.get_resource<rmm::cuda_stream_view>(resource_type::CUDA_STREAM_VIEW);
 };
 
@@ -69,7 +67,7 @@ inline rmm::cuda_stream_view get_cuda_stream(resources const& res)
  * @param[in] res raft resources object for managing resources
  * @param[in] stream_view cuda stream view
  */
-inline void set_cuda_stream(resources const& res, rmm::cuda_stream_view stream_view)
+inline void set_cuda_stream(resources& res, rmm::cuda_stream_view stream_view)
 {
   res.add_resource_factory(std::make_shared<cuda_stream_resource_factory>(stream_view));
 };

--- a/cpp/include/raft/core/resource/cuda_stream_pool.hpp
+++ b/cpp/include/raft/core/resource/cuda_stream_pool.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -67,9 +67,7 @@ inline bool is_stream_pool_initialized(const resources& res)
  */
 inline const rmm::cuda_stream_pool& get_cuda_stream_pool(const resources& res)
 {
-  if (!res.has_resource_factory(resource_type::CUDA_STREAM_POOL)) {
-    res.add_resource_factory(std::make_shared<cuda_stream_pool_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<cuda_stream_pool_resource_factory>());
   return *(
     *res.get_resource<std::shared_ptr<rmm::cuda_stream_pool>>(resource_type::CUDA_STREAM_POOL));
 };
@@ -80,8 +78,7 @@ inline const rmm::cuda_stream_pool& get_cuda_stream_pool(const resources& res)
  * @param res
  * @param stream_pool
  */
-inline void set_cuda_stream_pool(const resources& res,
-                                 std::shared_ptr<rmm::cuda_stream_pool> stream_pool)
+inline void set_cuda_stream_pool(resources& res, std::shared_ptr<rmm::cuda_stream_pool> stream_pool)
 {
   res.add_resource_factory(std::make_shared<cuda_stream_pool_resource_factory>(stream_pool));
 };
@@ -163,9 +160,7 @@ inline void sync_stream_pool(const resources& res, const std::vector<std::size_t
  */
 inline void wait_stream_pool_on_stream(const resources& res)
 {
-  if (!res.has_resource_factory(resource_type::CUDA_STREAM_POOL)) {
-    res.add_resource_factory(std::make_shared<cuda_stream_pool_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<cuda_stream_pool_resource_factory>());
 
   cudaEvent_t event = detail::get_cuda_stream_sync_event(res);
   RAFT_CUDA_TRY(cudaEventRecord(event, get_cuda_stream(res)));

--- a/cpp/include/raft/core/resource/cusolver_dn_handle.hpp
+++ b/cpp/include/raft/core/resource/cusolver_dn_handle.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -63,10 +63,7 @@ class cusolver_dn_resource_factory : public resource_factory {
  */
 inline cusolverDnHandle_t get_cusolver_dn_handle(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::CUSOLVER_DN_HANDLE)) {
-    cudaStream_t stream = get_cuda_stream(res);
-    res.add_resource_factory(std::make_shared<cusolver_dn_resource_factory>(stream));
-  }
+  res.ensure_default_factory(std::make_shared<cusolver_dn_resource_factory>(get_cuda_stream(res)));
   return *res.get_resource<cusolverDnHandle_t>(resource_type::CUSOLVER_DN_HANDLE);
 };
 

--- a/cpp/include/raft/core/resource/cusolver_sp_handle.hpp
+++ b/cpp/include/raft/core/resource/cusolver_sp_handle.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -60,10 +60,7 @@ class cusolver_sp_resource_factory : public resource_factory {
  */
 inline cusolverSpHandle_t get_cusolver_sp_handle(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::CUSOLVER_SP_HANDLE)) {
-    cudaStream_t stream = get_cuda_stream(res);
-    res.add_resource_factory(std::make_shared<cusolver_sp_resource_factory>(stream));
-  }
+  res.ensure_default_factory(std::make_shared<cusolver_sp_resource_factory>(get_cuda_stream(res)));
   return *res.get_resource<cusolverSpHandle_t>(resource_type::CUSOLVER_SP_HANDLE);
 };
 

--- a/cpp/include/raft/core/resource/cusparse_handle.hpp
+++ b/cpp/include/raft/core/resource/cusparse_handle.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -55,10 +55,7 @@ class cusparse_resource_factory : public resource_factory {
  */
 inline cusparseHandle_t get_cusparse_handle(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::CUSPARSE_HANDLE)) {
-    rmm::cuda_stream_view stream = get_cuda_stream(res);
-    res.add_resource_factory(std::make_shared<cusparse_resource_factory>(stream));
-  }
+  res.ensure_default_factory(std::make_shared<cusparse_resource_factory>(get_cuda_stream(res)));
   return *res.get_resource<cusparseHandle_t>(resource_type::CUSPARSE_HANDLE);
 };
 

--- a/cpp/include/raft/core/resource/custom_resource.hpp
+++ b/cpp/include/raft/core/resource/custom_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -69,9 +69,7 @@ template <typename ResourceT>
 auto get_custom_resource(resources const& res) -> ResourceT*
 {
   static_assert(std::is_default_constructible_v<ResourceT>);
-  if (!res.has_resource_factory(resource_type::CUSTOM)) {
-    res.add_resource_factory(std::make_shared<custom_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<custom_resource_factory>());
   return res.get_resource<custom_resource>(resource_type::CUSTOM)->load<ResourceT>();
 };
 

--- a/cpp/include/raft/core/resource/detail/stream_sync_event.hpp
+++ b/cpp/include/raft/core/resource/detail/stream_sync_event.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -31,9 +31,7 @@ class cuda_stream_sync_event_resource_factory : public resource_factory {
  */
 inline cudaEvent_t& get_cuda_stream_sync_event(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::CUDA_STREAM_SYNC_EVENT)) {
-    res.add_resource_factory(std::make_shared<cuda_stream_sync_event_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<cuda_stream_sync_event_resource_factory>());
   return *res.get_resource<cudaEvent_t>(resource_type::CUDA_STREAM_SYNC_EVENT);
 };
 

--- a/cpp/include/raft/core/resource/device_id.hpp
+++ b/cpp/include/raft/core/resource/device_id.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -53,9 +53,7 @@ class device_id_resource_factory : public resource_factory {
  */
 inline int get_device_id(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::DEVICE_ID)) {
-    res.add_resource_factory(std::make_shared<device_id_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<device_id_resource_factory>());
   return *res.get_resource<int>(resource_type::DEVICE_ID);
 };
 

--- a/cpp/include/raft/core/resource/device_memory_resource.hpp
+++ b/cpp/include/raft/core/resource/device_memory_resource.hpp
@@ -166,9 +166,7 @@ namespace detail {
 
 inline auto get_workspace_adaptor(resources const& res) -> rmm::mr::limiting_resource_adaptor*
 {
-  if (!res.has_resource_factory(resource_type::WORKSPACE_RESOURCE)) {
-    res.add_resource_factory(std::make_shared<workspace_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<workspace_resource_factory>());
   return res.get_resource<rmm::mr::limiting_resource_adaptor>(resource_type::WORKSPACE_RESOURCE);
 }
 
@@ -243,7 +241,7 @@ inline auto get_workspace_free_bytes(resources const& res) -> size_t
  *   the total amount of memory in bytes available to the temporary workspace resources.
  * @param alignment optional alignment requirements passed to allocations
  */
-inline void set_workspace_resource(resources const& res,
+inline void set_workspace_resource(resources& res,
                                    raft::mr::device_resource mr,
                                    std::optional<std::size_t> allocation_limit = std::nullopt,
                                    std::optional<std::size_t> alignment        = std::nullopt)
@@ -263,7 +261,7 @@ inline void set_workspace_resource(resources const& res,
  *
  */
 inline void set_workspace_to_pool_resource(
-  resources const& res, std::optional<std::size_t> allocation_limit = std::nullopt)
+  resources& res, std::optional<std::size_t> allocation_limit = std::nullopt)
 {
   if (!allocation_limit.has_value()) { allocation_limit = get_workspace_total_bytes(res); }
   res.add_resource_factory(std::make_shared<workspace_resource_factory>(
@@ -284,7 +282,7 @@ inline void set_workspace_to_pool_resource(
  *   the total amount of memory in bytes available to the temporary workspace resources.
  */
 inline void set_workspace_to_global_resource(
-  resources const& res, std::optional<std::size_t> allocation_limit = std::nullopt)
+  resources& res, std::optional<std::size_t> allocation_limit = std::nullopt)
 {
   res.add_resource_factory(std::make_shared<workspace_resource_factory>(
     raft::mr::device_resource{rmm::mr::get_current_device_resource_ref()},
@@ -300,9 +298,7 @@ inline void set_workspace_to_global_resource(
  */
 inline auto get_large_workspace_resource_ref(resources const& res) -> rmm::device_async_resource_ref
 {
-  if (!res.has_resource_factory(resource_type::LARGE_WORKSPACE_RESOURCE)) {
-    res.add_resource_factory(std::make_shared<large_workspace_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<large_workspace_resource_factory>());
   return rmm::device_async_resource_ref{
     *res.get_resource<raft::mr::device_resource>(resource_type::LARGE_WORKSPACE_RESOURCE)};
 }
@@ -313,7 +309,7 @@ inline auto get_large_workspace_resource_ref(resources const& res) -> rmm::devic
  * @param res raft resources object for managing resources
  * @param mr device memory resource
  */
-inline void set_large_workspace_resource(resources const& res, raft::mr::device_resource mr)
+inline void set_large_workspace_resource(resources& res, raft::mr::device_resource mr)
 {
   res.add_resource_factory(std::make_shared<large_workspace_resource_factory>(std::move(mr)));
 }

--- a/cpp/include/raft/core/resource/device_properties.hpp
+++ b/cpp/include/raft/core/resource/device_properties.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -54,10 +54,8 @@ class device_properties_resource_factory : public resource_factory {
  */
 inline cudaDeviceProp& get_device_properties(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::DEVICE_PROPERTIES)) {
-    int dev_id = get_device_id(res);
-    res.add_resource_factory(std::make_shared<device_properties_resource_factory>(dev_id));
-  }
+  res.ensure_default_factory(
+    std::make_shared<device_properties_resource_factory>(get_device_id(res)));
   return *res.get_resource<cudaDeviceProp>(resource_type::DEVICE_PROPERTIES);
 };
 

--- a/cpp/include/raft/core/resource/managed_memory_resource.hpp
+++ b/cpp/include/raft/core/resource/managed_memory_resource.hpp
@@ -56,9 +56,7 @@ class managed_memory_resource_factory : public resource_factory {
 inline auto get_managed_memory_resource_ref(resources const& res)
   -> raft::mr::host_device_resource_ref
 {
-  if (!res.has_resource_factory(resource_type::MANAGED_MEMORY_RESOURCE)) {
-    res.add_resource_factory(std::make_shared<managed_memory_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<managed_memory_resource_factory>());
   auto& mr =
     *res.get_resource<raft::mr::host_device_resource>(resource_type::MANAGED_MEMORY_RESOURCE);
   return raft::mr::host_device_resource_ref{mr};
@@ -70,7 +68,7 @@ inline auto get_managed_memory_resource_ref(resources const& res)
  * @param res raft resources object for managing resources
  * @param mr  host+device accessible memory resource
  */
-inline void set_managed_memory_resource(resources const& res, raft::mr::host_device_resource mr)
+inline void set_managed_memory_resource(resources& res, raft::mr::host_device_resource mr)
 {
   res.add_resource_factory(std::make_shared<managed_memory_resource_factory>(std::move(mr)));
 }

--- a/cpp/include/raft/core/resource/multi_gpu.hpp
+++ b/cpp/include/raft/core/resource/multi_gpu.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -31,7 +31,7 @@ class multi_gpu_resource_factory : public resource_factory {
 
 class root_rank_resource : public resource {
  public:
-  root_rank_resource() : root_rank_(0) {}
+  explicit root_rank_resource(int root_rank = 0) : root_rank_(root_rank) {}
   void* get_resource() override { return &root_rank_; }
 
   ~root_rank_resource() override {}
@@ -42,15 +42,17 @@ class root_rank_resource : public resource {
 
 class root_rank_resource_factory : public resource_factory {
  public:
+  explicit root_rank_resource_factory(int root_rank = 0) : root_rank_(root_rank) {}
   resource_type get_resource_type() override { return resource_type::ROOT_RANK; }
-  resource* make_resource() override { return new root_rank_resource(); }
+  resource* make_resource() override { return new root_rank_resource(root_rank_); }
+
+ private:
+  int root_rank_;
 };
 
-inline int& get_root_rank(resources const& res)
+inline int get_root_rank(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::ROOT_RANK)) {
-    res.add_resource_factory(std::make_shared<root_rank_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<root_rank_resource_factory>());
   return *res.get_resource<int>(resource_type::ROOT_RANK);
 };
 
@@ -63,9 +65,7 @@ inline int& get_root_rank(resources const& res)
  */
 inline std::vector<raft::resources>& get_multi_gpu_resource(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::MULTI_GPU)) {
-    res.add_resource_factory(std::make_shared<multi_gpu_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<multi_gpu_resource_factory>());
   return *res.get_resource<std::vector<raft::resources>>(resource_type::MULTI_GPU);
 };
 
@@ -118,10 +118,9 @@ inline const raft::resources& set_current_device_to_root_rank(resources const& r
 /**
  * @brief Set the root rank to given rank
  */
-inline void set_root_rank(resources const& res, int root_rank)
+inline void set_root_rank(resources& res, int root_rank)
 {
-  int& root_rank_ = get_root_rank(res);
-  root_rank_      = root_rank;
+  res.add_resource_factory(std::make_shared<root_rank_resource_factory>(root_rank));
 };
 
 }  // namespace raft::resource

--- a/cpp/include/raft/core/resource/nccl_comm.hpp
+++ b/cpp/include/raft/core/resource/nccl_comm.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -74,7 +74,7 @@ inline void _init_nccl_comms(const resources& res)
 inline std::vector<ncclComm_t>& get_nccl_comms(const resources& res)
 {
   if (!res.has_resource_factory(resource_type::NCCL_COMM)) {
-    res.add_resource_factory(std::make_shared<nccl_comm_resource_factory>());
+    res.ensure_default_factory(std::make_shared<nccl_comm_resource_factory>());
     _init_nccl_comms(res);
   }
   return *res.get_resource<std::vector<ncclComm_t>>(resource_type::NCCL_COMM);

--- a/cpp/include/raft/core/resource/pinned_memory_resource.hpp
+++ b/cpp/include/raft/core/resource/pinned_memory_resource.hpp
@@ -54,9 +54,7 @@ class pinned_memory_resource_factory : public resource_factory {
 inline auto get_pinned_memory_resource_ref(resources const& res)
   -> raft::mr::host_device_resource_ref
 {
-  if (!res.has_resource_factory(resource_type::PINNED_MEMORY_RESOURCE)) {
-    res.add_resource_factory(std::make_shared<pinned_memory_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<pinned_memory_resource_factory>());
   auto& mr =
     *res.get_resource<raft::mr::host_device_resource>(resource_type::PINNED_MEMORY_RESOURCE);
   return raft::mr::host_device_resource_ref{mr};
@@ -68,7 +66,7 @@ inline auto get_pinned_memory_resource_ref(resources const& res)
  * @param res raft resources object for managing resources
  * @param mr  host+device accessible memory resource
  */
-inline void set_pinned_memory_resource(resources const& res, raft::mr::host_device_resource mr)
+inline void set_pinned_memory_resource(resources& res, raft::mr::host_device_resource mr)
 {
   res.add_resource_factory(std::make_shared<pinned_memory_resource_factory>(std::move(mr)));
 }

--- a/cpp/include/raft/core/resource/resource_types.hpp
+++ b/cpp/include/raft/core/resource/resource_types.hpp
@@ -5,6 +5,9 @@
 
 #pragma once
 
+#include <atomic>
+#include <memory>
+
 namespace raft::resource {
 
 /**
@@ -56,15 +59,6 @@ class resource {
   virtual ~resource() {}
 };
 
-class empty_resource : public resource {
- public:
-  empty_resource() : resource() {}
-
-  void* get_resource() override { return nullptr; }
-
-  ~empty_resource() override {}
-};
-
 /**
  * @brief A resource factory knows how to construct an instance of
  * a specific raft::resource::resource.
@@ -87,26 +81,16 @@ class resource_factory {
 };
 
 /**
- * @brief A resource factory knows how to construct an instance of
- * a specific raft::resource::resource.
+ * @brief Shared cell holding a factory and a lazily-created resource.
+ *
+ * Multiple raft::resources handles can share a cell via shared_ptr.
+ * Lazy initialization stores the concrete resource atomically, so all
+ * handles sharing the cell see the update.  Explicit set replaces the
+ * shared_ptr<resource_cell> in the local handle, isolating the change.
  */
-class empty_resource_factory : public resource_factory {
- public:
-  empty_resource_factory() : resource_factory() {}
-  /**
-   * @brief Return the resource_type associated with the current factory
-   * @return resource_type corresponding to the current factory
-   */
-  resource_type get_resource_type() override { return resource_type::LAST_KEY; }
-
-  /**
-   * @brief Construct an instance of the factory's underlying resource.
-   * @return resource instance
-   */
-  resource* make_resource() override { return &res; }
-
- private:
-  empty_resource res;
+struct resource_cell {
+  std::atomic<std::shared_ptr<resource_factory>> factory{};
+  std::atomic<std::shared_ptr<resource>> res{};
 };
 
 /**

--- a/cpp/include/raft/core/resource/resource_types.hpp
+++ b/cpp/include/raft/core/resource/resource_types.hpp
@@ -10,7 +10,6 @@
 #include <atomic>
 #include <memory>
 
-
 namespace RAFT_EXPORT raft {
 namespace resource {
 

--- a/cpp/include/raft/core/resource/stream_view.hpp
+++ b/cpp/include/raft/core/resource/stream_view.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -50,9 +50,7 @@ struct stream_view_resource_factory : public resource_factory {
  */
 inline raft::stream_view get_stream_view(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::STREAM_VIEW)) {
-    res.add_resource_factory(std::make_shared<stream_view_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<stream_view_resource_factory>());
   return *res.get_resource<raft::stream_view>(resource_type::STREAM_VIEW);
 };
 
@@ -62,7 +60,7 @@ inline raft::stream_view get_stream_view(resources const& res)
  * @param[in] res raft resources object for managing resources
  * @param[in] view raft stream view
  */
-inline void set_stream_view(resources const& res, raft::stream_view view)
+inline void set_stream_view(resources& res, raft::stream_view view)
 {
   res.add_resource_factory(std::make_shared<stream_view_resource_factory>(view));
 };

--- a/cpp/include/raft/core/resource/sub_comms.hpp
+++ b/cpp/include/raft/core/resource/sub_comms.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -38,9 +38,7 @@ class sub_comms_resource_factory : public resource_factory {
 
 inline const comms::comms_t& get_subcomm(const resources& res, std::string key)
 {
-  if (!res.has_resource_factory(resource_type::SUB_COMMUNICATOR)) {
-    res.add_resource_factory(std::make_shared<sub_comms_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<sub_comms_resource_factory>());
 
   auto sub_comms =
     res.get_resource<std::unordered_map<std::string, std::shared_ptr<comms::comms_t>>>(
@@ -51,13 +49,16 @@ inline const comms::comms_t& get_subcomm(const resources& res, std::string key)
   return *sub_comm;
 }
 
+// In-place mutation: sub-communicators are typically set once during initialization
+// and should be visible to all copies of the resources handle (Goal 1 / lazy-init
+// propagation semantics).
+// Note: we don't replace the _resource_ here (sub_comms_resource), so `res` is passed
+//       by const reference.
 inline void set_subcomm(resources const& res,
                         std::string key,
                         std::shared_ptr<comms::comms_t> subcomm)
 {
-  if (!res.has_resource_factory(resource_type::SUB_COMMUNICATOR)) {
-    res.add_resource_factory(std::make_shared<sub_comms_resource_factory>());
-  }
+  res.ensure_default_factory(std::make_shared<sub_comms_resource_factory>());
   auto sub_comms =
     res.get_resource<std::unordered_map<std::string, std::shared_ptr<comms::comms_t>>>(
       resource_type::SUB_COMMUNICATOR);

--- a/cpp/include/raft/core/resource/thrust_policy.hpp
+++ b/cpp/include/raft/core/resource/thrust_policy.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -51,10 +51,8 @@ class thrust_policy_resource_factory : public resource_factory {
  */
 inline rmm::exec_policy_nosync& get_thrust_policy(resources const& res)
 {
-  if (!res.has_resource_factory(resource_type::THRUST_POLICY)) {
-    rmm::cuda_stream_view stream = get_cuda_stream(res);
-    res.add_resource_factory(std::make_shared<thrust_policy_resource_factory>(stream));
-  }
+  res.ensure_default_factory(
+    std::make_shared<thrust_policy_resource_factory>(get_cuda_stream(res)));
   return *res.get_resource<rmm::exec_policy_nosync>(resource_type::THRUST_POLICY);
 };
 

--- a/cpp/include/raft/core/resources.hpp
+++ b/cpp/include/raft/core/resources.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -9,9 +9,7 @@
 #include <raft/core/error.hpp>  // RAFT_EXPECTS
 #include <raft/core/logger.hpp>
 
-#include <algorithm>
-#include <mutex>
-#include <string>
+#include <memory>
 #include <vector>
 
 namespace raft {
@@ -25,6 +23,16 @@ namespace raft {
  * accessor functions can then register and load resources as needed in order
  * to keep its usage somewhat opaque to end-users.
  *
+ * Copies of a resources handle share the underlying resource_cell objects.
+ * Lazy initialization (via get_resource / ensure_default_factory) stores into the
+ * shared cell's atomics, so all copies see the update.  Explicit modification
+ * (via add_resource_factory) replaces the shared_ptr<resource_cell> in the local
+ * vector, isolating the change from other copies.
+ *
+ * Thread safety: concurrent const operations on the same handle are safe
+ * (inner-cell atomics).  Concurrent const + non-const on the same handle
+ * requires external synchronization (standard C++ rules).
+ *
  * @code{.cpp}
  * #include <raft/core/resources.hpp>
  * #include <raft/core/resource/cuda_stream.hpp>
@@ -37,30 +45,17 @@ namespace raft {
  */
 class resources {
  public:
-  template <typename T>
-  using pair_res = std::pair<resource::resource_type, std::shared_ptr<T>>;
-
-  using pair_res_factory = pair_res<resource::resource_factory>;
-  using pair_resource    = pair_res<resource::resource>;
-
-  resources()
-    : factories_(resource::resource_type::LAST_KEY), resources_(resource::resource_type::LAST_KEY)
+  resources() : cells_(resource::resource_type::LAST_KEY)
   {
-    for (int i = 0; i < resource::resource_type::LAST_KEY; ++i) {
-      factories_.at(i) = std::make_pair(resource::resource_type::LAST_KEY,
-                                        std::make_shared<resource::empty_resource_factory>());
-      resources_.at(i) = std::make_pair(resource::resource_type::LAST_KEY,
-                                        std::make_shared<resource::empty_resource>());
+    for (auto& c : cells_) {
+      c = std::make_shared<resource::resource_cell>();
     }
   }
 
-  /**
-   * @brief Shallow copy of underlying resources instance.
-   * Note that this does not create any new resources.
-   */
-  resources(const resources& res) : factories_(res.factories_), resources_(res.resources_) {}
-  resources(resources&&)            = delete;
-  resources& operator=(resources&&) = delete;
+  resources(const resources&)            = default;
+  resources(resources&&)                 = default;
+  resources& operator=(const resources&) = default;
+  resources& operator=(resources&&)      = default;
   virtual ~resources() {}
 
   /**
@@ -71,34 +66,50 @@ class resources {
    */
   virtual bool has_resource_factory(resource::resource_type resource_type) const
   {
-    std::lock_guard<std::mutex> _(mutex_);
-    return factories_.at(resource_type).first != resource::resource_type::LAST_KEY;
+    return cells_[resource_type]->factory.load() != nullptr;
   }
 
   /**
-   * @brief Register a resource_factory with the current instance.
-   * This will overwrite any existing resource factories.
+   * @brief Register a resource_factory with the current instance (explicit set).
+   *
+   * Creates a new resource_cell with the given factory.  Other copies of this
+   * handle continue to point at the old cell, so the change does not propagate.
+   *
    * @param factory resource factory to register on the current instance
    */
-  void add_resource_factory(std::shared_ptr<resource::resource_factory> factory) const
+  void add_resource_factory(std::shared_ptr<resource::resource_factory> factory)
   {
-    std::lock_guard<std::mutex> _(mutex_);
-    resource::resource_type rtype = factory.get()->get_resource_type();
+    resource::resource_type rtype = factory->get_resource_type();
     RAFT_EXPECTS(rtype != resource::resource_type::LAST_KEY,
                  "LAST_KEY is a placeholder and not a valid resource factory type.");
-    factories_.at(rtype) = std::make_pair(rtype, factory);
-    // Clear the corresponding resource, so that on next `get_resource` the new factory is used
-    if (resources_.at(rtype).first != resource::resource_type::LAST_KEY) {
-      resources_.at(rtype) = std::make_pair(resource::resource_type::LAST_KEY,
-                                            std::make_shared<resource::empty_resource>());
-    }
+    auto new_cell = std::make_shared<resource::resource_cell>();
+    new_cell->factory.store(std::move(factory));
+    cells_[rtype] = std::move(new_cell);
+  }
+
+  /**
+   * @brief Register a default factory if none has been set yet (lazy default).
+   *
+   * CAS's the factory into the existing shared cell.  If another thread or copy
+   * already set a factory, this is a no-op.  Because the cell is shared, all
+   * copies see the registered default.
+   *
+   * @param factory default resource factory
+   */
+  void ensure_default_factory(std::shared_ptr<resource::resource_factory> factory) const
+  {
+    resource::resource_type rtype = factory->get_resource_type();
+    std::shared_ptr<resource::resource_factory> expected{};
+    cells_[rtype]->factory.compare_exchange_strong(expected, std::move(factory));
   }
 
   /**
    * @brief Retrieve a resource for the given resource_type and cast to given pointer type.
-   * Note that the resources are loaded lazily on-demand and resources which don't yet
-   * exist on the current instance will be created using the corresponding factory, if
-   * it exists.
+   *
+   * Resources are created lazily on first access using the registered factory.
+   * The created resource is stored atomically in the shared cell, so all copies
+   * of this handle that share the same cell see the resource.
+   *
    * @tparam res_t pointer type for which retrieved resource will be casted
    * @param resource_type resource type to retrieve
    * @return the given resource, if it exists.
@@ -106,24 +117,25 @@ class resources {
   template <typename res_t>
   res_t* get_resource(resource::resource_type resource_type) const
   {
-    std::lock_guard<std::mutex> _(mutex_);
-
-    if (resources_.at(resource_type).first == resource::resource_type::LAST_KEY) {
-      RAFT_EXPECTS(factories_.at(resource_type).first != resource::resource_type::LAST_KEY,
+    auto& cell = cells_[resource_type];
+    auto res   = cell->res.load();
+    if (!res) {
+      auto factory = cell->factory.load();
+      RAFT_EXPECTS(factory != nullptr,
                    "No resource factory has been registered for the given resource %d.",
                    resource_type);
-      resource::resource_factory* factory = factories_.at(resource_type).second.get();
-      resources_.at(resource_type)        = std::make_pair(
-        resource_type, std::shared_ptr<resource::resource>(factory->make_resource()));
+      auto new_res = std::shared_ptr<resource::resource>(factory->make_resource());
+      std::shared_ptr<resource::resource> expected{};
+      if (cell->res.compare_exchange_strong(expected, new_res)) {
+        res = new_res;
+      } else {
+        res = expected;
+      }
     }
-
-    resource::resource* res = resources_.at(resource_type).second.get();
     return reinterpret_cast<res_t*>(res->get_resource());
   }
 
  protected:
-  mutable std::mutex mutex_;
-  mutable std::vector<pair_res_factory> factories_;
-  mutable std::vector<pair_resource> resources_;
+  std::vector<std::shared_ptr<resource::resource_cell>> cells_;
 };
 }  // namespace raft

--- a/cpp/include/raft/util/memory_tracking_resources.hpp
+++ b/cpp/include/raft/util/memory_tracking_resources.hpp
@@ -136,7 +136,7 @@ class memory_tracking_resources : public resources {
   // snapshot_ is destroyed last  (keeps original resource shared_ptrs alive).
   // owned_stream_ outlives report_ (report_ writes to it).
   // report_ is destroyed first of the three (stops background thread).
-  std::vector<pair_resource> snapshot_;
+  std::vector<std::shared_ptr<resource::resource_cell>> snapshot_;
   std::unique_ptr<std::ofstream> owned_stream_;
   raft::mr::resource_monitor report_;
 
@@ -163,7 +163,7 @@ class memory_tracking_resources : public resources {
     auto managed_ref  = raft::resource::get_managed_memory_resource_ref(*this);
 
     // Keeps original resource objects alive while tracking refs point into them.
-    snapshot_ = resources_;
+    snapshot_ = cells_;
 
     // --- Host (global) ---
     {

--- a/cpp/internal/CMakeLists.txt
+++ b/cpp/internal/CMakeLists.txt
@@ -1,6 +1,6 @@
 # =============================================================================
 # cmake-format: off
-# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 # cmake-format: on
 # =============================================================================
@@ -10,5 +10,5 @@ if(BUILD_TESTS OR BUILD_PRIMS_BENCH)
   target_include_directories(
     raft_internal INTERFACE "$<BUILD_INTERFACE:${RAFT_SOURCE_DIR}/internal>"
   )
-  target_compile_features(raft_internal INTERFACE cxx_std_17 $<BUILD_INTERFACE:cuda_std_17>)
+  target_compile_features(raft_internal INTERFACE cxx_std_20 $<BUILD_INTERFACE:cuda_std_20>)
 endif()

--- a/cpp/tests/core/handle.cpp
+++ b/cpp/tests/core/handle.cpp
@@ -342,4 +342,74 @@ TEST(Raft, HandleAssign)
   assert_handles_equal(handle, copied_handle);
 }
 
+TEST(Raft, LazyInitPropagates)
+{
+  raft::resources a;
+  raft::resources b(a);
+
+  // Neither a nor b has a CUDA stream factory yet
+  ASSERT_FALSE(a.has_resource_factory(resource::resource_type::CUDA_STREAM_VIEW));
+  ASSERT_FALSE(b.has_resource_factory(resource::resource_type::CUDA_STREAM_VIEW));
+
+  // Trigger lazy init on a
+  auto stream_a = resource::get_cuda_stream(a);
+
+  // b should see the same resource (Goal 1: lazy init propagates)
+  ASSERT_TRUE(b.has_resource_factory(resource::resource_type::CUDA_STREAM_VIEW));
+  auto stream_b = resource::get_cuda_stream(b);
+  ASSERT_EQ(stream_a, stream_b);
+}
+
+TEST(Raft, ExplicitSetRequiresNonConst)
+{
+  // Goal 2: add_resource_factory is non-const.
+  // This is a compile-time check -- the following must NOT compile:
+  //   const raft::resources r;
+  //   r.add_resource_factory(std::make_shared<resource::cuda_stream_resource_factory>());
+  // We verify the non-const overload works:
+  raft::resources r;
+  r.add_resource_factory(std::make_shared<resource::cuda_stream_resource_factory>());
+  ASSERT_TRUE(r.has_resource_factory(resource::resource_type::CUDA_STREAM_VIEW));
+}
+
+TEST(Raft, ExplicitSetDoesNotPropagate)
+{
+  raft::resources a;
+  raft::resources b(a);
+
+  // Trigger lazy init on both
+  auto stream_orig = resource::get_cuda_stream(a);
+  ASSERT_EQ(stream_orig, resource::get_cuda_stream(b));
+
+  // Explicit set on a -- creates a new cell
+  cudaStream_t raw_stream;
+  RAFT_CUDA_TRY(cudaStreamCreate(&raw_stream));
+  rmm::cuda_stream_view new_stream(raw_stream);
+  resource::set_cuda_stream(a, new_stream);
+
+  // a sees the new stream
+  ASSERT_EQ(new_stream, resource::get_cuda_stream(a));
+
+  // b still sees the old stream (Goal 3: explicit set does not propagate)
+  ASSERT_EQ(stream_orig, resource::get_cuda_stream(b));
+  ASSERT_NE(resource::get_cuda_stream(a), resource::get_cuda_stream(b));
+
+  RAFT_CUDA_TRY(cudaStreamDestroy(raw_stream));
+}
+
+TEST(Raft, ResourcesDefaultMovable)
+{
+  raft::resources a;
+  resource::get_cuda_stream(a);
+
+  // Move construct
+  raft::resources b(std::move(a));
+  ASSERT_TRUE(b.has_resource_factory(resource::resource_type::CUDA_STREAM_VIEW));
+
+  // Move assign
+  raft::resources c;
+  c = std::move(b);
+  ASSERT_TRUE(c.has_resource_factory(resource::resource_type::CUDA_STREAM_VIEW));
+}
+
 }  // namespace raft


### PR DESCRIPTION
Make the `raft::resources` resource initialization semantics more predictable.

1. All resources still are still initialized lazily on-demand (*no change*), but behave as-if they were initialized during the `raft::resources` handle construction: all copies of the `raft::resources` handle point to the same resources (*not a breaking change, fixes the re-initialization issue*).
2. `set_resource` changes to non-const semantics (*breaking change*).
     **Before**: all `set_xxx` resource-updating calls were operating on const handle
     **Now**: all `set_xxx` resources require a non-const handle.

### Thread-safety

First and foremost, thread-safety of using a specific resource depends on that resource. Here we discuss the thread-safety of using `raft::resources` handle itself (get_resource and set_resource functions).

#### Accessing the same resource by const ref

Updates (set_resource) are not possible (a user should copy a handle and modify the new one). All concurrent get_resource calls are atomic and safe, even if they initialize the factories and resources under the hood. The worst can happen is the same resource being initialized concurrently in two threads but only one being stored in the handle (the other one is discarded).

#### Accessing the same resource by non-const ref

Using the same object by non-const ref from multiple threads is always unsafe.

#### Accessing copies of the same resource

The resources and factories are updated atomically. Modifying any resource doesn't propagate to the copies. Accessing a resource while another threads access or modifies the same resource via another handle is thus safe.


### Implementation details

The PR adds one more layer of indirection (one extra shared_ptr) to each resource, which may cause an extra runtime overhead. This is unavoidable if we want to allow lazy-initialized resources back-propagate across handles.
On the other hand, the PR removes the handle mutex in favor of C++20 `std::atomic<shared_ptr>`, which may reduce the runtime overheads a little bit.


### Breaking changes

  - All resource setters change the function signature - this is a big breaking change. However, all known use-sites already call the resources setters on non-const `raft::resources` handles.
  - `std::atomic<shared_ptr>` requires enforcing C++20 for all dependent libraries. An alternative would be to put a mutex per `raft::resource_cell`.