### PR TITLE
skip CuPy 14.1.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=12.9.2,<13.0
 - cuda-version=12.9
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-132_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-132_arch-aarch64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -15,7 +15,7 @@ dependencies:
 - cuda-profiler-api
 - cuda-python>=13.0.1,<14.0
 - cuda-version=13.2
-- cupy>=13.6.0
+- cupy>=13.6.0,!=14.0.0,!=14.1.0
 - cxx-compiler
 - cython>=3.2.2
 - dask-cuda==26.6.*,>=0.0.0a0

--- a/conda/recipes/pylibraft/recipe.yaml
+++ b/conda/recipes/pylibraft/recipe.yaml
@@ -94,6 +94,8 @@ requirements:
     - if: cuda_major == "12"
       then: cuda-python >=12.9.2,<13.0
       else: cuda-python >=13.0.1,<14.0
+  run_constraints:
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
   ignore_run_exports:
     from_package:
       - ${{ compiler("c") }}

--- a/conda/recipes/raft-dask/recipe.yaml
+++ b/conda/recipes/raft-dask/recipe.yaml
@@ -98,6 +98,8 @@ requirements:
     - if: cuda_major == "12"
       then: cuda-python >=12.9.2,<13.0
       else: cuda-python >=13.0.1,<14.0
+  run_constraints:
+    - cupy >=13.6.0,!=14.0.0,!=14.1.0
   ignore_run_exports:
     from_package:
       - ${{ compiler("c") }}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -358,7 +358,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - cupy>=13.6.0
+          - cupy>=13.6.0,!=14.0.0,!=14.1.0
     # NOTE: This is intentionally not broken into groups by a 'cuda_suffixed' selector like
     #       other packages with -cu{nn}x suffixes in this file.
     #       All RAPIDS wheel builds (including in devcontainers) expect cupy to be suffixed.
@@ -368,11 +368,11 @@ dependencies:
           - matrix:
               cuda: "12.*"
             packages:
-              - cupy-cuda12x>=13.6.0
+              - cupy-cuda12x>=13.6.0,!=14.0.0,!=14.1.0
           # fallback to CUDA 13 versions if 'cuda' is '13.*' or not provided
           - matrix:
             packages:
-              - cupy-cuda13x>=13.6.0
+              - cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0
   depends_on_rapids_logger:
     common:
       - output_types: [conda, requirements, pyproject]

--- a/python/pylibraft/pyproject.toml
+++ b/python/pylibraft/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-    "cupy-cuda13x>=13.6.0",
+    "cupy-cuda13x>=13.6.0,!=14.0.0,!=14.1.0",
     "pytest",
     "pytest-cov",
     "scikit-learn",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/284

To reduce the risk of users encountering a known runtime issue with `cupy` and `torch`, RAPIDS 26.06 is taking on a requirement `cupy!=14.1.0`.

See the linked issue for details.
