### PR TITLE
fix(visibility): restrict RAFT_EXPORT to core/ and raft_runtime/ only

### DIFF
--- a/cpp/include/raft/common/detail/scatter.cuh
+++ b/cpp/include/raft/common/detail/scatter.cuh
@@ -9,7 +9,7 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/vectorized.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace detail {
 
 template <typename DataT, int VecLen, typename Lambda, typename IdxT>
@@ -41,4 +41,4 @@ void scatterImpl(
 }
 
 }  // namespace detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/comms/comms_test.hpp
+++ b/cpp/include/raft/comms/comms_test.hpp
@@ -10,7 +10,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/core/resources.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace comms {
 
 /**
@@ -157,4 +157,4 @@ bool test_commsplit(raft::resources const& h, int n_colors)
   return detail::test_commsplit(h, n_colors);
 }
 }  // namespace comms
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/comms/detail/mpi_comms.hpp
+++ b/cpp/include/raft/comms/detail/mpi_comms.hpp
@@ -60,7 +60,7 @@
 #ifndef MPI_TRY_NO_THROW
 #define MPI_TRY_NO_THROW(call) RAFT_MPI_TRY_NO_THROW(call)
 #endif
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace comms {
 namespace detail {
 
@@ -457,4 +457,4 @@ class mpi_comms : public comms_iface {
 
 }  // end namespace detail
 };  // end namespace comms
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/comms/detail/std_comms.hpp
+++ b/cpp/include/raft/comms/detail/std_comms.hpp
@@ -36,7 +36,7 @@
 #include <unordered_set>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace comms {
 namespace detail {
 
@@ -597,4 +597,4 @@ class std_comms : public comms_iface {
 };
 }  // namespace detail
 }  // end namespace comms
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/comms/detail/test.hpp
+++ b/cpp/include/raft/comms/detail/test.hpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <numeric>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace comms {
 namespace detail {
 
@@ -531,4 +531,4 @@ bool test_commsplit(raft::resources const& h, int n_colors)
 
 }  // namespace detail
 }  // namespace comms
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/comms/detail/ucp_helper.hpp
+++ b/cpp/include/raft/comms/detail/ucp_helper.hpp
@@ -12,7 +12,7 @@
 #include <ucp/api/ucp.h>
 #include <ucp/api/ucp_def.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace comms {
 namespace detail {
 
@@ -151,4 +151,4 @@ class comms_ucp_handler {
 };
 }  // end namespace detail
 }  // end namespace comms
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/comms/detail/util.hpp
+++ b/cpp/include/raft/comms/detail/util.hpp
@@ -15,7 +15,7 @@
 
 #include <string>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace comms {
 namespace detail {
 
@@ -97,4 +97,4 @@ inline status_t nccl_sync_stream(ncclComm_t comm, cudaStream_t stream)
 
 };  // namespace detail
 };  // namespace comms
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/comms/mpi_comms.hpp
+++ b/cpp/include/raft/comms/mpi_comms.hpp
@@ -11,7 +11,7 @@
 #include <raft/core/resource/comms.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace comms {
 
 using mpi_comms = detail::mpi_comms;
@@ -59,4 +59,4 @@ inline void initialize_mpi_comms(resources* handle, MPI_Comm comm)
  */
 
 };  // namespace comms
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/comms/std_comms.hpp
+++ b/cpp/include/raft/comms/std_comms.hpp
@@ -18,7 +18,7 @@
 
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace comms {
 
 using std_comms = detail::std_comms;
@@ -174,4 +174,4 @@ inline void get_nccl_unique_id(char* uid)
   memcpy(uid, id.internal, NCCL_UNIQUE_ID_BYTES);
 }
 };  // namespace comms
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/core/cublas_macros.hpp
+++ b/cpp/include/raft/core/cublas_macros.hpp
@@ -37,6 +37,9 @@ struct cublas_error : public raft::exception {
  * @}
  */
 
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -59,7 +62,7 @@ inline const char* cublas_error_to_string(cublasStatus_t err)
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #undef _CUBLAS_ERR_TO_STR
 

--- a/cpp/include/raft/core/cusolver_macros.hpp
+++ b/cpp/include/raft/core/cusolver_macros.hpp
@@ -38,6 +38,9 @@ struct cusolver_error : public raft::exception {
  * @}
  */
 
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -60,7 +63,7 @@ inline const char* cusolver_error_to_string(cusolverStatus_t err)
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #undef _CUSOLVER_ERR_TO_STR
 

--- a/cpp/include/raft/core/cusparse_macros.hpp
+++ b/cpp/include/raft/core/cusparse_macros.hpp
@@ -42,6 +42,9 @@ struct cusparse_error : public raft::exception {
 /**
  * @}
  */
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace sparse {
 namespace detail {
 
@@ -52,7 +55,7 @@ inline const char* cusparse_error_to_string(cusparseStatus_t err)
 
 }  // namespace detail
 }  // namespace sparse
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #undef _CUSPARSE_ERR_TO_STR
 

--- a/cpp/include/raft/core/detail/copy.hpp
+++ b/cpp/include/raft/core/detail/copy.hpp
@@ -27,7 +27,7 @@
 #endif
 #endif
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace detail {
 
 template <bool B,
@@ -543,4 +543,4 @@ mdspan_copyable_t<DstType, SrcType> copy(resources const& res, DstType&& dst, Sr
   }
 }
 }  // namespace detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/core/detail/fail_container_policy.hpp
+++ b/cpp/include/raft/core/detail/fail_container_policy.hpp
@@ -13,7 +13,7 @@
 
 #include <stddef.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace detail {
 
 template <typename T>
@@ -135,4 +135,4 @@ struct fail_container_policy {
 };
 
 }  // namespace detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/core/detail/mdspan_numpy_serializer.hpp
+++ b/cpp/include/raft/core/detail/mdspan_numpy_serializer.hpp
@@ -26,7 +26,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 namespace detail {
 
@@ -487,4 +487,4 @@ inline T deserialize_scalar(std::istream& is)
 
 }  // end namespace numpy_serializer
 }  // end namespace detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/core/detail/mdspan_util.cuh
+++ b/cpp/include/raft/core/detail/mdspan_util.cuh
@@ -10,7 +10,7 @@
 #include <tuple>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace detail {
 
 template <class T, std::size_t N, std::size_t... Idx>
@@ -58,4 +58,4 @@ RAFT_INLINE_FUNCTION auto popc(uint64_t v) -> int32_t
 }
 
 }  // namespace detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/core/detail/nvtx.hpp
+++ b/cpp/include/raft/core/detail/nvtx.hpp
@@ -21,7 +21,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace common::nvtx::detail {
 
 /**
@@ -178,11 +178,11 @@ inline void pop_range()
 }
 
 }  // namespace common::nvtx::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #else   // NVTX_ENABLED
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace common::nvtx::detail {
 
 template <typename Domain, typename... Args>
@@ -196,5 +196,5 @@ inline void pop_range()
 }
 
 }  // namespace common::nvtx::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 #endif  // NVTX_ENABLED

--- a/cpp/include/raft/core/detail/nvtx_range_stack.hpp
+++ b/cpp/include/raft/core/detail/nvtx_range_stack.hpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace common::nvtx {
 
 namespace detail {
@@ -91,4 +91,4 @@ inline auto thread_local_current_range() -> std::shared_ptr<const current_range>
 }
 
 }  // namespace common::nvtx
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/core/detail/span.hpp
+++ b/cpp/include/raft/core/detail/span.hpp
@@ -10,7 +10,7 @@
 #include <limits>  // numeric_limits
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 template <class ElementType, bool is_device, std::size_t Extent>
 class span;
@@ -95,4 +95,4 @@ struct span_storage<T, dynamic_extent> {
   [[nodiscard]] constexpr auto data() const noexcept -> T* { return ptr_; }
 };
 }  // namespace detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/core/mdarray.hpp
+++ b/cpp/include/raft/core/mdarray.hpp
@@ -50,6 +50,9 @@ class array_interface {
   auto view() const noexcept { return static_cast<Base*>(this)->view(); }
 };
 
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace detail {
 template <typename T, typename = void>
 struct is_array_interface : std::false_type {};
@@ -68,7 +71,9 @@ using is_array_interface_t = is_array_interface<std::remove_const_t<T>>;
 template <typename T>
 inline constexpr bool is_array_interface_v = is_array_interface<std::remove_const_t<T>>::value;
 }  // namespace detail
+}  // namespace raft
 
+namespace RAFT_EXPORT raft {
 template <typename...>
 struct is_array_interface : std::true_type {};
 template <typename T1>

--- a/cpp/include/raft/core/mdbuffer.cuh
+++ b/cpp/include/raft/core/mdbuffer.cuh
@@ -69,6 +69,9 @@ using alternate_from_mem_type =
   std::variant_alternative_t<variant_index_from_memory_type(MemType) % std::variant_size_v<Variant>,
                              Variant>;
 
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace detail {
 template <typename T, raft::memory_type MemType>
 struct memory_type_to_default_policy {};
@@ -92,7 +95,9 @@ struct memory_type_to_default_policy<T, raft::memory_type::pinned> {
 template <typename T, raft::memory_type MemType>
 using memory_type_to_default_policy_t = typename memory_type_to_default_policy<T, MemType>::type;
 }  // namespace detail
+}  // namespace raft
 
+namespace RAFT_EXPORT raft {
 /**
  * @brief A variant of container policies for each memory type which can be
  * used to build the default container policy for a buffer.

--- a/cpp/include/raft/core/mdspan.hpp
+++ b/cpp/include/raft/core/mdspan.hpp
@@ -25,6 +25,9 @@ template <typename ElementType,
           typename AccessorPolicy = cuda::std::default_accessor<ElementType>>
 using mdspan = cuda::std::mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>;
 
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace detail {
 
 template <typename IntType>
@@ -53,7 +56,9 @@ struct alignment {
 };
 
 }  // namespace detail
+}  // namespace raft
 
+namespace RAFT_EXPORT raft {
 /**
  * @brief Padded layouts that take a padding value directly.
  */

--- a/cpp/include/raft/core/memory_type.hpp
+++ b/cpp/include/raft/core/memory_type.hpp
@@ -56,6 +56,9 @@ struct memory_type_constant {
   }();
 };
 
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace detail {
 
 template <bool is_host_accessible, bool is_device_accessible>
@@ -73,7 +76,9 @@ auto constexpr memory_type_from_access()
 }
 
 }  // end namespace detail
+}  // namespace raft
 
+namespace RAFT_EXPORT raft {
 template <typename T>
 auto memory_type_from_pointer(T* ptr)
 {

--- a/cpp/include/raft/core/resource/detail/stream_sync_event.hpp
+++ b/cpp/include/raft/core/resource/detail/stream_sync_event.hpp
@@ -12,7 +12,7 @@
 
 #include <cuda_runtime.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace resource::detail {
 
 /**
@@ -40,4 +40,4 @@ inline cudaEvent_t& get_cuda_stream_sync_event(resources const& res)
 };
 
 }  // namespace resource::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/core/resource/device_memory_resource.hpp
+++ b/cpp/include/raft/core/resource/device_memory_resource.hpp
@@ -164,6 +164,11 @@ class workspace_resource_factory : public resource_factory {
   }
 };
 
+}  // namespace resource
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
+namespace resource {
 namespace detail {
 
 inline auto get_workspace_adaptor(resources const& res) -> rmm::mr::limiting_resource_adaptor*
@@ -175,7 +180,11 @@ inline auto get_workspace_adaptor(resources const& res) -> rmm::mr::limiting_res
 }
 
 }  // namespace detail
+}  // namespace resource
+}  // namespace raft
 
+namespace RAFT_EXPORT raft {
+namespace resource {
 /**
  * @brief Load a temp workspace resource from a resources instance (and populate it on the res if
  * needed).

--- a/cpp/include/raft/core/stream_view.hpp
+++ b/cpp/include/raft/core/stream_view.hpp
@@ -15,6 +15,9 @@
 
 namespace RAFT_EXPORT raft {
 
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace detail {
 struct fail_stream_view {
   constexpr fail_stream_view()                                           = default;
@@ -35,7 +38,9 @@ struct fail_stream_view {
   }
 };
 }  // namespace detail
+}  // namespace raft
 
+namespace RAFT_EXPORT raft {
 /** A lightweight wrapper around rmm::cuda_stream_view that can be used in
  * CUDA-free builds
  *

--- a/cpp/include/raft/label/classlabels.cuh
+++ b/cpp/include/raft/label/classlabels.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/label/detail/classlabels.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace label {
 
 /**
@@ -106,5 +106,5 @@ void make_monotonic(Type* out, Type* in, size_t N, cudaStream_t stream, bool zer
   detail::make_monotonic<Type>(out, in, N, stream, zero_based);
 }
 };  // namespace label
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/label/detail/classlabels.cuh
+++ b/cpp/include/raft/label/detail/classlabels.cuh
@@ -19,7 +19,7 @@
 
 #include <algorithm>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace label {
 namespace detail {
 
@@ -192,4 +192,4 @@ void make_monotonic(Type* out, Type* in, size_t N, cudaStream_t stream, bool zer
 
 };  // namespace detail
 };  // namespace label
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/label/detail/merge_labels.cuh
+++ b/cpp/include/raft/label/detail/merge_labels.cuh
@@ -14,7 +14,7 @@
 
 #include <limits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace label {
 namespace detail {
 
@@ -145,4 +145,4 @@ void merge_labels(value_idx* labels_a,
 
 }  // namespace detail
 };  // namespace label
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/label/merge_labels.cuh
+++ b/cpp/include/raft/label/merge_labels.cuh
@@ -11,7 +11,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/label/detail/merge_labels.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace label {
 
 /**
@@ -56,5 +56,5 @@ void merge_labels(value_idx* labels_a,
 }
 
 };  // namespace label
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/linalg/add.cuh
+++ b/cpp/include/raft/linalg/add.cuh
@@ -15,7 +15,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -193,6 +193,6 @@ void add_scalar(raft::resources const& handle,
 /** @} */  // end of group add
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/axpy.cuh
+++ b/cpp/include/raft/linalg/axpy.cuh
@@ -14,7 +14,7 @@
 #include <raft/core/host_mdspan.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -114,6 +114,6 @@ void axpy(raft::resources const& handle,
 /** @} */  // end of group axpy
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/binary_op.cuh
+++ b/cpp/include/raft/linalg/binary_op.cuh
@@ -12,7 +12,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/linalg/map.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -73,6 +73,6 @@ void binary_op(raft::resources const& handle, InType in1, InType in2, OutType ou
 /** @} */  // end of group binary_op
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/cholesky_r1_update.cuh
+++ b/cpp/include/raft/linalg/cholesky_r1_update.cuh
@@ -12,7 +12,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/core/resource/cublas_handle.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -127,6 +127,6 @@ void choleskyRank1Update(raft::resources const& handle,
 }
 
 };  // namespace linalg
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/coalesced_reduction.cuh
+++ b/cpp/include/raft/linalg/coalesced_reduction.cuh
@@ -15,7 +15,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resources.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -151,6 +151,6 @@ void coalesced_reduction(raft::resources const& handle,
 /** @} */  // end of group coalesced_reduction
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/contractions.cuh
+++ b/cpp/include/raft/linalg/contractions.cuh
@@ -11,7 +11,7 @@
 
 #include <raft/core/detail/macros.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -238,6 +238,6 @@ struct Policy2x8<half, _veclen> {
 using detail::Contractions_NT;
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/detail/add.cuh
+++ b/cpp/include/raft/linalg/detail/add.cuh
@@ -11,7 +11,7 @@
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -50,4 +50,4 @@ void addDevScalar(
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/axpy.cuh
+++ b/cpp/include/raft/linalg/detail/axpy.cuh
@@ -13,7 +13,7 @@
 
 #include <cublas_v2.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg::detail {
 
 template <typename T, bool DevicePointerMode = false>
@@ -32,4 +32,4 @@ void axpy(raft::resources const& handle,
 }
 
 }  // namespace linalg::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/cholesky_r1_update.cuh
+++ b/cpp/include/raft/linalg/detail/cholesky_r1_update.cuh
@@ -14,7 +14,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/linalg/binary_op.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -121,4 +121,4 @@ void choleskyRank1Update(raft::resources const& handle,
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/coalesced_reduction-inl.cuh
+++ b/cpp/include/raft/linalg/detail/coalesced_reduction-inl.cuh
@@ -14,7 +14,7 @@
 
 #include <cub/block/block_reduce.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -614,4 +614,4 @@ void coalescedReduction(OutType* dots,
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/contractions.cuh
+++ b/cpp/include/raft/linalg/detail/contractions.cuh
@@ -8,7 +8,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/util/device_loads_stores.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -310,4 +310,4 @@ struct Contractions_NT {
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/cublas_wrappers.hpp
+++ b/cpp/include/raft/linalg/detail/cublas_wrappers.hpp
@@ -13,7 +13,7 @@
 
 #include <cstdint>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -1024,4 +1024,4 @@ inline cublasStatus_t cublasscal(
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/cublaslt_wrappers.hpp
+++ b/cpp/include/raft/linalg/detail/cublaslt_wrappers.hpp
@@ -20,7 +20,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg::detail {
 
 /** Get the cublas compute type for the combination of input types. */
@@ -373,4 +373,4 @@ void matmul(raft::resources const& res,
 }
 
 }  // namespace linalg::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/cusolver_wrappers.hpp
+++ b/cpp/include/raft/linalg/detail/cusolver_wrappers.hpp
@@ -14,7 +14,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -1520,4 +1520,4 @@ inline cusolverStatus_t cusolverDnxsyevd(  // NOLINT
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/divide.cuh
+++ b/cpp/include/raft/linalg/detail/divide.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/operators.hpp>
 #include <raft/linalg/unary_op.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -22,4 +22,4 @@ void divideScalar(OutT* out, const InT* in, InT scalar, IdxType len, cudaStream_
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/eig.cuh
+++ b/cpp/include/raft/linalg/detail/eig.cuh
@@ -20,7 +20,7 @@
 
 #include <cuda_runtime_api.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -312,4 +312,4 @@ void eigJacobi(raft::resources const& handle,
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/eltwise.cuh
+++ b/cpp/include/raft/linalg/detail/eltwise.cuh
@@ -10,7 +10,7 @@
 #include <raft/linalg/binary_op.cuh>
 #include <raft/linalg/unary_op.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -63,4 +63,4 @@ void eltwiseDivideCheckZero(
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/gemm.cuh
+++ b/cpp/include/raft/linalg/detail/gemm.cuh
@@ -9,7 +9,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/core/resources.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg::detail {
 
 template <typename A_T, typename B_T, typename C_T, typename S_T, bool DevicePointerMode = false>
@@ -138,4 +138,4 @@ void legacy_gemm(raft::resources const& res,
 }
 
 }  // namespace linalg::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/gemv.hpp
+++ b/cpp/include/raft/linalg/detail/gemv.hpp
@@ -13,7 +13,7 @@
 
 #include <cublas_v2.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -134,4 +134,4 @@ void gemv(raft::resources const& handle,
 
 };  // namespace detail
 };  // namespace linalg
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/linalg/detail/lstsq.cuh
+++ b/cpp/include/raft/linalg/detail/lstsq.cuh
@@ -25,7 +25,7 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -443,4 +443,4 @@ void lstsqQR(raft::resources const& handle,
 }
 };  // namespace detail
 };  // namespace linalg
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/linalg/detail/map.cuh
+++ b/cpp/include/raft/linalg/detail/map.cuh
@@ -20,7 +20,7 @@
 
 #include <cuda/std/tuple>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg::detail {
 
 template <bool PassOffset, typename OutT, typename IdxT, typename Func, typename... InTs>
@@ -223,4 +223,4 @@ void map(const raft::resources& res, OutType out, Func f, InTypes... ins)
 }
 
 }  // namespace linalg::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/map_then_reduce.cuh
