### PR TITLE
[REVIEW] Drop extra copy in `CudaRuntimeError`

### DIFF
--- a/python/pylibraft/pylibraft/common/cuda.pyx
+++ b/python/pylibraft/pylibraft/common/cuda.pyx
@@ -25,9 +25,9 @@ from libc.stdint cimport uintptr_t
 class CudaRuntimeError(RuntimeError):
     def __init__(self, extraMsg=None):
         cdef cudaError_t e = cudaGetLastError()
-        cdef bytes errMsg = cudaGetErrorString(e)
-        cdef bytes errName = cudaGetErrorName(e)
-        msg = "Error! %s reason='%s'" % (errName.decode(), errMsg.decode())
+        cdef str errMsg = cudaGetErrorString(e).decode()
+        cdef str errName = cudaGetErrorName(e).decode()
+        msg = "Error! %s reason='%s'" % (errName, errMsg)
         if extraMsg is not None:
             msg += " extraMsg='%s'" % extraMsg
         super(CudaRuntimeError, self).__init__(msg)

--- a/python/pylibraft/pylibraft/common/cuda.pyx
+++ b/python/pylibraft/pylibraft/common/cuda.pyx
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 #
 


### PR DESCRIPTION
In `CudaRuntimeError`'s `__init__`, the assignment of `const char*` to `bytes` results in a copy as `bytes` must own its memory. After that the `bytes` object is `decode`d to a Python `str`. However it is possible to `decode` directly from `const char*` to `str` avoiding the copy to the temporary `bytes` object. Hence this code makes that change.