### PR TITLE
Fix eigDC version check for syevd

### DIFF
--- a/cpp/include/raft/linalg/detail/eig.cuh
+++ b/cpp/include/raft/linalg/detail/eig.cuh
@@ -81,15 +81,17 @@ void eigDC(raft::resources const& handle,
 {
   int cusolver_major = -1;
   int cusolver_minor = -1;
+  int cusolver_patch = -1;
   RAFT_CUSOLVER_TRY(cusolverGetProperty(MAJOR_VERSION, &cusolver_major));
   RAFT_CUSOLVER_TRY(cusolverGetProperty(MINOR_VERSION, &cusolver_minor));
-  int cusolver_version = cusolver_major * 1000 + cusolver_minor * 10;
+  RAFT_CUSOLVER_TRY(cusolverGetProperty(PATCH_LEVEL, &cusolver_patch));
+  int cusolver_version = cusolver_major * 10000 + cusolver_minor * 100 + cusolver_patch;
   cudaStream_t stream_new;
   cudaEvent_t sync_event = resource::detail::get_cuda_stream_sync_event(handle);
   rmm::cuda_stream stream_new_wrapper;
-  if (cusolver_version < 11070) {
+  if (cusolver_version < 110603) {
     // Use a new stream instead of `cudaStreamPerThread` to avoid cusolver bug # 4580093.
-    // Solved in cusolver 11.7.0 / CUDA 12.5.
+    // Solved in cusolver 11.6.2.40 / CUDA 12.5.
     stream_new = stream_new_wrapper.value();
     RAFT_CUDA_TRY(cudaEventRecord(sync_event, stream));
     RAFT_CUDA_TRY(cudaStreamWaitEvent(stream_new, sync_event));
@@ -143,7 +145,7 @@ void eigDC(raft::resources const& handle,
          "eig.cuh: eigensolver couldn't converge to a solution. "
          "This usually occurs when some of the features do not vary enough.");
 
-  if (cusolver_version < 11070) {
+  if (cusolver_version < 110603) {
     // Synchronize the created stream with the original stream before return
     RAFT_CUDA_TRY(cudaEventRecord(sync_event, stream_new));
     RAFT_CUDA_TRY(cudaStreamWaitEvent(stream, sync_event));

--- a/cpp/include/raft/linalg/detail/eig.cuh
+++ b/cpp/include/raft/linalg/detail/eig.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -79,13 +79,17 @@ void eigDC(raft::resources const& handle,
            math_t* eig_vals,
            cudaStream_t stream)
 {
-  int cudart_version = 0;
-  RAFT_CUDA_TRY(cudaRuntimeGetVersion(&cudart_version));
+  int cusolver_major = -1;
+  int cusolver_minor = -1;
+  RAFT_CUSOLVER_TRY(cusolverGetProperty(MAJOR_VERSION, &cusolver_major));
+  RAFT_CUSOLVER_TRY(cusolverGetProperty(MINOR_VERSION, &cusolver_minor));
+  int cusolver_version = cusolver_major * 1000 + cusolver_minor * 10;
   cudaStream_t stream_new;
   cudaEvent_t sync_event = resource::detail::get_cuda_stream_sync_event(handle);
   rmm::cuda_stream stream_new_wrapper;
-  if (cudart_version < 12050) {
+  if (cusolver_version < 11070) {
     // Use a new stream instead of `cudaStreamPerThread` to avoid cusolver bug # 4580093.
+    // Solved in cusolver 11.7.0 / CUDA 12.5.
     stream_new = stream_new_wrapper.value();
     RAFT_CUDA_TRY(cudaEventRecord(sync_event, stream));
     RAFT_CUDA_TRY(cudaStreamWaitEvent(stream_new, sync_event));
@@ -139,7 +143,7 @@ void eigDC(raft::resources const& handle,
          "eig.cuh: eigensolver couldn't converge to a solution. "
          "This usually occurs when some of the features do not vary enough.");
 
-  if (cudart_version < 12050) {
+  if (cusolver_version < 11070) {
     // Synchronize the created stream with the original stream before return
     RAFT_CUDA_TRY(cudaEventRecord(sync_event, stream_new));
     RAFT_CUDA_TRY(cudaStreamWaitEvent(stream, sync_event));

--- a/cpp/tests/linalg/eig.cu
+++ b/cpp/tests/linalg/eig.cu
@@ -156,7 +156,7 @@ TEST(Raft, EigStream)
   auto eig_vectors_stream =
     raft::make_device_matrix<float, std::uint32_t, raft::col_major>(handle, n_rows, n_rows);
   auto eig_vals_stream = raft::make_device_vector<float, std::uint32_t>(handle, n_rows);
-  uniform(handle, r, cov_matrix_stream.data(), n_rows * n_rows, float(-1.0), float(1.0));
+  uniform(handle, r, cov_matrix_stream.data_handle(), n_rows * n_rows, float(-1.0), float(1.0));
 
   raft::linalg::eig_dc(handle,
                        raft::make_const_mdspan(cov_matrix_stream.view()),

--- a/cpp/tests/linalg/eig.cu
+++ b/cpp/tests/linalg/eig.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -148,6 +148,7 @@ class EigTest : public ::testing::TestWithParam<EigInputs<T>> {
 TEST(Raft, EigStream)
 {
   // Separate test to check eig_dc stream workaround for CUDA 12+
+  raft::random::RngState r(1234ULL);
   raft::resources handle;
   auto n_rows = 5000;
   auto cov_matrix_stream =
@@ -155,6 +156,7 @@ TEST(Raft, EigStream)
   auto eig_vectors_stream =
     raft::make_device_matrix<float, std::uint32_t, raft::col_major>(handle, n_rows, n_rows);
   auto eig_vals_stream = raft::make_device_vector<float, std::uint32_t>(handle, n_rows);
+  uniform(handle, r, cov_matrix_stream.data(), n_rows * n_rows, float(-1.0), float(1.0));
 
   raft::linalg::eig_dc(handle,
                        raft::make_const_mdspan(cov_matrix_stream.view()),


### PR DESCRIPTION
Previous work on that bug:
- #2332
- #2430

Currently the version of cudart is check at runtime instead of checking for cusolver version. This PR solves that bug that could arise in the cases where CUDA version is superior to 12.5 but the cusolver version used was older.