+++ b/cpp/include/raft/linalg/detail/map_then_reduce.cuh
@@ -12,7 +12,7 @@
 
 #include <cub/block/block_reduce.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -86,4 +86,4 @@ void mapThenReduceImpl(OutType* out,
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/matrix_vector_op.cuh
+++ b/cpp/include/raft/linalg/detail/matrix_vector_op.cuh
@@ -9,7 +9,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/linewise_op.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -91,4 +91,4 @@ void matrixVectorOp(MatT* out,
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/mean_squared_error.cuh
+++ b/cpp/include/raft/linalg/detail/mean_squared_error.cuh
@@ -8,7 +8,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/linalg/map_then_reduce.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -25,4 +25,4 @@ void meanSquaredError(
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/multiply.cuh
+++ b/cpp/include/raft/linalg/detail/multiply.cuh
@@ -9,7 +9,7 @@
 #include <raft/core/operators.hpp>
 #include <raft/linalg/unary_op.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -22,4 +22,4 @@ void multiplyScalar(
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/norm.cuh
+++ b/cpp/include/raft/linalg/detail/norm.cuh
@@ -10,7 +10,7 @@
 #include <raft/linalg/norm_types.hpp>
 #include <raft/linalg/reduce.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -62,4 +62,4 @@ void colNormCaller(
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/normalize.cuh
+++ b/cpp/include/raft/linalg/detail/normalize.cuh
@@ -10,7 +10,7 @@
 
 #include <cub/block/block_reduce.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -176,4 +176,4 @@ void coalesced_normalize(Type* out,
 
 }  // namespace detail
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/detail/pca.cuh
+++ b/cpp/include/raft/linalg/detail/pca.cuh
@@ -26,7 +26,7 @@
 
 #include <rmm/device_uvector.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg::detail {
 
 template <typename math_t, typename idx_t>
@@ -321,4 +321,4 @@ void pca_fit_transform(raft::resources const& handle,
 }
 
 };  // end namespace linalg::detail
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/qr.cuh
+++ b/cpp/include/raft/linalg/detail/qr.cuh
@@ -18,7 +18,7 @@
 
 #include <algorithm>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -151,4 +151,4 @@ void qrGetQR(raft::resources const& handle,
 
 };  // namespace detail
 };  // namespace linalg
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/linalg/detail/reduce.cuh
+++ b/cpp/include/raft/linalg/detail/reduce.cuh
@@ -10,7 +10,7 @@
 #include <raft/linalg/coalesced_reduction.cuh>
 #include <raft/linalg/strided_reduction.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -50,4 +50,4 @@ void reduce(OutType* dots,
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/reduce_cols_by_key.cuh
+++ b/cpp/include/raft/linalg/detail/reduce_cols_by_key.cuh
@@ -12,7 +12,7 @@
 
 #include <limits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -130,4 +130,4 @@ void reduce_cols_by_key(const T* data,
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/reduce_rows_by_key.cuh
+++ b/cpp/include/raft/linalg/detail/reduce_rows_by_key.cuh
@@ -14,7 +14,7 @@
 #include <limits>
 
 #define MAX_BLOCKS 65535u
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -400,4 +400,4 @@ void reduce_rows_by_key(const DataIteratorT d_A,
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/rsvd.cuh
+++ b/cpp/include/raft/linalg/detail/rsvd.cuh
@@ -25,7 +25,7 @@
 
 #include <algorithm>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -503,4 +503,4 @@ void rsvdPerc(raft::resources const& handle,
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/strided_reduction.cuh
+++ b/cpp/include/raft/linalg/detail/strided_reduction.cuh
@@ -12,7 +12,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -179,4 +179,4 @@ void stridedReduction(OutType* dots,
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/subtract.cuh
+++ b/cpp/include/raft/linalg/detail/subtract.cuh
@@ -11,7 +11,7 @@
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/cuda_utils.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -55,4 +55,4 @@ void subtractDevScalar(math_t* outDev,
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/svd.cuh
+++ b/cpp/include/raft/linalg/detail/svd.cuh
@@ -28,7 +28,7 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -333,4 +333,4 @@ bool evaluateSVDByL2Norm(raft::resources const& handle,
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/transpose.cuh
+++ b/cpp/include/raft/linalg/detail/transpose.cuh
@@ -20,7 +20,7 @@
 
 #include <cmath>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 namespace detail {
 
@@ -269,4 +269,4 @@ void transpose_col_major_impl(
 
 };  // end namespace detail
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/detail/tsvd.cuh
+++ b/cpp/include/raft/linalg/detail/tsvd.cuh
@@ -38,7 +38,7 @@
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg::detail {
 
 template <typename math_t, typename idx_t>
@@ -521,4 +521,4 @@ void tsvd_fit_transform(raft::resources const& handle,
 }
 
 };  // end namespace linalg::detail
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/divide.cuh
+++ b/cpp/include/raft/linalg/divide.cuh
@@ -15,7 +15,7 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -80,6 +80,6 @@ void divide_scalar(raft::resources const& handle,
 /** @} */  // end of group add
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/dot.cuh
+++ b/cpp/include/raft/linalg/dot.cuh
@@ -15,7 +15,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/linalg/detail/cublas_wrappers.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -86,5 +86,5 @@ void dot(raft::resources const& handle,
 /** @} */  // end of group dot
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 #endif

--- a/cpp/include/raft/linalg/eig.cuh
+++ b/cpp/include/raft/linalg/eig.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -211,6 +211,6 @@ void eig_jacobi(raft::resources const& handle,
 /** @} */  // end of eig
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/eltwise.cuh
+++ b/cpp/include/raft/linalg/eltwise.cuh
@@ -11,7 +11,7 @@
 
 #include <raft/core/detail/macros.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -86,6 +86,6 @@ void eltwiseDivideCheckZero(
 /** @} */
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/gemm.cuh
+++ b/cpp/include/raft/linalg/gemm.cuh
@@ -19,7 +19,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -286,6 +286,6 @@ void gemm(raft::resources const& res,
 /** @} */  // end of gemm
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/gemv.cuh
+++ b/cpp/include/raft/linalg/gemv.cuh
@@ -17,7 +17,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -296,5 +296,5 @@ void gemv(raft::resources const& handle,
 /** @} */  // end of gemv
 
 };  // namespace linalg
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/linalg/init.cuh
+++ b/cpp/include/raft/linalg/init.cuh
@@ -11,7 +11,7 @@
 #include <raft/linalg/map.cuh>
 #include <raft/util/cudart_utils.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -60,6 +60,6 @@ void zero(T* out, int n, cudaStream_t stream)
 }
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/linalg_types.hpp
+++ b/cpp/include/raft/linalg/linalg_types.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -24,4 +24,4 @@ enum class FillMode { UPPER, LOWER };
 enum class Operation { NON_TRANSPOSE, TRANSPOSE };
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/lstsq.cuh
+++ b/cpp/include/raft/linalg/lstsq.cuh
@@ -11,7 +11,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resources.hpp>
 #include <raft/linalg/detail/lstsq.cuh>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /** Solves the linear ordinary least squares problem `Aw = b`
@@ -236,6 +236,6 @@ void lstsq_qr(raft::resources const& handle,
 /** @} */  // end of lstsq
 
 };  // namespace linalg
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/map.cuh
+++ b/cpp/include/raft/linalg/map.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/resources.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -303,6 +303,6 @@ void map_offset(
 /** @} */  // end of map
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/map_reduce.cuh
+++ b/cpp/include/raft/linalg/map_reduce.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -105,6 +105,6 @@ void map_reduce(raft::resources const& handle,
 /** @} */  // end of map_reduce
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/map_then_reduce.cuh
+++ b/cpp/include/raft/linalg/map_then_reduce.cuh
@@ -11,7 +11,7 @@
 
 #include <raft/core/detail/macros.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -80,6 +80,6 @@ template <typename InType,
 }
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/matrix_vector.cuh
+++ b/cpp/include/raft/linalg/matrix_vector.cuh
@@ -12,7 +12,7 @@
 #include <raft/matrix/detail/math.cuh>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -201,4 +201,4 @@ void binary_sub(raft::resources const& handle,
 /** @} */  // end of matrix_vector
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/matrix_vector_op.cuh
+++ b/cpp/include/raft/linalg/matrix_vector_op.cuh
@@ -17,7 +17,7 @@
 #include <raft/core/types.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -235,6 +235,6 @@ void matrix_vector_op(raft::resources const& handle,
 /** @} */  // end of group matrix_vector_op
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/mean_squared_error.cuh
+++ b/cpp/include/raft/linalg/mean_squared_error.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -71,6 +71,6 @@ void mean_squared_error(raft::resources const& handle,
 /** @} */  // end of group mean_squared_error
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/multiply.cuh
+++ b/cpp/include/raft/linalg/multiply.cuh
@@ -15,7 +15,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -82,6 +82,6 @@ void multiply_scalar(
 /** @} */  // end of group multiply
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/norm.cuh
+++ b/cpp/include/raft/linalg/norm.cuh
@@ -19,7 +19,7 @@
 #include <raft/linalg/norm_types.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -150,6 +150,6 @@ void norm(raft::resources const& handle,
 /** @} */
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/norm_types.hpp
+++ b/cpp/include/raft/linalg/norm_types.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /** Enum to tell how to compute a norm */
@@ -23,4 +23,4 @@ enum NormType : unsigned short {
 };
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/normalize.cuh
+++ b/cpp/include/raft/linalg/normalize.cuh
@@ -14,7 +14,7 @@
 #include <raft/linalg/norm_types.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -107,4 +107,4 @@ void row_normalize(raft::resources const& handle,
 /** @} */
 
 }  // namespace linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/linalg/pca.cuh
+++ b/cpp/include/raft/linalg/pca.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/core/device_mdspan.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -191,4 +191,4 @@ void trunc_comp_exp_vars(raft::resources const& handle,
 /** @} */  // end group pca
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/pca_types.hpp
+++ b/cpp/include/raft/linalg/pca_types.hpp
@@ -9,7 +9,7 @@
 
 #include <cstdint>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -37,4 +37,4 @@ struct paramsPCA : paramsTSVD {
 };
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/power.cuh
+++ b/cpp/include/raft/linalg/power.cuh
@@ -15,7 +15,7 @@
 #include <raft/linalg/unary_op.cuh>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -131,6 +131,6 @@ void power_scalar(
 /** @} */  // end of group add
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/qr.cuh
+++ b/cpp/include/raft/linalg/qr.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resources.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -111,6 +111,6 @@ void qr_get_qr(raft::resources const& handle,
 /** @} */
 
 };  // namespace linalg
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/reduce.cuh
+++ b/cpp/include/raft/linalg/reduce.cuh
@@ -17,7 +17,7 @@
 #include <raft/core/types.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -182,6 +182,6 @@ void reduce(raft::resources const& handle,
 /** @} */  // end of group reduction
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/reduce_cols_by_key.cuh
+++ b/cpp/include/raft/linalg/reduce_cols_by_key.cuh
@@ -14,7 +14,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resources.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -104,6 +104,6 @@ void reduce_cols_by_key(
 /** @} */  // end of group reduce_cols_by_key
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/reduce_rows_by_key.cuh
+++ b/cpp/include/raft/linalg/reduce_rows_by_key.cuh
@@ -14,7 +14,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/core/resources.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -183,6 +183,6 @@ void reduce_rows_by_key(
 /** @} */  // end of group reduce_rows_by_key
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/rsvd.cuh
+++ b/cpp/include/raft/linalg/rsvd.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -868,6 +868,6 @@ void randomized_svd(const raft::resources& handle,
 /** @} */  // end of group rsvd
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/sqrt.cuh
+++ b/cpp/include/raft/linalg/sqrt.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/linalg/unary_op.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -69,6 +69,6 @@ void sqrt(raft::resources const& handle, InType in, OutType out)
 /** @} */  // end of group add
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/strided_reduction.cuh
+++ b/cpp/include/raft/linalg/strided_reduction.cuh
@@ -18,7 +18,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -162,6 +162,6 @@ void strided_reduction(raft::resources const& handle,
 /** @} */  // end of group strided_reduction
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/subtract.cuh
+++ b/cpp/include/raft/linalg/subtract.cuh
@@ -16,7 +16,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -191,6 +191,6 @@ void subtract_scalar(
 /** @} */  // end of group subtract
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/svd.cuh
+++ b/cpp/include/raft/linalg/svd.cuh
@@ -14,7 +14,7 @@
 
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -408,6 +408,6 @@ void svd_reconstruction(raft::resources const& handle,
 /** @} */  // end of group svd
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/ternary_op.cuh
+++ b/cpp/include/raft/linalg/ternary_op.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/linalg/map.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 /**
  * @brief perform element-wise ternary operation on the input arrays
@@ -74,6 +74,6 @@ void ternary_op(
 /** @} */  // end of group ternary_op
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/transpose.cuh
+++ b/cpp/include/raft/linalg/transpose.cuh
@@ -14,7 +14,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/core/type_traits.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -97,6 +97,6 @@ auto transpose(raft::resources const& handle,
 /** @} */  // end of group transpose
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/linalg/tsvd.cuh
+++ b/cpp/include/raft/linalg/tsvd.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/core/device_mdspan.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -169,4 +169,4 @@ void sign_flip_components(raft::resources const& handle,
 /** @} */  // end group tsvd
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft

--- a/cpp/include/raft/linalg/unary_op.cuh
+++ b/cpp/include/raft/linalg/unary_op.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/linalg/map.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace linalg {
 
 /**
@@ -116,6 +116,6 @@ void write_only_unary_op(const raft::resources& handle, OutType out, Lambda op)
 /** @} */  // end of group unary_op
 
 };  // end namespace linalg
-};  // end namespace RAFT_EXPORT raft
+};  // end namespace raft
 
 #endif

--- a/cpp/include/raft/matrix/argmax.cuh
+++ b/cpp/include/raft/matrix/argmax.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/math.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -41,4 +41,4 @@ void argmax(raft::resources const& handle,
 /** @} */  // end of group argmax
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/argmin.cuh
+++ b/cpp/include/raft/matrix/argmin.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/math.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -41,4 +41,4 @@ void argmin(raft::resources const& handle,
 /** @} */  // end of group argmin
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/col_wise_sort.cuh
+++ b/cpp/include/raft/matrix/col_wise_sort.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/columnWiseSort.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -126,5 +126,5 @@ void sort_cols_per_row(Args... args)
 /** @} */  // end of group col_wise_sort
 
 };  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 #endif

--- a/cpp/include/raft/matrix/copy.cuh
+++ b/cpp/include/raft/matrix/copy.cuh
@@ -11,7 +11,7 @@
 #include <raft/matrix/detail/matrix.cuh>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -116,4 +116,4 @@ void trunc_zero_origin(raft::resources const& handle,
 /** @} */  // end of group matrix_copy
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/columnWiseSort.cuh
+++ b/cpp/include/raft/matrix/detail/columnWiseSort.cuh
@@ -22,7 +22,7 @@
   devKeyValSortColumnPerRow<InType, OutType, blockSize, elemPT><<<rows, blockSize, 0, stream>>>( \
     keyIn, keyOut, valueInOut, rows, columns, std::numeric_limits<InType>::max())
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 namespace detail {
 
@@ -342,4 +342,4 @@ void sortColumnsPerRow(const InType* in,
 }
 };  // end namespace detail
 };  // end namespace matrix
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/matrix/detail/gather.cuh
+++ b/cpp/include/raft/matrix/detail/gather.cuh
@@ -22,7 +22,7 @@
 
 #include <functional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 namespace detail {
 
@@ -622,4 +622,4 @@ void gather(raft::resources const& res,
 
 }  // namespace detail
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/gather_inplace.cuh
+++ b/cpp/include/raft/matrix/detail/gather_inplace.cuh
@@ -13,7 +13,7 @@
 #include <cuda/iterator>
 #include <thrust/for_each.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 namespace detail {
 
@@ -131,4 +131,4 @@ void gather(raft::resources const& handle,
 
 }  // namespace detail
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/linewise_op.cuh
+++ b/cpp/include/raft/matrix/detail/linewise_op.cuh
@@ -16,7 +16,7 @@
 
 #include <algorithm>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 namespace detail {
 
@@ -807,4 +807,4 @@ struct MatrixLinewiseOp {
 
 }  // end namespace detail
 }  // end namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/math.cuh
+++ b/cpp/include/raft/matrix/detail/math.cuh
@@ -19,7 +19,7 @@
 
 #include <cub/block/block_reduce.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 namespace detail {
 
@@ -402,4 +402,4 @@ void signFlip(math_t* inout, int n_rows, int n_cols, cudaStream_t stream)
 
 }  // end namespace detail
 }  // end namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/matrix.cuh
+++ b/cpp/include/raft/matrix/detail/matrix.cuh
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <cstddef>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 namespace detail {
 
@@ -309,4 +309,4 @@ m_t getL2Norm(raft::resources const& handle, const m_t* in, idx_t size, cudaStre
 
 }  // end namespace detail
 }  // end namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/print.hpp
+++ b/cpp/include/raft/matrix/detail/print.hpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <cstddef>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix::detail {
 
 template <typename m_t, typename idx_t = int>
@@ -36,4 +36,4 @@ void printHost(
 }
 
 }  // namespace matrix::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/sample_rows.cuh
+++ b/cpp/include/raft/matrix/detail/sample_rows.cuh
@@ -15,7 +15,7 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix::detail {
 
 /** Select rows randomly from input and copy to output. */
@@ -66,4 +66,4 @@ void sample_rows(raft::resources const& res,
   sample_rows<T, IdxT>(res, random_state, input, n_dim, n_rows_input, output);
 }
 }  // namespace matrix::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/scatter_inplace.cuh
+++ b/cpp/include/raft/matrix/detail/scatter_inplace.cuh
@@ -16,7 +16,7 @@
 
 #include <cstdint>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 namespace detail {
 
@@ -117,4 +117,4 @@ void scatter(raft::resources const& handle,
 
 }  // end namespace detail
 }  // end namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/select_k-inl.cuh
+++ b/cpp/include/raft/matrix/detail/select_k-inl.cuh
@@ -20,7 +20,7 @@
 
 #include <cub/device/device_segmented_radix_sort.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix::detail {
 
 /**
@@ -311,4 +311,4 @@ void select_k(raft::resources const& handle,
   }
 }
 }  // namespace matrix::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/select_k_layout.cuh
+++ b/cpp/include/raft/matrix/detail/select_k_layout.cuh
@@ -10,7 +10,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix::detail::select {
 
 /**
@@ -46,4 +46,4 @@ struct csr_layout {
 };
 
 }  // namespace matrix::detail::select
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/select_radix.cuh
+++ b/cpp/include/raft/matrix/detail/select_radix.cuh
@@ -29,7 +29,7 @@
 #include <cub/block/block_store.cuh>
 #include <cub/block/radix_rank_sort_operations.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix::detail::select::radix {
 namespace impl {
 
@@ -1316,4 +1316,4 @@ void select_k(raft::resources const& res,
 }
 
 }  // namespace matrix::detail::select::radix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/select_warpsort.cuh
+++ b/cpp/include/raft/matrix/detail/select_warpsort.cuh
@@ -92,7 +92,7 @@
       }
  */
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix::detail::select::warpsort {
 
 static constexpr int kMaxCapacity = 256;
@@ -1232,4 +1232,4 @@ void select_k(raft::resources const& res,
 }
 
 }  // namespace matrix::detail::select::warpsort
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/detail/shift.cuh
+++ b/cpp/include/raft/matrix/detail/shift.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/matrix/shift_types.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix::detail {
 enum FillType { CONSTANT, MATRIX, SELF_ID };
 
@@ -192,4 +192,4 @@ void shift(raft::resources const& handle,
     handle, in_out, values.data_handle(), k, shift_direction, shift_type);
 }
 }  // namespace matrix::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/diagonal.cuh
+++ b/cpp/include/raft/matrix/diagonal.cuh
@@ -12,7 +12,7 @@
 #include <raft/matrix/init.cuh>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -103,4 +103,4 @@ void eye(const raft::resources& handle, raft::device_matrix_view<math_t, idx_t, 
 /** @} */  // end of group matrix_diagonal
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/gather.cuh
+++ b/cpp/include/raft/matrix/gather.cuh
@@ -13,7 +13,7 @@
 #include <raft/matrix/detail/gather_inplace.cuh>
 #include <raft/util/itertools.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -467,4 +467,4 @@ void gather(raft::resources const& handle,
 /** @} */  // end of group matrix_gather
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/init.cuh
+++ b/cpp/include/raft/matrix/init.cuh
@@ -12,7 +12,7 @@
 #include <raft/linalg/map.cuh>
 #include <raft/matrix/detail/math.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -66,4 +66,4 @@ void fill(raft::resources const& handle,
 /** @} */  // end of group matrix_init
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/linewise_op.cuh
+++ b/cpp/include/raft/matrix/linewise_op.cuh
@@ -12,7 +12,7 @@
 #include <raft/core/types.hpp>
 #include <raft/matrix/detail/linewise_op.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -116,4 +116,4 @@ void linewise_op(raft::resources const& handle,
 /** @} */  // end of group linewise_op
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/matrix_types.hpp
+++ b/cpp/include/raft/matrix/matrix_types.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 struct print_separators {
@@ -15,4 +15,4 @@ struct print_separators {
 };
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/norm.cuh
+++ b/cpp/include/raft/matrix/norm.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/matrix.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -33,4 +33,4 @@ m_t l2_norm(raft::resources const& handle, raft::device_mdspan<const m_t, idx_t>
 /** @} */  // end of group matrix_norm
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/power.cuh
+++ b/cpp/include/raft/matrix/power.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/math.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -93,4 +93,4 @@ void power(raft::resources const& handle,
 /** @} */  // end group matrix_power
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/print.cuh
+++ b/cpp/include/raft/matrix/print.cuh
@@ -12,7 +12,7 @@
 #include <raft/matrix/detail/matrix.cuh>
 #include <raft/matrix/matrix_types.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -43,4 +43,4 @@ void print(raft::resources const& handle,
 
 /** @} */  // end group matrix_print
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/print.hpp
+++ b/cpp/include/raft/matrix/print.hpp
@@ -10,7 +10,7 @@
 #include <raft/matrix/detail/print.hpp>
 #include <raft/matrix/matrix_types.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -25,4 +25,4 @@ void print(raft::host_matrix_view<const m_t, idx_t, col_major> in, print_separat
     in.data_handle(), in.extent(0), in.extent(1), separators.horizontal, separators.vertical);
 }
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/ratio.cuh
+++ b/cpp/include/raft/matrix/ratio.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/math.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -93,4 +93,4 @@ void ratio(raft::resources const& handle, raft::device_vector_view<math_t, idx_t
 /** @} */  // end group matrix_ratio
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/reciprocal.cuh
+++ b/cpp/include/raft/matrix/reciprocal.cuh
@@ -11,7 +11,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/math.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -79,4 +79,4 @@ void reciprocal(raft::resources const& handle,
 /** @} */  // end group matrix_reciprocal
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/reverse.cuh
+++ b/cpp/include/raft/matrix/reverse.cuh
@@ -11,7 +11,7 @@
 #include <raft/matrix/detail/matrix.cuh>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -61,4 +61,4 @@ void row_reverse(raft::resources const& handle,
 /** @} */  // end group matrix_reverse
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/sample_rows.cuh
+++ b/cpp/include/raft/matrix/sample_rows.cuh
@@ -13,7 +13,7 @@
 #include <raft/matrix/detail/sample_rows.cuh>
 #include <raft/random/rng.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /** @brief Select rows randomly from input and copy to output.
@@ -69,4 +69,4 @@ raft::device_matrix<T, IdxT> sample_rows(
 }
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/scatter.cuh
+++ b/cpp/include/raft/matrix/scatter.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/matrix/detail/scatter_inplace.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 /**
  * @brief In-place scatter elements in a row-major matrix according to a
@@ -47,4 +47,4 @@ void scatter(raft::resources const& handle,
 }
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/select_k.cuh
+++ b/cpp/include/raft/matrix/select_k.cuh
@@ -16,7 +16,7 @@
 
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -110,4 +110,4 @@ void select_k(raft::resources const& handle,
 /** @} */  // end of group select_k
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/select_k_types.hpp
+++ b/cpp/include/raft/matrix/select_k_types.hpp
@@ -8,7 +8,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -91,4 +91,4 @@ inline auto operator<<(std::ostream& os, const SelectAlgo& algo) -> std::ostream
 /** @} */  // end of group select_k
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/shift.cuh
+++ b/cpp/include/raft/matrix/shift.cuh
@@ -11,7 +11,7 @@
 #include <raft/matrix/detail/shift.cuh>
 #include <raft/matrix/shift_types.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -110,4 +110,4 @@ void shift(raft::resources const& handle,
   detail::shift(handle, in_out, values, shift_direction, shift_type);
 }
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/shift_types.hpp
+++ b/cpp/include/raft/matrix/shift_types.hpp
@@ -6,11 +6,11 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 enum ShiftDirection { TOWARDS_BEGINNING, TOWARDS_END };
 enum ShiftType { ROW, COL };
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/sign_flip.cuh
+++ b/cpp/include/raft/matrix/sign_flip.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/matrix.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -36,4 +36,4 @@ void sign_flip(raft::resources const& handle,
 
 /** @} */  // end group matrix_sign_flip
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/slice.cuh
+++ b/cpp/include/raft/matrix/slice.cuh
@@ -11,7 +11,7 @@
 #include <raft/matrix/detail/matrix.cuh>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -72,4 +72,4 @@ void slice(raft::resources const& handle,
 /** @} */  // end group matrix_slice
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/sqrt.cuh
+++ b/cpp/include/raft/matrix/sqrt.cuh
@@ -11,7 +11,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/math.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -105,4 +105,4 @@ void weighted_sqrt(raft::resources const& handle,
 /** @} */  // end group matrix_sqrt
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/threshold.cuh
+++ b/cpp/include/raft/matrix/threshold.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/matrix.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -60,4 +60,4 @@ void zero_small_values(raft::resources const& handle,
 /** @} */  // end group matrix_threshold
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/matrix/triangular.cuh
+++ b/cpp/include/raft/matrix/triangular.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/matrix/detail/matrix.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace matrix {
 
 /**
@@ -41,4 +41,4 @@ void upper_triangular(raft::resources const& handle,
 /** @} */  // end group matrix_triangular
 
 }  // namespace matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/mr/host_device_resource.hpp
+++ b/cpp/include/raft/mr/host_device_resource.hpp
@@ -8,7 +8,7 @@
 
 #include <cuda/memory_resource>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace mr {
 
 /**
@@ -52,4 +52,4 @@ using host_device_resource_ref =
   cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, cuda::mr::device_accessible>;
 
 }  // namespace mr
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/mr/host_memory_resource.hpp
+++ b/cpp/include/raft/mr/host_memory_resource.hpp
@@ -26,6 +26,12 @@ inline auto new_delete_resource() -> raft::mr::host_resource_ref
   return raft::mr::host_resource_ref{instance};
 }
 
+}  // namespace mr
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
+namespace mr {
+
 namespace detail {
 
 struct default_host_resource_holder {
@@ -49,6 +55,12 @@ struct default_host_resource_holder {
 inline default_host_resource_holder default_host_resource_holder_{};
 
 }  // namespace detail
+
+}  // namespace mr
+}  // namespace raft
+
+namespace RAFT_EXPORT raft {
+namespace mr {
 
 /**
  * @brief Get the current default host memory resource.

--- a/cpp/include/raft/mr/host_memory_resource.hpp
+++ b/cpp/include/raft/mr/host_memory_resource.hpp
@@ -26,12 +26,6 @@ inline auto new_delete_resource() -> raft::mr::host_resource_ref
   return raft::mr::host_resource_ref{instance};
 }
 
-}  // namespace mr
-}  // namespace raft
-
-namespace raft {
-namespace mr {
-
 namespace detail {
 
 struct default_host_resource_holder {
@@ -55,12 +49,6 @@ struct default_host_resource_holder {
 inline default_host_resource_holder default_host_resource_holder_{};
 
 }  // namespace detail
-
-}  // namespace mr
-}  // namespace raft
-
-namespace raft {
-namespace mr {
 
 /**
  * @brief Get the current default host memory resource.

--- a/cpp/include/raft/mr/host_memory_resource.hpp
+++ b/cpp/include/raft/mr/host_memory_resource.hpp
@@ -12,7 +12,7 @@
 #include <mutex>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace mr {
 
 /**
@@ -27,7 +27,7 @@ inline auto new_delete_resource() -> raft::mr::host_resource_ref
 }
 
 }  // namespace mr
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 namespace raft {
 namespace mr {
@@ -59,7 +59,7 @@ inline default_host_resource_holder default_host_resource_holder_{};
 }  // namespace mr
 }  // namespace raft
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace mr {
 
 /**
@@ -89,4 +89,4 @@ inline auto set_default_host_resource(raft::mr::host_resource_ref ref)
 }
 
 }  // namespace mr
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/mr/mmap_memory_resource.hpp
+++ b/cpp/include/raft/mr/mmap_memory_resource.hpp
@@ -71,12 +71,6 @@ struct tmpfile_descriptor {
 
 }  // namespace detail
 
-}  // namespace mr
-}  // namespace raft
-
-namespace raft {
-namespace mr {
-
 /** Default flags for `mmap_memory_resource`. */
 constexpr int kMmapDefault = 0x0;
 /** Request 2MB huge pages support through `madvise`. */

--- a/cpp/include/raft/mr/mmap_memory_resource.hpp
+++ b/cpp/include/raft/mr/mmap_memory_resource.hpp
@@ -22,7 +22,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace mr {
 
 namespace detail {
@@ -70,6 +70,12 @@ struct tmpfile_descriptor {
 };
 
 }  // namespace detail
+
+}  // namespace mr
+}  // namespace raft
+
+namespace RAFT_EXPORT raft {
+namespace mr {
 
 /** Default flags for `mmap_memory_resource`. */
 constexpr int kMmapDefault = 0x0;

--- a/cpp/include/raft/mr/mmap_memory_resource.hpp
+++ b/cpp/include/raft/mr/mmap_memory_resource.hpp
@@ -74,7 +74,7 @@ struct tmpfile_descriptor {
 }  // namespace mr
 }  // namespace raft
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace mr {
 
 /** Default flags for `mmap_memory_resource`. */
@@ -168,4 +168,4 @@ class mmap_memory_resource {
 };
 
 }  // namespace mr
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/mr/notifying_adaptor.hpp
+++ b/cpp/include/raft/mr/notifying_adaptor.hpp
@@ -15,7 +15,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace mr {
 
 /**
@@ -145,4 +145,4 @@ class notifying_adaptor : public cuda::forward_property<notifying_adaptor<Upstre
 };
 
 }  // namespace mr
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/mr/resource_monitor.hpp
+++ b/cpp/include/raft/mr/resource_monitor.hpp
@@ -18,7 +18,7 @@
 #include <utility>
 #include <vector>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace mr {
 
 /**
@@ -157,4 +157,4 @@ class resource_monitor {
 };
 
 }  // namespace mr
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/mr/statistics_adaptor.hpp
+++ b/cpp/include/raft/mr/statistics_adaptor.hpp
@@ -16,7 +16,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace mr {
 
 /**
@@ -133,4 +133,4 @@ template <typename Upstream>
 statistics_adaptor(Upstream) -> statistics_adaptor<Upstream>;
 
 }  // namespace mr
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/pmr/resource_adaptor.hpp
+++ b/cpp/include/raft/pmr/resource_adaptor.hpp
@@ -12,7 +12,7 @@
 #include <memory>
 #include <memory_resource>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace pmr {
 
 /**
@@ -83,4 +83,4 @@ static_assert(cuda::mr::synchronous_resource_with<resource_adaptor, cuda::mr::ho
               "raft::mr::host_resource_ref consumption");
 
 }  // namespace pmr
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/detail/curand_wrappers.hpp
+++ b/cpp/include/raft/random/detail/curand_wrappers.hpp
@@ -9,7 +9,7 @@
 
 #include <curand.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 namespace detail {
 
@@ -47,4 +47,4 @@ inline curandStatus_t curandGenerateNormal(
 
 };  // end namespace detail
 };  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/detail/make_blobs.cuh
+++ b/cpp/include/raft/random/detail/make_blobs.cuh
@@ -19,7 +19,7 @@
 
 #include <vector>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 namespace detail {
@@ -248,4 +248,4 @@ void make_blobs_caller(DataT* out,
 
 }  // end namespace detail
 }  // end namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/detail/make_regression.cuh
+++ b/cpp/include/raft/random/detail/make_regression.cuh
@@ -25,7 +25,7 @@
 
 #include <algorithm>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 namespace detail {
 
@@ -270,4 +270,4 @@ void make_regression_caller(raft::resources const& handle,
 
 }  // namespace detail
 }  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/detail/multi_variable_gaussian.cuh
+++ b/cpp/include/raft/random/detail/multi_variable_gaussian.cuh
@@ -32,7 +32,7 @@
 // mvg.cuh takes in matrices that are column major (as in fortran)
 #define IDX2C(i, j, ld) (j * ld + i)
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 namespace detail {
 
@@ -452,4 +452,4 @@ class multi_variable_gaussian : public detail::multi_variable_gaussian_impl<T> {
 
 };  // end of namespace detail
 };  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/detail/permute.cuh
+++ b/cpp/include/raft/random/detail/permute.cuh
@@ -14,7 +14,7 @@
 
 #include <memory>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 namespace detail {
 
@@ -153,4 +153,4 @@ void permute(IntType* perms,
 
 };  // end namespace detail
 };  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/detail/rmat_rectangular_generator.cuh
+++ b/cpp/include/raft/random/detail/rmat_rectangular_generator.cuh
@@ -15,7 +15,7 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 namespace detail {
 
@@ -293,4 +293,4 @@ void rmat_rectangular_gen_impl(raft::resources const& handle,
 
 }  // end namespace detail
 }  // end namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/detail/rmat_rectangular_generator_types.cuh
+++ b/cpp/include/raft/random/detail/rmat_rectangular_generator_types.cuh
@@ -15,7 +15,7 @@
 #include <optional>
 #include <variant>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 namespace detail {
 
@@ -246,4 +246,4 @@ class rmat_rectangular_gen_output {
 
 }  // end namespace detail
 }  // end namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/detail/rng_device.cuh
+++ b/cpp/include/raft/random/detail/rng_device.cuh
@@ -18,7 +18,7 @@
 
 #include <random>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 namespace detail {
 
@@ -756,4 +756,4 @@ RAFT_KERNEL fillKernel(
 
 };  // end namespace detail
 };  // end namespace random
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/random/detail/rng_impl.cuh
+++ b/cpp/include/raft/random/detail/rng_impl.cuh
@@ -23,7 +23,7 @@
 #include <cub/device/device_select.cuh>
 #include <cuda_fp16.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 namespace detail {
 
@@ -461,4 +461,4 @@ auto excess_subsample(raft::resources const& res, RngState& state, IdxT N, IdxT 
 
 };  // end namespace detail
 };  // end namespace random
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/random/detail/rng_impl_deprecated.cuh
+++ b/cpp/include/raft/random/detail/rng_impl_deprecated.cuh
@@ -24,7 +24,7 @@
 
 #include <random>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 namespace detail {
 
@@ -297,4 +297,4 @@ class RngImpl {
 
 };  // end namespace detail
 };  // end namespace random
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/random/device/sample.cuh
+++ b/cpp/include/raft/random/device/sample.cuh
@@ -13,7 +13,7 @@
 
 #include <stdint.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random::device {
 
 /**
@@ -95,4 +95,4 @@ DI i_t block_random_sample(rng_t rng, T* shbuf, T weight = 1, i_t idx = threadId
 }
 
 }  // namespace random::device
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/make_blobs.cuh
+++ b/cpp/include/raft/random/make_blobs.cuh
@@ -17,7 +17,7 @@
 
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 /**
@@ -177,5 +177,5 @@ void make_blobs(
 /** @} */  // end group make_blobs
 
 }  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 #endif

--- a/cpp/include/raft/random/make_regression.cuh
+++ b/cpp/include/raft/random/make_regression.cuh
@@ -22,7 +22,7 @@
 #include <algorithm>
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 /**
@@ -179,6 +179,6 @@ void make_regression(raft::resources const& handle,
 /** @} */  // end group make_regression
 
 }  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/random/multi_variable_gaussian.cuh
+++ b/cpp/include/raft/random/multi_variable_gaussian.cuh
@@ -16,7 +16,7 @@
 
 #include <rmm/resource_ref.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 /**
@@ -49,5 +49,5 @@ void multi_variable_gaussian(raft::resources const& handle,
 /** @} */
 
 };  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 #endif

--- a/cpp/include/raft/random/permute.cuh
+++ b/cpp/include/raft/random/permute.cuh
@@ -18,7 +18,7 @@
 #include <optional>
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 namespace permute_impl {
@@ -196,5 +196,5 @@ void permute(IntType* perms,
 }
 
 };  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 #endif

--- a/cpp/include/raft/random/random_types.hpp
+++ b/cpp/include/raft/random/random_types.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 /**
@@ -35,4 +35,4 @@ enum class multi_variable_gaussian_decomposition_method { CHOLESKY, JACOBI, QR }
 /** @} */
 
 };  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/rmat_rectangular_generator.cuh
+++ b/cpp/include/raft/random/rmat_rectangular_generator.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/core/resources.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 /**
@@ -296,4 +296,4 @@ void rmat_rectangular_gen(IdxT* out,
 /** @} */
 
 }  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/rng.cuh
+++ b/cpp/include/raft/random/rng.cuh
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <variant>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 /**
@@ -1170,4 +1170,4 @@ class DEPR Rng : public detail::RngImpl {
 #undef DEPR
 
 };  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/random/rng_device.cuh
+++ b/cpp/include/raft/random/rng_device.cuh
@@ -13,7 +13,7 @@
 
 #include <raft/core/detail/macros.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 using detail::DeviceState;
@@ -43,5 +43,5 @@ using detail::custom_next;
 using detail::box_muller_transform;
 
 };  // end namespace random
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/random/rng_state.hpp
+++ b/cpp/include/raft/random/rng_state.hpp
@@ -12,7 +12,7 @@
 
 #include <cstdint>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 /** all different generator types used */
@@ -50,5 +50,5 @@ struct RngState {
 };
 
 };  // end namespace random
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/random/sample_without_replacement.cuh
+++ b/cpp/include/raft/random/sample_without_replacement.cuh
@@ -18,7 +18,7 @@
 #include <type_traits>
 #include <variant>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace random {
 
 namespace sample_without_replacement_impl {
@@ -158,4 +158,4 @@ void sample_without_replacement(Args... args)
 /** @} */
 
 }  // namespace random
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/solver/detail/lap_functions.cuh
+++ b/cpp/include/raft/solver/detail/lap_functions.cuh
@@ -45,7 +45,7 @@
 
 #include <cstddef>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace solver::detail {
 
 const int BLOCKDIMX{64};
@@ -570,4 +570,4 @@ inline void calcObjValPrimal(raft::resources const& handle,
 }
 
 }  // namespace solver::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/solver/detail/lap_kernels.cuh
+++ b/cpp/include/raft/solver/detail/lap_kernels.cuh
@@ -38,7 +38,7 @@
 #include <thrust/for_each.h>
 
 #include <cstddef>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace solver::detail {
 const int DORMANT{0};
 const int ACTIVE{1};
@@ -559,4 +559,4 @@ RAFT_KERNEL kernel_calcObjValPrimal(weight_t* d_obj_val_primal,
 }
 
 }  // namespace solver::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/solver/linear_assignment.cuh
+++ b/cpp/include/raft/solver/linear_assignment.cuh
@@ -43,7 +43,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/fill.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace solver {
 
 /**
@@ -336,6 +336,6 @@ class LinearAssignmentProblem {
 };
 
 }  // namespace solver
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/solver/linear_assignment_types.hpp
+++ b/cpp/include/raft/solver/linear_assignment_types.hpp
@@ -29,7 +29,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace solver {
 template <typename vertex_t, typename weight_t>
 struct Vertices {
@@ -49,4 +49,4 @@ struct VertexData {
   int* is_visited;
 };
 }  // namespace solver
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/convert/coo.cuh
+++ b/cpp/include/raft/sparse/convert/coo.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/sparse/convert/detail/coo.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace convert {
 
@@ -31,6 +31,6 @@ void csr_to_coo(
 
 };  // end NAMESPACE convert
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/convert/csr.cuh
+++ b/cpp/include/raft/sparse/convert/csr.cuh
@@ -17,7 +17,7 @@
 #include <raft/sparse/convert/detail/csr.cuh>
 #include <raft/sparse/csr.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace convert {
 
@@ -197,6 +197,6 @@ void bitset_to_csr(raft::resources const& handle,
 
 };  // end NAMESPACE convert
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/convert/dense.cuh
+++ b/cpp/include/raft/sparse/convert/dense.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/sparse/convert/detail/dense.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace convert {
 
@@ -52,6 +52,6 @@ void csr_to_dense(cusparseHandle_t handle,
 
 };  // end NAMESPACE convert
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/convert/detail/adj_to_csr.cuh
+++ b/cpp/include/raft/sparse/convert/detail/adj_to_csr.cuh
@@ -16,7 +16,7 @@
 
 #include <cooperative_groups.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace convert {
 namespace detail {
@@ -164,4 +164,4 @@ void adj_to_csr(raft::resources const& handle,
 };  // end NAMESPACE detail
 };  // end NAMESPACE convert
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/convert/detail/bitmap_to_csr.cuh
+++ b/cpp/include/raft/sparse/convert/detail/bitmap_to_csr.cuh
@@ -21,7 +21,7 @@
 #include <thrust/fill.h>
 #include <thrust/scan.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace convert {
 namespace detail {
@@ -341,4 +341,4 @@ void bitmap_to_csr(raft::resources const& handle,
 };  // end NAMESPACE detail
 };  // end NAMESPACE convert
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/convert/detail/bitset_to_csr.cuh
+++ b/cpp/include/raft/sparse/convert/detail/bitset_to_csr.cuh
@@ -19,7 +19,7 @@
 #include <thrust/fill.h>
 #include <thrust/scan.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace convert {
 namespace detail {
@@ -165,4 +165,4 @@ void bitset_to_csr(raft::resources const& handle,
 };  // end NAMESPACE detail
 };  // end NAMESPACE convert
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/convert/detail/coo.cuh
+++ b/cpp/include/raft/sparse/convert/detail/coo.cuh
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace convert {
 namespace detail {
@@ -66,4 +66,4 @@ void csr_to_coo(
 };  // end NAMESPACE detail
 };  // end NAMESPACE convert
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/convert/detail/csr.cuh
+++ b/cpp/include/raft/sparse/convert/detail/csr.cuh
@@ -29,7 +29,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace convert {
 namespace detail {
@@ -92,4 +92,4 @@ void sorted_coo_to_csr(const T* rows, nnz_t nnz, outT* row_ind, int m, cudaStrea
 };  // end NAMESPACE detail
 };  // end NAMESPACE convert
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/convert/detail/dense.cuh
+++ b/cpp/include/raft/sparse/convert/detail/dense.cuh
@@ -23,7 +23,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace convert {
 namespace detail {
@@ -131,4 +131,4 @@ void csr_to_dense(cusparseHandle_t handle,
 };  // namespace detail
 };  // end NAMESPACE convert
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/coo.hpp
+++ b/cpp/include/raft/sparse/coo.hpp
@@ -8,7 +8,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/sparse/detail/coo.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 
 /** @brief A Container object for sparse coordinate. There are two motivations
@@ -33,4 +33,4 @@ template <typename value_t, typename value_idx = int, typename nnz_t = uint64_t>
 using COO = detail::COO<value_t, value_idx, nnz_t>;
 
 };  // namespace sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/csr.hpp
+++ b/cpp/include/raft/sparse/csr.hpp
@@ -8,7 +8,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/sparse/detail/csr.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 
 constexpr int TPB_X = 256;
@@ -169,4 +169,4 @@ void weak_cc(Index_* labels,
 }
 
 };  // namespace sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/detail/coo.cuh
+++ b/cpp/include/raft/sparse/detail/coo.cuh
@@ -12,7 +12,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace detail {
 
@@ -239,4 +239,4 @@ class COO {
 
 };  // namespace detail
 };  // namespace sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/detail/csr.cuh
+++ b/cpp/include/raft/sparse/detail/csr.cuh
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace detail {
 
@@ -159,4 +159,4 @@ void weak_cc_batched(Index_* labels,
 
 };  // namespace detail
 };  // namespace sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/detail/cusparse_wrappers.h
+++ b/cpp/include/raft/sparse/detail/cusparse_wrappers.h
@@ -14,7 +14,7 @@
 
 #include <cusparse.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace detail {
 
@@ -1471,4 +1471,4 @@ inline cusparseStatus_t cusparsecsr2dense(cusparseHandle_t handle,
 
 }  // namespace detail
 }  // namespace sparse
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/detail/utils.h
+++ b/cpp/include/raft/sparse/detail/utils.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 
 /**
@@ -106,4 +106,4 @@ __device__ indT get_stop_idx(T row, T m, indT nnz, const indT* ind)
 }
 
 };  // namespace sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/linalg/add.cuh
+++ b/cpp/include/raft/sparse/linalg/add.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/sparse/linalg/detail/add.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 
@@ -84,6 +84,6 @@ void csr_add_finalize(const int* a_ind,
 
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/linalg/degree.cuh
+++ b/cpp/include/raft/sparse/linalg/degree.cuh
@@ -11,7 +11,7 @@
 #include <raft/sparse/coo.hpp>
 #include <raft/sparse/linalg/detail/degree.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 
@@ -108,6 +108,6 @@ void coo_degree_nz(COO<T>* in, int* results, cudaStream_t stream)
 
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/linalg/detail/add.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/add.cuh
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -238,4 +238,4 @@ void csr_add_finalize(const int* a_ind,
 };  // end NAMESPACE detail
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/cusparse_utils.hpp
+++ b/cpp/include/raft/sparse/linalg/detail/cusparse_utils.hpp
@@ -15,7 +15,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -135,4 +135,4 @@ inline cusparseOperation_t convert_operation(const raft::linalg::Operation op)
 }  // end namespace detail
 }  // end namespace linalg
 }  // end namespace sparse
-}  // end namespace RAFT_EXPORT raft
+}  // end namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/degree.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/degree.cuh
@@ -15,7 +15,7 @@
 
 #include <stdio.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -112,4 +112,4 @@ void coo_degree_nz(const idx_t* rows, const T* vals, nnz_t nnz, idx_t* results, 
 };  // end NAMESPACE detail
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/laplacian.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/laplacian.cuh
@@ -18,7 +18,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::linalg::detail {
 
 struct zero_to_one_functor {
@@ -282,4 +282,4 @@ auto laplacian_normalized(raft::resources const& res,
 }
 
 }  // namespace sparse::linalg::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/masked_matmul.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/masked_matmul.cuh
@@ -23,7 +23,7 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/device_uvector.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -157,4 +157,4 @@ void masked_matmul(raft::resources const& handle,
 }  // namespace detail
 }  // namespace linalg
 }  // namespace sparse
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/norm.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/norm.cuh
@@ -25,7 +25,7 @@
 #include <iostream>
 #include <limits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -222,4 +222,4 @@ void rowNormCsrCaller(const IdxType* ia,
 };  // end NAMESPACE detail
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/sddmm.hpp
+++ b/cpp/include/raft/sparse/linalg/detail/sddmm.hpp
@@ -14,7 +14,7 @@
 #include <raft/linalg/linalg_types.hpp>
 #include <raft/sparse/detail/cusparse_wrappers.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -82,4 +82,4 @@ void sddmm(raft::resources const& handle,
 }  // end namespace detail
 }  // end namespace linalg
 }  // end namespace sparse
-}  // end namespace RAFT_EXPORT raft
+}  // end namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/spmm.hpp
+++ b/cpp/include/raft/sparse/linalg/detail/spmm.hpp
@@ -13,7 +13,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/sparse/detail/cusparse_wrappers.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -106,4 +106,4 @@ void spmm(raft::resources const& handle,
 }  // end namespace detail
 }  // end namespace linalg
 }  // end namespace sparse
-}  // end namespace RAFT_EXPORT raft
+}  // end namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/symmetrize.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/symmetrize.cuh
@@ -33,7 +33,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -425,4 +425,4 @@ void symmetrize(raft::resources const& handle,
 };  // end NAMESPACE detail
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/transpose.h
+++ b/cpp/include/raft/sparse/linalg/detail/transpose.h
@@ -23,7 +23,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -97,4 +97,4 @@ void csr_transpose(cusparseHandle_t handle,
 };  // end NAMESPACE detail
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/linalg/detail/utils.cuh
+++ b/cpp/include/raft/sparse/linalg/detail/utils.cuh
@@ -12,7 +12,7 @@
 #include <cuda_fp16.h>
 #include <cuda_pipeline.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 namespace detail {
@@ -158,4 +158,4 @@ void faster_dot_on_csr(raft::resources const& handle,
 }  // namespace detail
 }  // namespace linalg
 }  // namespace sparse
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/linalg/laplacian.cuh
+++ b/cpp/include/raft/sparse/linalg/laplacian.cuh
@@ -9,7 +9,7 @@
 #include <raft/sparse/linalg/detail/laplacian.cuh>
 #include <raft/sparse/matrix/diagonal.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::linalg {
 
 /** Given a CSR adjacency matrix, return the graph Laplacian
@@ -100,4 +100,4 @@ auto laplacian_normalized(raft::resources const& res,
 }
 
 }  // namespace sparse::linalg
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/linalg/masked_matmul.cuh
+++ b/cpp/include/raft/sparse/linalg/masked_matmul.cuh
@@ -7,7 +7,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/sparse/linalg/detail/masked_matmul.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 
@@ -104,4 +104,4 @@ void masked_matmul(raft::resources const& handle,
 
 }  // end namespace linalg
 }  // end namespace sparse
-}  // end namespace RAFT_EXPORT raft
+}  // end namespace raft

--- a/cpp/include/raft/sparse/linalg/norm.cuh
+++ b/cpp/include/raft/sparse/linalg/norm.cuh
@@ -12,7 +12,7 @@
 #include <raft/linalg/norm_types.hpp>
 #include <raft/sparse/linalg/detail/norm.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 
@@ -92,6 +92,6 @@ void rowNormCsr(raft::resources const& handle,
 
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/linalg/sddmm.hpp
+++ b/cpp/include/raft/sparse/linalg/sddmm.hpp
@@ -10,7 +10,7 @@
 #include <raft/sparse/linalg/detail/sddmm.hpp>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 
@@ -73,4 +73,4 @@ void sddmm(raft::resources const& handle,
 
 }  // end namespace linalg
 }  // end namespace sparse
-}  // end namespace RAFT_EXPORT raft
+}  // end namespace raft

--- a/cpp/include/raft/sparse/linalg/spmm.hpp
+++ b/cpp/include/raft/sparse/linalg/spmm.hpp
@@ -11,7 +11,7 @@
 #include <raft/sparse/linalg/detail/cusparse_utils.hpp>
 #include <raft/sparse/linalg/detail/spmm.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 
@@ -81,6 +81,6 @@ void spmm(raft::resources const& handle,
 
 }  // end namespace linalg
 }  // end namespace sparse
-}  // end namespace RAFT_EXPORT raft
+}  // end namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/linalg/symmetrize.cuh
+++ b/cpp/include/raft/sparse/linalg/symmetrize.cuh
@@ -11,7 +11,7 @@
 #include <raft/sparse/coo.hpp>
 #include <raft/sparse/linalg/detail/symmetrize.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 
@@ -172,6 +172,6 @@ void symmetrize(raft::resources const& handle,
 
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/linalg/transpose.cuh
+++ b/cpp/include/raft/sparse/linalg/transpose.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/sparse/linalg/detail/transpose.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace linalg {
 
@@ -58,4 +58,4 @@ void csr_transpose(raft::resources const& handle,
 
 };  // end NAMESPACE linalg
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/matrix/detail/diagonal.cuh
+++ b/cpp/include/raft/sparse/matrix/detail/diagonal.cuh
@@ -13,7 +13,7 @@
 #include <raft/matrix/init.cuh>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::matrix::detail {
 
 /**
@@ -252,4 +252,4 @@ void set_diagonal(raft::resources const& res,
 }
 
 }  // namespace sparse::matrix::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/matrix/detail/preprocessing.cuh
+++ b/cpp/include/raft/sparse/matrix/detail/preprocessing.cuh
@@ -14,7 +14,7 @@
 
 #include <thrust/reduce.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::matrix::detail {
 
 /**
@@ -213,4 +213,4 @@ void transform_tfidf(raft::resources const& handle,
 }
 
 }  // namespace sparse::matrix::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/matrix/detail/select_k-inl.cuh
+++ b/cpp/include/raft/sparse/matrix/detail/select_k-inl.cuh
@@ -19,7 +19,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::matrix::detail {
 
 using namespace raft::matrix::detail;
@@ -218,4 +218,4 @@ void select_k(raft::resources const& handle,
 }
 
 }  // namespace sparse::matrix::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/matrix/diagonal.cuh
+++ b/cpp/include/raft/sparse/matrix/diagonal.cuh
@@ -14,7 +14,7 @@
 #include <raft/sparse/matrix/detail/diagonal.cuh>
 #include <raft/util/input_validation.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::matrix {
 
 /**
@@ -159,4 +159,4 @@ void set_diagonal(raft::resources const& res,
 }
 
 }  // namespace sparse::matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/matrix/preprocessing.cuh
+++ b/cpp/include/raft/sparse/matrix/preprocessing.cuh
@@ -11,7 +11,7 @@
 #include <raft/sparse/convert/coo.cuh>
 #include <raft/sparse/matrix/detail/preprocessing.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::matrix {
 /**
  * @brief This function calculate the tf-idf values for each entry in the COO sparse
@@ -208,4 +208,4 @@ void encode_bm25(raft::resources const& handle,
 }
 
 }  // namespace sparse::matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/matrix/select_k.cuh
+++ b/cpp/include/raft/sparse/matrix/select_k.cuh
@@ -16,7 +16,7 @@
 
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::matrix {
 
 using SelectAlgo = raft::matrix::SelectAlgo;
@@ -76,4 +76,4 @@ void select_k(raft::resources const& handle,
 /** @} */  // end of group select_k
 
 }  // namespace sparse::matrix
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/op/detail/filter.cuh
+++ b/cpp/include/raft/sparse/op/detail/filter.cuh
@@ -30,7 +30,7 @@
 #include <cstdio>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 namespace detail {
@@ -273,4 +273,4 @@ void coo_remove_zeros(COO<T, idx_t, nnz_t>* in, COO<T, idx_t, nnz_t>* out, cudaS
 };  // namespace detail
 };  // namespace op
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/op/detail/reduce.cuh
+++ b/cpp/include/raft/sparse/op/detail/reduce.cuh
@@ -29,7 +29,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 namespace detail {
@@ -150,4 +150,4 @@ void max_duplicates(raft::resources const& handle,
 };  // END namespace detail
 };  // END namespace op
 };  // END namespace sparse
-};  // END namespace RAFT_EXPORT raft
+};  // END namespace raft

--- a/cpp/include/raft/sparse/op/detail/row_op.cuh
+++ b/cpp/include/raft/sparse/op/detail/row_op.cuh
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 namespace detail {
@@ -61,4 +61,4 @@ void csr_row_op(const Index_* row_ind, Index_ n_rows, Index_ nnz, Lambda op, cud
 };  // namespace detail
 };  // namespace op
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/op/detail/slice.cuh
+++ b/cpp/include/raft/sparse/op/detail/slice.cuh
@@ -23,7 +23,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 namespace detail {
@@ -94,4 +94,4 @@ void csr_row_slice_populate(value_idx start_offset,
 };  // namespace detail
 };  // namespace op
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/op/detail/sort.h
+++ b/cpp/include/raft/sparse/op/detail/sort.h
@@ -25,7 +25,7 @@
 
 #include <algorithm>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 namespace detail {
@@ -103,4 +103,4 @@ void coo_sort_by_weight(
 };  // namespace detail
 };  // namespace op
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/sparse/op/filter.cuh
+++ b/cpp/include/raft/sparse/op/filter.cuh
@@ -14,7 +14,7 @@
 #include <raft/sparse/coo.hpp>
 #include <raft/sparse/op/detail/filter.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 
@@ -101,6 +101,6 @@ void coo_remove_zeros(COO<T, idx_t, nnz_t>* in, COO<T, idx_t, nnz_t>* out, cudaS
 
 };  // namespace op
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/op/reduce.cuh
+++ b/cpp/include/raft/sparse/op/reduce.cuh
@@ -12,7 +12,7 @@
 #include <raft/sparse/coo.hpp>
 #include <raft/sparse/op/detail/reduce.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 /**
@@ -72,6 +72,6 @@ void max_duplicates(raft::resources const& handle,
 }
 };  // END namespace op
 };  // END namespace sparse
-};  // END namespace RAFT_EXPORT raft
+};  // END namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/op/row_op.cuh
+++ b/cpp/include/raft/sparse/op/row_op.cuh
@@ -10,7 +10,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/sparse/op/detail/row_op.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 
@@ -33,6 +33,6 @@ void csr_row_op(const Index_* row_ind, Index_ n_rows, Index_ nnz, Lambda op, cud
 
 };  // namespace op
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/op/slice.cuh
+++ b/cpp/include/raft/sparse/op/slice.cuh
@@ -11,7 +11,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/sparse/op/detail/slice.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 
@@ -66,6 +66,6 @@ void csr_row_slice_populate(value_idx start_offset,
 
 };  // namespace op
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/op/sort.cuh
+++ b/cpp/include/raft/sparse/op/sort.cuh
@@ -11,7 +11,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/sparse/op/detail/sort.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse {
 namespace op {
 
@@ -64,6 +64,6 @@ void coo_sort_by_weight(
 }
 };  // namespace op
 };  // end NAMESPACE sparse
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/solver/detail/lanczos.cuh
+++ b/cpp/include/raft/sparse/solver/detail/lanczos.cuh
@@ -66,7 +66,7 @@
 #include <utility>
 #include <vector>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::solver::detail {
 
 template <typename T>
