### PR TITLE
SelectK race condition fix

### DIFF
--- a/cpp/include/raft/matrix/detail/select_radix.cuh
+++ b/cpp/include/raft/matrix/detail/select_radix.cuh
@@ -748,15 +748,8 @@ RAFT_KERNEL radix_kernel(const T* in,
                                              pass,
                                              early_stop);
   __threadfence();
-  // Ensure every thread in this block has finished its writes (and the
-  // corresponding __threadfence) before any block signals completion via
-  // atomicInc. Otherwise warp 0's thread 0 can race ahead of lagging warps
-  // that are still issuing atomicAdds inside filter_and_histogram (e.g. the
-  // histogram merge loop, or writes to `out`/`out_buf` in the early_stop
-  // path), causing the block that becomes the "last block" to read an
-  // incomplete histogram / miss output writes. The resulting wrong
-  // kth_value_bits can yield either slightly wrong top-k values or fewer than
-  // k writes to `out` (leaving the caller's initialization sentinel in place).
+  // Ensure every thread in this block has finished its writes before finished_block_cnt is updated.
+  // Otherwise, the last block (isLastBlock) will read an incomplete histogram.
   __syncthreads();
 
   bool isLastBlock = false;

--- a/cpp/include/raft/matrix/detail/select_radix.cuh
+++ b/cpp/include/raft/matrix/detail/select_radix.cuh
@@ -748,6 +748,16 @@ RAFT_KERNEL radix_kernel(const T* in,
                                              pass,
                                              early_stop);
   __threadfence();
+  // Ensure every thread in this block has finished its writes (and the
+  // corresponding __threadfence) before any block signals completion via
+  // atomicInc. Otherwise warp 0's thread 0 can race ahead of lagging warps
+  // that are still issuing atomicAdds inside filter_and_histogram (e.g. the
+  // histogram merge loop, or writes to `out`/`out_buf` in the early_stop
+  // path), causing the block that becomes the "last block" to read an
+  // incomplete histogram / miss output writes. The resulting wrong
+  // kth_value_bits can yield either slightly wrong top-k values or fewer than
+  // k writes to `out` (leaving the caller's initialization sentinel in place).
+  __syncthreads();
 
   bool isLastBlock = false;
   if (threadIdx.x == 0) {


### PR DESCRIPTION
Resolves https://github.com/rapidsai/raft/issues/2997, a longstanding flaky test failure.

There is a synchronization race where the output buffer histogram may not be fully populated when it is read by the last block. 
The blocks signal completion via `finished_block_cnt`, but does not guarantee all threads are complete with the `filter_and_historgram` function. 
So we need to use `__syncthreads()` to guarantee all threads within the block are done before incrementing `finished_block_cnt`.