### PR TITLE
refactor: switch to `rapids-artifact-name` for consistent artifact naming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,6 +141,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: libraft
       package-type: cpp
+      publish-wheel-search-key: raft_wheel_cpp_libraft
   wheel-build-pylibraft:
     needs: wheel-build-libraft
     permissions:
@@ -179,7 +180,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: pylibraft
       package-type: python
-      publish-wheel-search-key: pylibraft_wheel_python_abi3
+      publish-wheel-search-key: raft_wheel_python_pylibraft
   wheel-build-raft-dask:
     needs: wheel-build-libraft
     permissions:
@@ -218,7 +219,7 @@ jobs:
       date: ${{ inputs.date }}
       package-name: raft_dask
       package-type: python
-      publish-wheel-search-key: raft_dask_wheel_python_abi3
+      publish-wheel-search-key: raft_wheel_python_raft_dask
   devcontainers:
     name: Build devcontainers
     secrets: inherit  # zizmor: ignore[secrets-inherit]

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -234,6 +234,7 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/conda-cpp-post-build-checks.yaml@main
     with:
       build_type: pull-request
+      package_name: libraft
   conda-python-build:
     needs: conda-cpp-build
     permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,7 @@ jobs:
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
       sha: ${{ inputs.sha }}
+      package_name: libraft
   conda-cpp-tests:
     permissions:
       actions: read

--- a/ci/build_cpp.sh
+++ b/ci/build_cpp.sh
@@ -40,3 +40,6 @@ sccache --stop-server >/dev/null 2>&1 || true
 
 # remove build_cache directory
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")"
+export RAPIDS_PACKAGE_NAME

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -5,8 +5,8 @@
 set -euo pipefail
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name "conda_python" raft --stable --cuda "$RAPIDS_CUDA_VERSION")")
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python raft raft --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-logger "Create test conda environment"
 . /opt/conda/etc/profile.d/conda.sh

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -13,7 +13,7 @@ rapids-print-env
 
 rapids-logger "Begin py build"
 
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")")
 
 version=$(rapids-generate-version)
 export RAPIDS_PACKAGE_VERSION=${version}
@@ -55,5 +55,5 @@ sccache --stop-server >/dev/null 2>&1 || true
 # remove build_cache directory
 rm -rf "$RAPIDS_CONDA_BLD_OUTPUT_DIR"/build_cache
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name conda_python raft --stable --cuda)"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name conda_python raft raft --stable --cuda "$RAPIDS_CUDA_VERSION")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel_libraft.sh
+++ b/ci/build_wheel_libraft.sh
@@ -31,3 +31,6 @@ export PIP_NO_BUILD_ISOLATION=0
 
 ci/build_wheel.sh libraft ${package_dir}
 ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
+
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")"
+export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel_pylibraft.sh
+++ b/ci/build_wheel_pylibraft.sh
@@ -15,7 +15,7 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 #
 # env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
 # 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)
-LIBRAFT_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libraft_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+LIBRAFT_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")")
 echo "libraft-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBRAFT_WHEELHOUSE}"/libraft_*.whl)" >> "${PIP_CONSTRAINT}"
 
 # TODO: move this variable into `ci-wheel`
@@ -26,5 +26,5 @@ export RAPIDS_PY_API
 ci/build_wheel.sh pylibraft ${package_dir} --stable
 ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name wheel_python pylibraft --stable --cuda)"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python pylibraft raft --stable --cuda "$RAPIDS_CUDA_VERSION")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/build_wheel_raft_dask.sh
+++ b/ci/build_wheel_raft_dask.sh
@@ -15,7 +15,7 @@ RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
 #
 # env variable 'PIP_CONSTRAINT' is set up by rapids-init-pip. It constrains all subsequent
 # 'pip install', 'pip download', etc. calls (except those used in 'pip wheel', handled separately in build scripts)
-LIBRAFT_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libraft_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
+LIBRAFT_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")")
 echo "libraft-${RAPIDS_PY_CUDA_SUFFIX} @ file://$(echo "${LIBRAFT_WHEELHOUSE}"/libraft_*.whl)" >> "${PIP_CONSTRAINT}"
 
 # TODO: move this variable into `ci-wheel`