@@ -796,4 +796,4 @@ auto lanczos_compute_eigenpairs(
 }
 
 }  // namespace sparse::solver::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/solver/detail/mst_kernels.cuh
+++ b/cpp/include/raft/sparse/solver/detail/mst_kernels.cuh
@@ -12,7 +12,7 @@
 
 #include <limits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::solver::detail {
 
 template <typename vertex_t, typename edge_t, typename alteration_t>
@@ -321,4 +321,4 @@ RAFT_KERNEL kernel_count_new_mst_edges(const vertex_t* mst_src,
 }
 
 }  // namespace sparse::solver::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/solver/detail/mst_solver_inl.cuh
+++ b/cpp/include/raft/sparse/solver/detail/mst_solver_inl.cuh
@@ -34,7 +34,7 @@
 
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::solver {
 
 // curand generator uniform
@@ -403,4 +403,4 @@ void MST_solver<vertex_t, edge_t, weight_t, alteration_t>::append_src_dst_pair(
                   new_edges_functor<vertex_t, weight_t>());
 }
 }  // namespace sparse::solver
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/solver/detail/mst_utils.cuh
+++ b/cpp/include/raft/sparse/solver/detail/mst_utils.cuh
@@ -12,7 +12,7 @@
 
 #include <iostream>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::solver::detail {
 
 template <typename idx_t>
