### PR TITLE
bump NCCL floor to 2.28

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -29,7 +29,7 @@ dependencies:
 - libcusolver-dev
 - libcusparse-dev
 - libucxx==0.51.*,>=0.0.0a0
-- nccl>=2.19
+- nccl>=2.28
 - ninja
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -29,7 +29,7 @@ dependencies:
 - libcusolver-dev
 - libcusparse-dev
 - libucxx==0.51.*,>=0.0.0a0
-- nccl>=2.19
+- nccl>=2.28
 - ninja
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -29,7 +29,7 @@ dependencies:
 - libcusolver-dev
 - libcusparse-dev
 - libucxx==0.51.*,>=0.0.0a0
-- nccl>=2.19
+- nccl>=2.28
 - ninja
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -29,7 +29,7 @@ dependencies:
 - libcusolver-dev
 - libcusparse-dev
 - libucxx==0.51.*,>=0.0.0a0
-- nccl>=2.19
+- nccl>=2.28
 - ninja
 - numpy>=1.23,<3.0
 - numpydoc

--- a/conda/recipes/libraft/conda_build_config.yaml
+++ b/conda/recipes/libraft/conda_build_config.yaml
@@ -17,4 +17,4 @@ cmake_version:
   - ">=4.0"
 
 nccl_version:
-  - ">=2.19"
+  - ">=2.28"

--- a/conda/recipes/raft-dask/conda_build_config.yaml
+++ b/conda/recipes/raft-dask/conda_build_config.yaml
@@ -17,4 +17,4 @@ cmake_version:
   - ">=4.0"
 
 nccl_version:
-  - ">=2.19"
+  - ">=2.28"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -642,7 +642,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - &nccl_unsuffixed nccl>=2.19
+          - &nccl_unsuffixed nccl>=2.28
     specific:
       - output_types: [pyproject, requirements]
         matrices:
@@ -650,11 +650,11 @@ dependencies:
               cuda: "12.*"
               cuda_suffixed: "true"
             packages:
-              - nvidia-nccl-cu12>=2.19
+              - nvidia-nccl-cu12>=2.28
           - matrix:
               cuda: "13.*"
               cuda_suffixed: "true"
             packages:
-              - nvidia-nccl-cu13>=2.19
+              - nvidia-nccl-cu13>=2.28
           - matrix:
             packages:


### PR DESCRIPTION
https://github.com/rapidsai/raft/pull/3002 updated raft to use new nccl functions added in NCCL 2.28.3 (2.28.3 is the first public release version of NCCL 2.28, the most recent NCCL version is 2.30).

Following this, this PR bumps up the minimum NCCL version to 2.28 to fix CI failures in cuGraph (complaining ncclGather is undefined in wheel tests with CUDA 12.9).