@@ -26,5 +26,5 @@ export RAPIDS_PY_API
 ci/build_wheel.sh raft-dask ${package_dir} --stable
 ci/validate_wheel.sh ${package_dir} "${RAPIDS_WHEEL_BLD_OUTPUT_DIR}"
 
-RAPIDS_PACKAGE_NAME="$(rapids-package-name wheel_python raft_dask --stable --cuda)"
+RAPIDS_PACKAGE_NAME="$(rapids-artifact-name wheel_python raft_dask raft --stable --cuda "$RAPIDS_CUDA_VERSION")"
 export RAPIDS_PACKAGE_NAME

--- a/ci/test_cpp.sh
+++ b/ci/test_cpp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail
@@ -12,7 +12,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../
 rapids-logger "Configuring conda strict channel priority"
 conda config --set channel_priority strict
 
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")")
 RAPIDS_TESTS_DIR=${RAPIDS_TESTS_DIR:-"${PWD}/test-results"}/
 mkdir -p "${RAPIDS_TESTS_DIR}"
 

--- a/ci/test_python.sh
+++ b/ci/test_python.sh
@@ -13,8 +13,8 @@ rapids-logger "Configuring conda strict channel priority"
 conda config --set channel_priority strict
 
 rapids-logger "Downloading artifacts from previous jobs"
-CPP_CHANNEL=$(rapids-download-conda-from-github cpp)
-PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-package-name "conda_python" raft --stable --cuda "$RAPIDS_CUDA_VERSION")")
+CPP_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")")
+PYTHON_CHANNEL=$(rapids-download-from-github "$(rapids-artifact-name conda_python raft raft --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 rapids-logger "Generate Python testing dependencies"
 rapids-dependency-file-generator \

--- a/ci/test_wheel_pylibraft.sh
+++ b/ci/test_wheel_pylibraft.sh
@@ -6,9 +6,8 @@ set -euo pipefail
 
 source rapids-init-pip
 
-RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
-LIBRAFT_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libraft_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
-PYLIBRAFT_WHEELHOUSE=$(rapids-download-from-github "$(rapids-package-name "wheel_python" pylibraft --stable --cuda "$RAPIDS_CUDA_VERSION")")
+LIBRAFT_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")")
+PYLIBRAFT_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python pylibraft raft --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"

--- a/ci/test_wheel_raft_dask.sh
+++ b/ci/test_wheel_raft_dask.sh
@@ -10,9 +10,9 @@ source rapids-init-pip
 rm -rf /usr/lib64/libnccl*
 
 RAPIDS_PY_CUDA_SUFFIX="$(rapids-wheel-ctk-name-gen "${RAPIDS_CUDA_VERSION}")"
-LIBRAFT_WHEELHOUSE=$(RAPIDS_PY_WHEEL_NAME="libraft_${RAPIDS_PY_CUDA_SUFFIX}" rapids-download-wheels-from-github cpp)
-PYLIBRAFT_WHEELHOUSE=$(rapids-download-from-github "$(rapids-package-name "wheel_python" pylibraft --stable --cuda "$RAPIDS_CUDA_VERSION")")
-RAFT_DASK_WHEELHOUSE=$(rapids-download-from-github "$(rapids-package-name "wheel_python" raft_dask --stable --cuda "$RAPIDS_CUDA_VERSION")")
+LIBRAFT_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_cpp libraft raft --cuda "$RAPIDS_CUDA_VERSION")")
+PYLIBRAFT_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python pylibraft raft --stable --cuda "$RAPIDS_CUDA_VERSION")")
+RAFT_DASK_WHEELHOUSE=$(rapids-download-from-github "$(rapids-artifact-name wheel_python raft_dask raft --stable --cuda "$RAPIDS_CUDA_VERSION")")
 
 # generate constraints (possibly pinning to oldest support versions of dependencies)
 rapids-generate-pip-constraints test_python "${PIP_CONSTRAINT}"


### PR DESCRIPTION
This PR swaps in `rapids-artifact-name` for `rapids-package-name` everywhere, and also removes any legacy named artifacts. All artifacts now follow the same naming convention (and that convention can be updated/expanded from a central location). Part of rapidsai/build-planning#270