@@ -22,4 +22,4 @@ __device__ idx_t get_1D_idx()
 }
 
 }  // namespace sparse::solver::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/solver/lanczos.cuh
+++ b/cpp/include/raft/sparse/solver/lanczos.cuh
@@ -12,7 +12,7 @@
 #include <raft/sparse/solver/lanczos_types.hpp>
 #include <raft/spectral/matrix_wrappers.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::solver {
 
 // =========================================================
@@ -115,6 +115,6 @@ auto lanczos_compute_eigenpairs(
 }
 
 }  // namespace sparse::solver
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/sparse/solver/lanczos_types.hpp
+++ b/cpp/include/raft/sparse/solver/lanczos_types.hpp
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::solver {
 
 /**
@@ -68,4 +68,4 @@ struct lanczos_solver_config {
 };
 
 }  // namespace sparse::solver
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/sparse/solver/mst.cuh
+++ b/cpp/include/raft/sparse/solver/mst.cuh
@@ -8,7 +8,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/sparse/solver/mst_solver.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::solver {
 
 /**
@@ -62,4 +62,4 @@ Graph_COO<vertex_t, edge_t, weight_t> mst(raft::resources const& handle,
 }
 
 }  // end namespace sparse::solver
-}  // end namespace RAFT_EXPORT raft
+}  // end namespace raft

--- a/cpp/include/raft/sparse/solver/mst_solver.cuh
+++ b/cpp/include/raft/sparse/solver/mst_solver.cuh
@@ -12,7 +12,7 @@
 #include <rmm/device_scalar.hpp>
 #include <rmm/device_uvector.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace sparse::solver {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
@@ -90,6 +90,6 @@ class MST_solver {
 };
 
 }  // namespace sparse::solver
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #include <raft/sparse/solver/detail/mst_solver_inl.cuh>

--- a/cpp/include/raft/spectral/detail/matrix_wrappers.hpp
+++ b/cpp/include/raft/spectral/detail/matrix_wrappers.hpp
@@ -35,7 +35,7 @@
 // Get index of matrix entry
 #define IDX(i, j, lda) ((size_t)(i) + (j) * (lda))
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace spectral {
 namespace matrix {
 namespace detail {
@@ -474,4 +474,4 @@ struct modularity_matrix_t : laplacian_matrix_t<index_type, value_type, nnz_type
 }  // namespace detail
 }  // namespace matrix
 }  // namespace spectral
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/spectral/detail/modularity_maximization.hpp
+++ b/cpp/include/raft/spectral/detail/modularity_maximization.hpp
@@ -24,7 +24,7 @@
 
 #include <tuple>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace spectral {
 namespace detail {
 
@@ -85,4 +85,4 @@ void analyzeModularity(
 
 }  // namespace detail
 }  // namespace spectral
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/spectral/detail/partition.hpp
+++ b/cpp/include/raft/spectral/detail/partition.hpp
@@ -22,7 +22,7 @@
 
 #include <tuple>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace spectral {
 namespace detail {
 
@@ -94,4 +94,4 @@ void analyzePartition(raft::resources const& handle,
 
 }  // namespace detail
 }  // namespace spectral
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/spectral/detail/spectral_util.cuh
+++ b/cpp/include/raft/spectral/detail/spectral_util.cuh
@@ -26,7 +26,7 @@
 
 #include <algorithm>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace spectral {
 
 template <typename vertex_t, typename edge_t, typename weight_t>
@@ -166,4 +166,4 @@ bool construct_indicator(
 }
 
 }  // namespace spectral
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/spectral/matrix_wrappers.hpp
+++ b/cpp/include/raft/spectral/matrix_wrappers.hpp
@@ -11,7 +11,7 @@
 // Useful macros
 // =========================================================
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace spectral {
 namespace matrix {
 
@@ -36,4 +36,4 @@ using detail::modularity_matrix_t;
 
 }  // namespace matrix
 }  // namespace spectral
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/spectral/modularity_maximization.cuh
+++ b/cpp/include/raft/spectral/modularity_maximization.cuh
@@ -12,7 +12,7 @@
 
 #include <tuple>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace spectral {
 
 //===================================================
@@ -39,6 +39,6 @@ void analyzeModularity(raft::resources const& handle,
 }
 
 }  // namespace spectral
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/spectral/partition.cuh
+++ b/cpp/include/raft/spectral/partition.cuh
@@ -13,7 +13,7 @@
 
 #include <tuple>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace spectral {
 
 // =========================================================
@@ -47,6 +47,6 @@ void analyzePartition(raft::resources const& handle,
 }
 
 }  // namespace spectral
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/stats/accuracy.cuh
+++ b/cpp/include/raft/stats/accuracy.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/scores.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -63,6 +63,6 @@ float accuracy(raft::resources const& handle,
 /** @} */  // end group stats_accuracy
 
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/stats/adjusted_rand_index.cuh
+++ b/cpp/include/raft/stats/adjusted_rand_index.cuh
@@ -18,7 +18,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/adjusted_rand_index.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -75,5 +75,5 @@ double adjusted_rand_index(raft::resources const& handle,
 /** @} */  // end group stats_adj_rand_index
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/completeness_score.cuh
+++ b/cpp/include/raft/stats/completeness_score.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/homogeneity_score.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -76,5 +76,5 @@ double completeness_score(raft::resources const& handle,
 /** @} */  // end group stats_completeness
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/contingency_matrix.cuh
+++ b/cpp/include/raft/stats/contingency_matrix.cuh
@@ -16,7 +16,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/stats/detail/contingencyMatrix.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -202,5 +202,5 @@ void contingency_matrix(Args... args)
   contingency_matrix(std::forward<Args>(args)..., std::nullopt, std::nullopt);
 }
 };  // namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/cov.cuh
+++ b/cpp/include/raft/stats/cov.cuh
@@ -12,7 +12,7 @@
 #include <raft/core/device_mdspan.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/cov.cuh>
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 /**
  * @brief Compute covariance of the input matrix
@@ -104,5 +104,5 @@ void cov(raft::resources const& handle,
 /** @} */  // end group stats_cov
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/detail/adjusted_rand_index.cuh
+++ b/cpp/include/raft/stats/detail/adjusted_rand_index.cuh
@@ -29,7 +29,7 @@
 
 #include <math.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -193,4 +193,4 @@ double compute_adjusted_rand_index(const T* firstClusterArray,
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/batched/information_criterion.cuh
+++ b/cpp/include/raft/stats/detail/batched/information_criterion.cuh
@@ -10,7 +10,7 @@
 
 #include <cmath>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace batched {
 namespace detail {
@@ -61,4 +61,4 @@ void information_criterion(ScalarT* d_ic,
 }  // namespace detail
 }  // namespace batched
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/batched/silhouette_score.cuh
+++ b/cpp/include/raft/stats/detail/batched/silhouette_score.cuh
@@ -21,7 +21,7 @@
 #include <thrust/fill.h>
 #include <thrust/reduce.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace batched {
 namespace detail {
@@ -268,4 +268,4 @@ value_t silhouette_score(
 }  // namespace detail
 }  // namespace batched
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/contingencyMatrix.cuh
+++ b/cpp/include/raft/stats/detail/contingencyMatrix.cuh
@@ -17,7 +17,7 @@
 
 #include <math.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -302,4 +302,4 @@ void contingencyMatrix(const T* groundTruth,
 
 };  // namespace detail
 };  // namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/cov.cuh
