### PR TITLE
Restore resource_cast guard for RAFT memory pool

### DIFF
--- a/cpp/include/raft/core/device_resources_manager.hpp
+++ b/cpp/include/raft/core/device_resources_manager.hpp
@@ -15,6 +15,8 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
+#include <cuda/memory_resource>
+
 #include <algorithm>
 #include <memory>
 #include <optional>
@@ -156,15 +158,18 @@ struct device_resources_manager {
           // If max_mem_pool_size is nullopt or non-zero, create a pool memory
           // resource
           if (params.max_mem_pool_size.value_or(1) != 0) {
-            // TODO: reinstate the dynamic_cast<cuda_memory_resource*> guard that
-            // skipped pool creation when a non-default resource was already set,
-            // once CCCL exposes resource_cast or an equivalent type-query.
             auto upstream = rmm::mr::get_current_device_resource_ref();
-            result.emplace(
-              upstream,
-              params.init_mem_pool_size.value_or(rmm::percent_of_free_device_memory(50)),
-              params.max_mem_pool_size);
-            rmm::mr::set_current_device_resource(*result);
+            if (cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&upstream) != nullptr) {
+              result.emplace(
+                upstream,
+                params.init_mem_pool_size.value_or(rmm::percent_of_free_device_memory(50)),
+                params.max_mem_pool_size);
+              rmm::mr::set_current_device_resource(*result);
+            } else {
+              RAFT_LOG_WARN(
+                "Pool allocation requested, but other memory resource has already been set and "
+                "will not be overwritten");
+            }
           }
           return result;
         }()},

--- a/cpp/tests/core/device_resources_manager.cpp
+++ b/cpp/tests/core/device_resources_manager.cpp
@@ -9,6 +9,7 @@
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 
+#include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
 
 #include <gtest/gtest.h>
@@ -46,11 +47,13 @@ TEST(DeviceResourcesManager, ObeysSetters)
   auto unique_pools   = std::array<std::set<rmm::cuda_stream_pool const*>, 2>{};
 
   // Provide lock for counting unique objects
-  auto mtx = std::mutex{};
+  auto mtx         = std::mutex{};
+  auto default_mrs = std::array<bool, 2>{};
 
   for (auto i = std::size_t{}; i < devices.size(); ++i) {
     auto scoped_device = device_setter{devices[i]};
     auto upstream      = rmm::mr::get_current_device_resource_ref();
+    default_mrs[i] = cuda::mr::resource_cast<rmm::mr::cuda_memory_resource>(&upstream) != nullptr;
     device_resources_manager::set_workspace_memory_resource(
       raft::mr::device_resource{
         rmm::mr::pool_memory_resource(upstream, workspace_init, workspace_limit)},
@@ -83,6 +86,10 @@ TEST(DeviceResourcesManager, ObeysSetters)
 
     auto const& pool = res.get_stream_pool();
     EXPECT_EQ(streams_per_pool, pool.get_pool_size());
+
+    auto current_mr = rmm::mr::get_current_device_resource_ref();
+    auto* mr        = cuda::mr::resource_cast<rmm::mr::pool_memory_resource>(&current_mr);
+    if (default_mrs[i % devices.size()]) { EXPECT_NE(mr, nullptr); }
 
     {
       auto lock = std::unique_lock{mtx};


### PR DESCRIPTION
## Description
PR #2996 migrated RAFT to the CCCL/RMM memory-resource model and temporarily removed the guard that prevented `device_resources_manager` from overwriting a user-installed RMM resource. Now that CCCL provides `cuda::mr::resource_cast` support for RMM resources, restore that behavior using `rmm::mr::get_current_device_resource_ref()`.

With this change, `device_resources_manager` only creates and installs its pool when the current resource is the default `rmm::mr::cuda_memory_resource`. If another resource is already installed, RAFT preserves it and emits the existing warning.

The test coverage removed during #2996 is restored with `resource_cast` against the current resource ref.