+++ b/cpp/include/raft/stats/detail/cov.cuh
@@ -10,7 +10,7 @@
 #include <raft/linalg/gemm.cuh>
 #include <raft/stats/mean_center.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 /**
@@ -62,4 +62,4 @@ void cov(raft::resources const& handle,
 }
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/dispersion.cuh
+++ b/cpp/include/raft/stats/detail/dispersion.cuh
@@ -17,7 +17,7 @@
 
 #include <memory>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -128,4 +128,4 @@ DataT dispersion(const DataT* centroids,
 
 }  // end namespace detail
 }  // end namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/entropy.cuh
+++ b/cpp/include/raft/stats/detail/entropy.cuh
@@ -22,7 +22,7 @@
 
 #include <math.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -144,4 +144,4 @@ double entropy(const T* clusterArray,
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/histogram.cuh
+++ b/cpp/include/raft/stats/detail/histogram.cuh
@@ -19,7 +19,7 @@
 
 ///@todo: add cub's histogram as another option
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -484,4 +484,4 @@ void histogram(HistType type,
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/homogeneity_score.cuh
+++ b/cpp/include/raft/stats/detail/homogeneity_score.cuh
@@ -15,7 +15,7 @@
 #include <raft/stats/entropy.cuh>
 #include <raft/stats/mutual_info_score.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 /**
@@ -58,4 +58,4 @@ double homogeneity_score(const T* truthClusterArray,
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/kl_divergence.cuh
+++ b/cpp/include/raft/stats/detail/kl_divergence.cuh
@@ -19,7 +19,7 @@
 
 #include <math.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -73,4 +73,4 @@ DataT kl_divergence(const DataT* modelPDF, const DataT* candidatePDF, int size, 
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/mean.cuh
+++ b/cpp/include/raft/stats/detail/mean.cuh
@@ -10,7 +10,7 @@
 #include <raft/linalg/reduce.cuh>
 #include <raft/util/cuda_utils.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -49,4 +49,4 @@ template <bool rowMajor, typename Type, typename IdxType = int>
 
 }  // namespace detail
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/mean_center.cuh
+++ b/cpp/include/raft/stats/detail/mean_center.cuh
@@ -10,7 +10,7 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/vectorized.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -59,4 +59,4 @@ void meanAdd(Type* out, const Type* data, const Type* mu, IdxType D, IdxType N, 
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/meanvar.cuh
+++ b/cpp/include/raft/stats/detail/meanvar.cuh
@@ -9,7 +9,7 @@
 #include <raft/linalg/reduce.cuh>
 #include <raft/util/cuda_utils.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats::detail {
 
 template <typename T>
@@ -219,4 +219,4 @@ void meanvar(
 }
 
 };  // namespace stats::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/minmax.cuh
+++ b/cpp/include/raft/stats/detail/minmax.cuh
@@ -11,7 +11,7 @@
 
 #include <limits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -225,4 +225,4 @@ void minmax(const T* data,
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/mutual_info_score.cuh
+++ b/cpp/include/raft/stats/detail/mutual_info_score.cuh
@@ -28,7 +28,7 @@
 
 #include <math.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -163,4 +163,4 @@ double mutual_info_score(const T* firstClusterArray,
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/neighborhood_recall.cuh
+++ b/cpp/include/raft/stats/detail/neighborhood_recall.cuh
@@ -21,7 +21,7 @@
 #include <cstddef>
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats::detail {
 
 template <typename IndicesValueType,
@@ -104,4 +104,4 @@ void neighborhood_recall(
 }
 
 }  // namespace stats::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/rand_index.cuh
+++ b/cpp/include/raft/stats/detail/rand_index.cuh
@@ -52,7 +52,7 @@
 
 #include <math.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -159,4 +159,4 @@ double compute_rand_index(const T* firstClusterArray,
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/scores.cuh
+++ b/cpp/include/raft/stats/detail/scores.cuh
@@ -25,7 +25,7 @@
 
 #define N_THREADS 512
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 /**
@@ -206,4 +206,4 @@ void regression_metrics(const T* predictions,
 }
 }  // namespace detail
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/silhouette_score.cuh
+++ b/cpp/include/raft/stats/detail/silhouette_score.cuh
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <numeric>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -309,4 +309,4 @@ DataT silhouette_score(
 
 };  // namespace detail
 };  // namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/stddev.cuh
+++ b/cpp/include/raft/stats/detail/stddev.cuh
@@ -11,7 +11,7 @@
 #include <raft/linalg/reduce.cuh>
 #include <raft/util/cuda_utils.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -103,4 +103,4 @@ void vars(Type* var,
 
 }  // namespace detail
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/sum.cuh
+++ b/cpp/include/raft/stats/detail/sum.cuh
@@ -10,7 +10,7 @@
 #include <raft/linalg/reduce.cuh>
 #include <raft/util/cuda_utils.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -22,4 +22,4 @@ void sum(Type* output, const Type* input, IdxType D, IdxType N, cudaStream_t str
 
 }  // namespace detail
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/trustworthiness_score.cuh
+++ b/cpp/include/raft/stats/detail/trustworthiness_score.cuh
@@ -14,7 +14,7 @@
 
 #define N_THREADS 512
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -208,4 +208,4 @@ double trustworthiness_score(const raft::resources& h,
 
 }  // namespace detail
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/detail/v_measure.cuh
+++ b/cpp/include/raft/stats/detail/v_measure.cuh
@@ -9,7 +9,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/stats/homogeneity_score.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -51,4 +51,4 @@ double v_measure(const T* truthClusterArray,
 
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/detail/weighted_mean.cuh
+++ b/cpp/include/raft/stats/detail/weighted_mean.cuh
@@ -11,7 +11,7 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/cudart_utils.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 namespace detail {
 
@@ -54,4 +54,4 @@ void weightedMean(
 }
 };  // end namespace detail
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/stats/dispersion.cuh
+++ b/cpp/include/raft/stats/dispersion.cuh
@@ -15,7 +15,7 @@
 
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -119,5 +119,5 @@ value_t cluster_dispersion(
   return cluster_dispersion(handle, centroids, cluster_sizes, opt_centroid, n_points);
 }
 }  // end namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 #endif

--- a/cpp/include/raft/stats/entropy.cuh
+++ b/cpp/include/raft/stats/entropy.cuh
@@ -12,7 +12,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/entropy.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -71,5 +71,5 @@ double entropy(raft::resources const& handle,
 /** @} */  // end group stats_entropy
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/histogram.cuh
+++ b/cpp/include/raft/stats/histogram.cuh
@@ -19,7 +19,7 @@
 
 ///@todo: add cub's histogram as another option
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -106,5 +106,5 @@ void histogram(raft::resources const& handle,
 /** @} */  // end group stats_histogram
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/homogeneity_score.cuh
+++ b/cpp/include/raft/stats/homogeneity_score.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/homogeneity_score.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -79,5 +79,5 @@ double homogeneity_score(raft::resources const& handle,
 /** @} */  // end group stats_homogeneity_score
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/information_criterion.cuh
+++ b/cpp/include/raft/stats/information_criterion.cuh
@@ -25,7 +25,7 @@
 #include <raft/stats/detail/batched/information_criterion.cuh>
 #include <raft/stats/stats_types.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -104,5 +104,5 @@ void information_criterion_batched(raft::resources const& handle,
 /** @} */  // end group stats_information_criterion
 
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 #endif

--- a/cpp/include/raft/stats/kl_divergence.cuh
+++ b/cpp/include/raft/stats/kl_divergence.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/kl_divergence.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -67,5 +67,5 @@ value_t kl_divergence(raft::resources const& handle,
 /** @} */  // end group kl_divergence
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/mean.cuh
+++ b/cpp/include/raft/stats/mean.cuh
@@ -14,7 +14,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/stats/detail/mean.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -136,5 +136,5 @@ template <typename value_t, typename idx_t, typename layout_t>
 /** @} */  // end group stats_mean
 
 };  // namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/mean_center.cuh
+++ b/cpp/include/raft/stats/mean_center.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/mean_center.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -139,5 +139,5 @@ void mean_add(raft::resources const& handle,
 /** @} */  // end group stats_mean_center
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/meanvar.cuh
+++ b/cpp/include/raft/stats/meanvar.cuh
@@ -12,7 +12,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/meanvar.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -99,5 +99,5 @@ void meanvar(raft::resources const& handle,
 /** @} */  // end group stats_mean_var
 
 };  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 #endif

--- a/cpp/include/raft/stats/minmax.cuh
+++ b/cpp/include/raft/stats/minmax.cuh
@@ -17,7 +17,7 @@
 #include <limits>
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -130,5 +130,5 @@ void minmax(raft::resources const& handle,
 /** @} */  // end group stats_minmax
 
 };  // namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/mutual_info_score.cuh
+++ b/cpp/include/raft/stats/mutual_info_score.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/mutual_info_score.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -77,5 +77,5 @@ double mutual_info_score(raft::resources const& handle,
 /** @} */  // end group stats_mutual_info
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/neighborhood_recall.cuh
+++ b/cpp/include/raft/stats/neighborhood_recall.cuh
@@ -19,7 +19,7 @@
 
 #include <optional>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -183,4 +183,4 @@ void neighborhood_recall(
 /** @} */  // end group stats_recall
 
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/r2_score.cuh
+++ b/cpp/include/raft/stats/r2_score.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resource/cuda_stream.hpp>
 #include <raft/stats/detail/scores.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -78,6 +78,6 @@ value_t r2_score(raft::resources const& handle,
 /** @} */  // end group stats_r2_score
 
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/stats/rand_index.cuh
+++ b/cpp/include/raft/stats/rand_index.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/stats/detail/rand_index.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -63,5 +63,5 @@ double rand_index(raft::resources const& handle,
 /** @} */  // end group stats_rand_index
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/regression_metrics.cuh
+++ b/cpp/include/raft/stats/regression_metrics.cuh
@@ -14,7 +14,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/stats/detail/scores.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -92,6 +92,6 @@ void regression_metrics(raft::resources const& handle,
 /** @} */  // end group stats_regression_metrics
 
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/stats/silhouette_score.cuh
+++ b/cpp/include/raft/stats/silhouette_score.cuh
@@ -13,7 +13,7 @@
 #include <raft/stats/detail/batched/silhouette_score.cuh>
 #include <raft/stats/detail/silhouette_score.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -211,5 +211,5 @@ value_t silhouette_score_batched(
     handle, X, labels, opt_scores, n_unique_labels, batch_size, metric);
 }
 };  // namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/stats_types.hpp
+++ b/cpp/include/raft/stats/stats_types.hpp
@@ -8,7 +8,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/util/cudart_utils.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -65,4 +65,4 @@ enum IC_Type { AIC, AICc, BIC };
 /** @} */
 
 };  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/stats/stddev.cuh
+++ b/cpp/include/raft/stats/stddev.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/stats/detail/stddev.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -169,5 +169,5 @@ void vars(raft::resources const& handle,
 /** @} */  // end group stats_variance
 
 };  // namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/sum.cuh
+++ b/cpp/include/raft/stats/sum.cuh
@@ -14,7 +14,7 @@
 #include <raft/stats/detail/sum.cuh>
 #include <raft/util/cudart_utils.hpp>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -75,5 +75,5 @@ void sum(raft::resources const& handle,
 /** @} */  // end group stats_sum
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/trustworthiness_score.cuh
+++ b/cpp/include/raft/stats/trustworthiness_score.cuh
@@ -12,7 +12,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/stats/detail/trustworthiness_score.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -86,6 +86,6 @@ double trustworthiness_score(
 /** @} */  // end group stats_trustworthiness
 
 }  // namespace stats
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 #endif

--- a/cpp/include/raft/stats/v_measure.cuh
+++ b/cpp/include/raft/stats/v_measure.cuh
@@ -13,7 +13,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/stats/detail/v_measure.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -83,5 +83,5 @@ double v_measure(raft::resources const& handle,
 /** @} */  // end group stats_vmeasure
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/stats/weighted_mean.cuh
+++ b/cpp/include/raft/stats/weighted_mean.cuh
@@ -14,7 +14,7 @@
 #include <raft/core/types.hpp>
 #include <raft/stats/detail/weighted_mean.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace stats {
 
 /**
@@ -170,5 +170,5 @@ void col_weighted_mean(raft::resources const& handle,
 /** @} */  // end group stats_weighted_mean
 
 };  // end namespace stats
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft
 #endif

--- a/cpp/include/raft/util/arch.cuh
+++ b/cpp/include/raft/util/arch.cuh
@@ -8,26 +8,7 @@
 #include <raft/util/cuda_rt_essentials.hpp>  // RAFT_CUDA_TRY
 
 namespace raft {
-namespace util {
-namespace arch {
-
-// detail::SM_generic is a template to create a generic compile-time SM
-// architecture constant.
-namespace detail {
-template <int n>
-struct SM_generic {
- public:
-  __host__ __device__ constexpr int value() const { return n; }
-};
-}  // namespace detail
-
-}  // namespace arch
-}  // namespace util
-}  // namespace raft
-
-namespace raft {
-namespace util {
-namespace arch {
+namespace util::arch {
 
 /* raft::util::arch provides the following facilities:
  *
@@ -49,6 +30,16 @@ namespace arch {
  *   of compute architectures. This can be used to check if the current
  *   compile-time architecture is in a specified compatibility range.
  */
+
+// detail::SM_generic is a template to create a generic compile-time SM
+// architecture constant.
+namespace detail {
+template <int n>
+struct SM_generic {
+ public:
+  __host__ __device__ constexpr int value() const { return n; }
+};
+}  // namespace detail
 
 // A list of architectures that RAPIDS explicitly builds for (SM60, ..., SM90)
 // and SM_MIN and SM_FUTURE, that allow specifying an open interval of
@@ -143,6 +134,5 @@ struct SM_range {
   }
 };
 
-}  // namespace arch
-}  // namespace util
+}  // namespace util::arch
 }  // namespace raft

--- a/cpp/include/raft/util/arch.cuh
+++ b/cpp/include/raft/util/arch.cuh
@@ -7,8 +7,27 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/util/cuda_rt_essentials.hpp>  // RAFT_CUDA_TRY
 
+namespace raft {
+namespace util {
+namespace arch {
+
+// detail::SM_generic is a template to create a generic compile-time SM
+// architecture constant.
+namespace detail {
+template <int n>
+struct SM_generic {
+ public:
+  __host__ __device__ constexpr int value() const { return n; }
+};
+}  // namespace detail
+
+}  // namespace arch
+}  // namespace util
+}  // namespace raft
+
 namespace RAFT_EXPORT raft {
-namespace util::arch {
+namespace util {
+namespace arch {
 
 /* raft::util::arch provides the following facilities:
  *
@@ -30,16 +49,6 @@ namespace util::arch {
  *   of compute architectures. This can be used to check if the current
  *   compile-time architecture is in a specified compatibility range.
  */
-
-// detail::SM_generic is a template to create a generic compile-time SM
-// architecture constant.
-namespace detail {
-template <int n>
-struct SM_generic {
- public:
-  __host__ __device__ constexpr int value() const { return n; }
-};
-}  // namespace detail
 
 // A list of architectures that RAPIDS explicitly builds for (SM60, ..., SM90)
 // and SM_MIN and SM_FUTURE, that allow specifying an open interval of
@@ -134,5 +143,6 @@ struct SM_range {
   }
 };
 
-}  // namespace util::arch
+}  // namespace arch
+}  // namespace util
 }  // namespace RAFT_EXPORT raft

--- a/cpp/include/raft/util/arch.cuh
+++ b/cpp/include/raft/util/arch.cuh
@@ -25,7 +25,7 @@ struct SM_generic {
 }  // namespace util
 }  // namespace raft
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace util {
 namespace arch {
 
@@ -145,4 +145,4 @@ struct SM_range {
 
 }  // namespace arch
 }  // namespace util
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/bitonic_sort.cuh
+++ b/cpp/include/raft/util/bitonic_sort.cuh
@@ -8,7 +8,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/util/cuda_utils.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace util {
 
 namespace {
@@ -237,4 +237,4 @@ class bitonic {
 };
 
 }  // namespace util
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/cache.cuh
+++ b/cpp/include/raft/util/cache.cuh
@@ -20,7 +20,7 @@
 
 #include <cstddef>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace cache {
 
 /**
@@ -397,4 +397,4 @@ class Cache {
   }
 };
 };  // namespace cache
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/cache.hpp
+++ b/cpp/include/raft/util/cache.hpp
@@ -15,7 +15,7 @@
 #include <tuple>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace cache {
 
 /** Associative cache with least recently used replacement policy. */
@@ -97,4 +97,4 @@ class lru {
 };
 
 };  // namespace cache
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/cache_util.cuh
+++ b/cpp/include/raft/util/cache_util.cuh
@@ -10,7 +10,7 @@
 
 #include <cub/block/block_radix_sort.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace cache {
 
 /**
@@ -352,4 +352,4 @@ RAFT_KERNEL get_cache_idx(int* keys,
   }
 }
 };  // namespace cache
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/util/cuda_data_type.hpp
+++ b/cpp/include/raft/util/cuda_data_type.hpp
@@ -12,7 +12,7 @@
 
 #include <cstdint>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 template <typename T>
 constexpr auto get_cuda_data_type() -> cudaDataType_t;
@@ -72,4 +72,4 @@ inline constexpr auto get_cuda_data_type<double>() -> cudaDataType_t
 {
   return CUDA_R_64F;
 }
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/cuda_dev_essentials.cuh
+++ b/cpp/include/raft/util/cuda_dev_essentials.cuh
@@ -13,7 +13,7 @@
 // scope is necessarily limited to ensure that compilation times are minimized.
 // Please make sure not to include large / expensive files from here.
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /** helper macro for device inlined functions */
 #define DI  inline __device__
@@ -122,4 +122,4 @@ HDI auto to_float(T& a)
   }
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/cuda_rt_essentials.hpp
+++ b/cpp/include/raft/util/cuda_rt_essentials.hpp
@@ -16,7 +16,7 @@
 
 #include <cstdio>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /**
  * @brief Exception thrown when a CUDA error is encountered.
@@ -26,7 +26,7 @@ struct cuda_error : public raft::exception {
   explicit cuda_error(std::string const& message) : raft::exception(message) {}
 };
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 /**
  * @brief Error checking macro for CUDA runtime API functions.

--- a/cpp/include/raft/util/cuda_utils.cuh
+++ b/cpp/include/raft/util/cuda_utils.cuh
@@ -21,7 +21,7 @@
 #include <raft/util/cuda_dev_essentials.cuh>
 #include <raft/util/reduction.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /** Device function to have atomic add support for older archs */
 template <typename Type>
@@ -674,4 +674,4 @@ inline cudaStream_t select_stream(cudaStream_t user_stream,
   return n_int_streams > 0 ? int_streams[idx % n_int_streams] : user_stream;
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/cudart_utils.hpp
+++ b/cpp/include/raft/util/cudart_utils.hpp
@@ -25,7 +25,7 @@
 #include <mutex>
 #include <string>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /** Helper method to get to know warp size in device code */
 __host__ __device__ constexpr inline int warp_size() { return 32; }
@@ -470,4 +470,4 @@ constexpr inline auto upper_bound<__nv_bfloat16>() -> __nv_bfloat16
   return static_cast<__nv_bfloat16>(__bfloat16_constexpr{0x7f80u});
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/detail/cub_wrappers.cuh
+++ b/cpp/include/raft/util/detail/cub_wrappers.cuh
@@ -11,7 +11,7 @@
 
 #include <cub/device/device_radix_sort.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /**
  * @brief Convenience wrapper over cub's SortPairs method
@@ -42,4 +42,4 @@ void sortPairs(rmm::device_uvector<char>& workspace,
     workspace.data(), worksize, inKeys, outKeys, inVals, outVals, len, 0, sizeof(KeyT) * 8, stream);
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/detail/itertools.hpp
+++ b/cpp/include/raft/util/detail/itertools.hpp
@@ -10,7 +10,7 @@
 #include <tuple>
 #include <vector>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace util::itertools::detail {
 
 template <class S, typename... Args, size_t... Is>
@@ -31,4 +31,4 @@ inline std::vector<S> product(std::index_sequence<Is...> index, const std::vecto
 }
 
 }  // namespace util::itertools::detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/detail/popc.cuh
+++ b/cpp/include/raft/util/detail/popc.cuh
@@ -11,7 +11,7 @@
 #include <raft/core/resources.hpp>
 #include <raft/linalg/coalesced_reduction.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace detail {
 
 /**
@@ -65,4 +65,4 @@ void popc(const raft::resources& res,
 }
 
 }  // namespace detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/detail/scatter.cuh
+++ b/cpp/include/raft/util/detail/scatter.cuh
@@ -9,7 +9,7 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/vectorized.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace detail {
 
 template <typename DataT, int VecLen, typename Lambda, typename IdxT>
@@ -41,4 +41,4 @@ void scatterImpl(
 }
 
 }  // namespace detail
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/device_atomics.cuh
+++ b/cpp/include/raft/util/device_atomics.cuh
@@ -439,10 +439,6 @@ struct typesAtomicCASImpl<T, 8> {
 }  // namespace detail
 }  // namespace device_atomics
 
-}  // namespace raft
-
-namespace raft {
-
 /** -------------------------------------------------------------------------*
  * @brief compute atomic binary operation
  * reads the `old` located at the `address` in global or shared memory,

--- a/cpp/include/raft/util/device_atomics.cuh
+++ b/cpp/include/raft/util/device_atomics.cuh
@@ -441,7 +441,7 @@ struct typesAtomicCASImpl<T, 8> {
 
 }  // namespace raft
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /** -------------------------------------------------------------------------*
  * @brief compute atomic binary operation
@@ -479,7 +479,7 @@ __forceinline__ __device__ bool genericAtomicOperation(bool* address,
   return T(fun(address, update_value, op));
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 /**
  * @brief Overloads for `atomicAdd`

--- a/cpp/include/raft/util/device_atomics.cuh
+++ b/cpp/include/raft/util/device_atomics.cuh
@@ -21,7 +21,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 namespace device_atomics {
 namespace detail {
@@ -438,6 +438,10 @@ struct typesAtomicCASImpl<T, 8> {
 
 }  // namespace detail
 }  // namespace device_atomics
+
+}  // namespace raft
+
+namespace RAFT_EXPORT raft {
 
 /** -------------------------------------------------------------------------*
  * @brief compute atomic binary operation

--- a/cpp/include/raft/util/device_loads_stores.cuh
+++ b/cpp/include/raft/util/device_loads_stores.cuh
@@ -13,7 +13,7 @@
 
 #include <cstdint>  // uintX_t
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /**
  * @defgroup SmemStores Shared memory store operations
@@ -771,4 +771,4 @@ DI void stg(const int64_t& reg, void* addr, bool guard)
 
 /** @} */
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/device_utils.cuh
+++ b/cpp/include/raft/util/device_utils.cuh
@@ -10,7 +10,7 @@
 
 #include <utility>  // pair
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 // TODO move to raft https://github.com/rapidsai/raft/issues/90
 /** helper method to get the compute capability version numbers */
@@ -96,4 +96,4 @@ DI T batchedBlockReduce(T val, char* smem)
   return val;
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/fast_int_div.cuh
+++ b/cpp/include/raft/util/fast_int_div.cuh
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace util {
 
 /**
@@ -113,4 +113,4 @@ HDI int operator%(int n, const FastIntDiv& divisor)
 }
 
 };  // namespace util
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/input_validation.hpp
+++ b/cpp/include/raft/util/input_validation.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <raft/core/detail/macros.hpp>
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 template <class ElementType, class Extents, class Layout, class Accessor>
 constexpr bool is_row_or_column_major(mdspan<ElementType, Extents, Layout, Accessor> m)
@@ -119,4 +119,4 @@ constexpr bool is_scalar_view(mdspan<ElementType, Extents> m)
   return false;
 }
 
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/util/integer_utils.hpp
+++ b/cpp/include/raft/util/integer_utils.hpp
@@ -86,9 +86,6 @@ constexpr inline S div_rounding_up_unsafe(const S& dividend, const T& divisor) n
   return (dividend + divisor - 1) / divisor;
 }
 
-}  // namespace raft
-
-namespace raft {
 namespace detail {
 template <typename I>
 constexpr inline I div_rounding_up_safe(std::integral_constant<bool, false>,
@@ -111,9 +108,7 @@ constexpr inline I div_rounding_up_safe(std::integral_constant<bool, true>,
 }
 
 }  // namespace detail
-}  // namespace raft
 
-namespace raft {
 /**
  * Divides the left-hand-side by the right-hand-side, rounding up
  * to an integral multiple of the right-hand-side, e.g. (9,5) -> 2 , (10,5) -> 2, (11,5) -> 3.

--- a/cpp/include/raft/util/integer_utils.hpp
+++ b/cpp/include/raft/util/integer_utils.hpp
@@ -36,7 +36,7 @@
 #include <stdexcept>
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 //! Utility functions
 /**
  * Finds the smallest integer not less than `number_to_round` and modulo `S` is
@@ -86,7 +86,7 @@ constexpr inline S div_rounding_up_unsafe(const S& dividend, const T& divisor) n
   return (dividend + divisor - 1) / divisor;
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 namespace raft {
 namespace detail {
@@ -113,7 +113,7 @@ constexpr inline I div_rounding_up_safe(std::integral_constant<bool, true>,
 }  // namespace detail
 }  // namespace raft
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 /**
  * Divides the left-hand-side by the right-hand-side, rounding up
  * to an integral multiple of the right-hand-side, e.g. (9,5) -> 2 , (10,5) -> 2, (11,5) -> 3.
@@ -247,4 +247,4 @@ _RAFT_HOST_DEVICE inline void wmul_64bit(uint64_t& res_hi, uint64_t& res_lo, uin
 #endif
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/integer_utils.hpp
+++ b/cpp/include/raft/util/integer_utils.hpp
@@ -86,6 +86,9 @@ constexpr inline S div_rounding_up_unsafe(const S& dividend, const T& divisor) n
   return (dividend + divisor - 1) / divisor;
 }
 
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace detail {
 template <typename I>
 constexpr inline I div_rounding_up_safe(std::integral_constant<bool, false>,
@@ -108,7 +111,9 @@ constexpr inline I div_rounding_up_safe(std::integral_constant<bool, true>,
 }
 
 }  // namespace detail
+}  // namespace raft
 
+namespace RAFT_EXPORT raft {
 /**
  * Divides the left-hand-side by the right-hand-side, rounding up
  * to an integral multiple of the right-hand-side, e.g. (9,5) -> 2 , (10,5) -> 2, (11,5) -> 3.

--- a/cpp/include/raft/util/itertools.hpp
+++ b/cpp/include/raft/util/itertools.hpp
@@ -13,7 +13,7 @@
  *
  */
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace util::itertools {
 
 /**
@@ -36,4 +36,4 @@ std::vector<S> product(std::initializer_list<Args>... lists)
 }
 
 }  // namespace util::itertools
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/memory_tracking_resources.hpp
+++ b/cpp/include/raft/util/memory_tracking_resources.hpp
@@ -27,7 +27,7 @@
 #include <ostream>
 #include <string>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /**
  * @brief A resources handle that wraps all reachable memory resources with
@@ -226,4 +226,4 @@ class memory_tracking_resources : public resources {
   }
 };
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/memory_type_dispatcher.cuh
+++ b/cpp/include/raft/util/memory_type_dispatcher.cuh
@@ -14,6 +14,9 @@
 
 namespace RAFT_EXPORT raft {
 
+}  // namespace RAFT_EXPORT raft
+
+namespace raft {
 namespace detail {
 
 template <typename lambda_t, typename arg_t, typename = void>
@@ -33,7 +36,9 @@ auto static constexpr is_callable_for_memory_type =
   is_callable<lambda_t, decltype(std::declval<mdbuffer_type>().template view<mem_type>())>::value;
 
 }  // namespace detail
+}  // namespace raft
 
+namespace RAFT_EXPORT raft {
 /**
  * @defgroup memory_type_dispatcher Dispatch functor based on memory type
  * @{

--- a/cpp/include/raft/util/memory_type_dispatcher.cuh
+++ b/cpp/include/raft/util/memory_type_dispatcher.cuh
@@ -12,9 +12,9 @@
 #include <type_traits>
 #include <utility>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft
 
 namespace raft {
 namespace detail {
@@ -38,7 +38,7 @@ auto static constexpr is_callable_for_memory_type =
 }  // namespace detail
 }  // namespace raft
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 /**
  * @defgroup memory_type_dispatcher Dispatch functor based on memory type
  * @{
@@ -202,4 +202,4 @@ decltype(auto) memory_type_dispatcher(raft::resources const& res, lambda_t&& f, 
 
 /** @} */
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/memory_type_dispatcher.cuh
+++ b/cpp/include/raft/util/memory_type_dispatcher.cuh
@@ -14,9 +14,6 @@
 
 namespace raft {
 
-}  // namespace raft
-
-namespace raft {
 namespace detail {
 
 template <typename lambda_t, typename arg_t, typename = void>
@@ -36,9 +33,7 @@ auto static constexpr is_callable_for_memory_type =
   is_callable<lambda_t, decltype(std::declval<mdbuffer_type>().template view<mem_type>())>::value;
 
 }  // namespace detail
-}  // namespace raft
 
-namespace raft {
 /**
  * @defgroup memory_type_dispatcher Dispatch functor based on memory type
  * @{

--- a/cpp/include/raft/util/popc.cuh
+++ b/cpp/include/raft/util/popc.cuh
@@ -6,7 +6,7 @@
 #pragma once
 #include <raft/core/detail/macros.hpp>
 #include <raft/util/detail/popc.cuh>
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /**
  * @brief Count the number of bits that are set to 1 in a vector.
@@ -28,4 +28,4 @@ void popc(const raft::resources& res,
   detail::popc(res, values, max_len, counter);
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/pow2_utils.cuh
+++ b/cpp/include/raft/util/pow2_utils.cuh
@@ -8,7 +8,7 @@
 #include <raft/core/detail/macros.hpp>
 #include <raft/util/cuda_utils.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /**
  * Checks whether an integer is a power of 2.
@@ -169,4 +169,4 @@ struct Pow2 {
 #undef Pow2_WHEN_INTEGRAL
 };
 
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/util/raft_explicit.hpp
+++ b/cpp/include/raft/util/raft_explicit.hpp
@@ -62,7 +62,7 @@
     throw "raft_explicit_error";                                                               \
   }
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace util::raft_explicit {
 /**
  * @brief Template that is always false
@@ -77,4 +77,4 @@ struct implicit_instantiation {
   static constexpr bool value = false;
 };
 }  // namespace util::raft_explicit
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/reduction.cuh
+++ b/cpp/include/raft/util/reduction.cuh
@@ -13,7 +13,7 @@
 
 #include <stdint.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /**
  * @brief Logical-warp-level reduction
@@ -287,4 +287,4 @@ DI void logicalWarpReduceVector(T* acc, int lane_id, ReduceLambda reduce_op)
   }
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/scatter.cuh
+++ b/cpp/include/raft/util/scatter.cuh
@@ -10,7 +10,7 @@
 #include <raft/util/cuda_utils.cuh>
 #include <raft/util/detail/scatter.cuh>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /**
  * @brief Performs scatter operation based on the input indexing array
@@ -56,4 +56,4 @@ void scatter(DataT* out,
   }
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/seive.hpp
+++ b/cpp/include/raft/util/seive.hpp
@@ -12,7 +12,7 @@
 // Taken from:
 //  https://github.com/teju85/programming/blob/master/euler/include/seive.h
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 namespace common {
 
 /**
@@ -113,4 +113,4 @@ class Seive {
   std::vector<unsigned> seive;
 };
 };  // namespace common
-};  // namespace RAFT_EXPORT raft
+};  // namespace raft

--- a/cpp/include/raft/util/variant_utils.hpp
+++ b/cpp/include/raft/util/variant_utils.hpp
@@ -8,7 +8,7 @@
 #include <type_traits>
 #include <variant>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 template <typename variant1, typename variant2>
 struct concatenated_variant;
@@ -52,4 +52,4 @@ struct is_type_in_variant<T, std::variant<Vs...>> {
 template <typename T, typename VariantType>
 auto static constexpr is_type_in_variant_v = is_type_in_variant<T, VariantType>::value;
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/vectorized.cuh
+++ b/cpp/include/raft/util/vectorized.cuh
@@ -13,7 +13,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 // Third parameter enables SFINAE for conditional specializations (e.g., KeyValuePair by size)
 template <typename math_, int VecLen, typename Enable = void>
@@ -428,4 +428,4 @@ DI void copy_vectorized(T* out, const T* in, uint32_t n)
     }
   }
 }
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/vectorized_kvp.cuh
+++ b/cpp/include/raft/util/vectorized_kvp.cuh
@@ -10,7 +10,7 @@
 
 #include <type_traits>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 /**
  * Generic IOType specializations for ALL KeyValuePair<K, V> types based on sizeof.
  *
@@ -62,4 +62,4 @@ struct IOType<KeyValuePair<K, V>, 1, std::enable_if_t<sizeof(KeyValuePair<K, V>)
   static_assert(std::is_trivially_copyable_v<KeyValuePair<K, V>>);
   using Type = int4;
 };
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft/util/warp_primitives.cuh
+++ b/cpp/include/raft/util/warp_primitives.cuh
@@ -12,7 +12,7 @@
 
 #include <stdint.h>
 
-namespace RAFT_EXPORT raft {
+namespace raft {
 
 /** True CUDA alignment of a type (adapted from CUB) */
 template <typename T>
@@ -219,4 +219,4 @@ DI std::enable_if_t<!is_shuffleable_v<T>, T> shfl_xor(T val,
   return output;
 }
 
-}  // namespace RAFT_EXPORT raft
+}  // namespace raft

--- a/cpp/include/raft_runtime/matrix/select_k.hpp
+++ b/cpp/include/raft_runtime/matrix/select_k.hpp
@@ -12,12 +12,11 @@
 #include <optional>
 
 namespace raft::runtime::matrix {
-RAFT_EXPORT void select_k(
-  const resources& handle,
-  raft::device_matrix_view<const float, int64_t, row_major> in_val,
-  std::optional<raft::device_matrix_view<const int64_t, int64_t, row_major>> in_idx,
-  raft::device_matrix_view<float, int64_t, row_major> out_val,
-  raft::device_matrix_view<int64_t, int64_t, row_major> out_idx,
-  bool select_min);
+void select_k(const resources& handle,
+              raft::device_matrix_view<const float, int64_t, row_major> in_val,
+              std::optional<raft::device_matrix_view<const int64_t, int64_t, row_major>> in_idx,
+              raft::device_matrix_view<float, int64_t, row_major> out_val,
+              raft::device_matrix_view<int64_t, int64_t, row_major> out_idx,
+              bool select_min);
 
 }  // namespace raft::runtime::matrix


### PR DESCRIPTION
Restrict symbol exports from libraft.so to only the public API surface:

- **`include/raft/core/`** (non-detail): exported via `namespace RAFT_EXPORT raft`
- **`include/raft_runtime/`**: exported via `RAFT_EXPORT` on function declarations (lanczos_solver, rmat_rectangular_gen)
- **Everything else** (linalg, matrix, random, sparse, spectral, stats, util, label, solver, comms, mr, pmr, and all detail/ namespaces): hidden

With `CXX_VISIBILITY_PRESET hidden` on `raft_objs`, this ensures only the intended public symbols are visible in the shared library, preventing symbol interposition between libcuml.so and libcuvs.so for internal raft implementation details.

### Changes

1. **Remove `RAFT_EXPORT` from detail namespaces** — prevents internal detail symbols from being exported
2. **Remove `RAFT_EXPORT` from all non-core directories** — linalg, matrix, random, sparse, spectral, stats, util, label, solver, comms, mr, pmr no longer export symbols
3. **Remove `RAFT_EXPORT` from `raft_runtime::matrix::select_k`** — this function has no `.cu` source in `src/` and is not compiled into libraft.so (it's instantiated by downstream consumers like cuvs)

### Verification

- libraft.so builds and links cleanly
- cuvs compiles successfully against these changes (tested distance, brute_force, cagra, select_k, sparse_distance translation units)

Contributes to https://github.com/rapidsai/build-infra/issues/53