### PR TITLE
Coderabbit integration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+reviews:
+  profile: chill
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  poem: false
+  sequence_diagrams: false
+  collapse_walkthrough: true
+  request_changes_workflow: false
+  review_status: false
+
+  # Exclude generated build trees from review noise
+  path_filters:
+    - "!**/build/**"
+    - "!python/**/build/**"
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "^main$"
+      - "^release/.*"
+      - "^hotfix/.*"
+    ignore_usernames: ["rapids-bot", "GPUtester", "nv-automation-bot", "copy-pr-bot"]
+
+  tools:
+    markdownlint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    gitleaks:
+      enabled: true
+
+  # Detailed review guidelines are in cpp/REVIEW_GUIDELINES.md and python/REVIEW_GUIDELINES.md.
+  # RAFT design idioms and preferred APIs are in docs/source/developer_guide.md.
+  path_instructions:
+    - path: "docs/**/*"
+      instructions: |
+        For documentation changes, focus on:
+        - Accuracy: verify code examples match current API
+        - Completeness: flag missing docs for public API changes
+        - Consistency: terminology and types match code
+
+    - path: "cpp/**/*"
+      instructions: |
+        For C++/CUDA changes, apply cpp/REVIEW_GUIDELINES.md and verify the code
+        follows the idioms in docs/source/developer_guide.md, especially the
+        "Preferred APIs and idioms" section (raft::resources over raw handles,
+        public API over detail, mdarray over device_uvector/std::vector, and
+        avoiding deprecated functions). For public headers under cpp/include/raft,
+        also require Doxygen on new APIs and deprecation warnings on breaking changes.
+
+    - path: "python/**/*"
+      instructions: |
+        For Python/Cython changes, apply python/REVIEW_GUIDELINES.md.
+
+    - path: "ci/**/*"
+      instructions: |
+        CI scripts: meaningful errors, GPU checks before GPU tests, correct env handling.
+
+knowledge_base:
+  opt_out: false
+  code_guidelines:
+    filePatterns:
+      - "cpp/REVIEW_GUIDELINES.md"
+      - "python/REVIEW_GUIDELINES.md"
+      - "docs/source/contributing.md"
+      - "docs/source/developer_guide.md"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@ build.sh           @rapidsai/raft-cmake-codeowners
 /.github/                @rapidsai/ci-codeowners
 /ci/                     @rapidsai/ci-codeowners
 /.shellcheckrc           @rapidsai/ci-codeowners
+/.coderabbit.yaml        @rapidsai/ci-codeowners
 
 #packaging code owners
 /.pre-commit-config.yaml @rapidsai/packaging-codeowners

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,6 +84,8 @@ jobs:
       files_yaml: |
         build_docs:
           - '**'
+          - '!**/*/REVIEW_GUIDELINES.md'
+          - '!.coderabbit.yaml'
           - '!.devcontainer/**'
           - '!.github/CODEOWNERS'
           - '!.github/ISSUE_TEMPLATE/**'
@@ -104,6 +106,8 @@ jobs:
           - '!thirdparty/LICENSES/**'
         test_cpp:
           - '**'
+          - '!**/*/REVIEW_GUIDELINES.md'
+          - '!.coderabbit.yaml'
           - '!.devcontainer/**'
           - '!.github/CODEOWNERS'
           - '!.github/ISSUE_TEMPLATE/**'
@@ -133,6 +137,8 @@ jobs:
           - '!thirdparty/LICENSES/**'
         test_python_conda:
           - '**'
+          - '!**/*/REVIEW_GUIDELINES.md'
+          - '!.coderabbit.yaml'
           - '!.devcontainer/**'
           - '!.github/CODEOWNERS'
           - '!.github/ISSUE_TEMPLATE/**'
@@ -161,6 +167,8 @@ jobs:
           - '!thirdparty/LICENSES/**'
         test_python_wheels:
           - '**'
+          - '!**/*/REVIEW_GUIDELINES.md'
+          - '!.coderabbit.yaml'
           - '!.devcontainer/**'
           - '!.github/CODEOWNERS'
           - '!.github/ISSUE_TEMPLATE/**'

--- a/cpp/REVIEW_GUIDELINES.md
+++ b/cpp/REVIEW_GUIDELINES.md
@@ -1,0 +1,317 @@
+# AI Code Review Guidelines - RAFT C++/CUDA
+
+**Role**: Act as a principal engineer with 10+ years experience in GPU computing and high-performance numerical computing. Focus ONLY on CRITICAL and HIGH issues.
+
+**Target**: Sub-3% false positive rate. Be direct, concise, minimal.
+
+**Context**: RAFT is a foundational library of GPU-accelerated primitives (core/mdspan/resources, linalg, sparse, stats, distance, random, cluster, matrix, neighbors, solvers) built with CUDA. Dependencies include RMM, libcudacxx, thrust, CUB, cuBLAS, and cuSOLVER.
+
+**Verify changes against `docs/source/developer_guide.md`**, especially *Preferred APIs and idioms*, *Public Interface*, *Resource Management*, and *Asynchronous operations and stream ordering*.
+
+## IGNORE These Issues
+
+- Style/formatting (clang-format handles this)
+- Minor naming preferences (unless truly misleading)
+- Personal taste on implementation (unless impacts maintainability)
+- Nits that don't affect functionality
+- Already-covered issues (one comment per root cause)
+
+## CRITICAL Issues (Always Comment)
+
+### GPU/CUDA Errors
+- Unchecked CUDA errors (kernel launches, memory operations, synchronization)
+- Race conditions in GPU kernels (shared memory, atomics, warps)
+- Device memory leaks (cudaMalloc/cudaFree imbalance, leaked streams/events)
+- Invalid memory access (out-of-bounds, use-after-free, host/device confusion)
+- Missing CUDA synchronization causing non-deterministic failures
+- Kernel launch with zero blocks/threads or invalid grid/block dimensions
+- **Missing explicit stream creation for concurrent operations** (reusing default stream, missing stream isolation)
+- **Incorrect stream lifecycle management** (using destroyed streams, not creating dedicated streams for concurrent ops)
+
+### Algorithm Correctness
+- Logic errors in primitive/algorithm kernels
+- Numerical instability causing wrong results (overflow, underflow, precision loss)
+- Incorrect gradient computations or convergence criteria (e.g. in solvers like lanczos/spectral)
+- **Data layout bugs** (incorrect row-major vs column-major assumptions)
+
+### Resource Management
+- GPU memory leaks (device allocations, managed memory, pinned memory)
+- CUDA stream/event leaks or improper cleanup
+- Missing RAII or proper cleanup. Including in exception paths.
+- Resource exhaustion (GPU memory)
+
+### API Breaking Changes
+- C++ API changes without proper deprecation warnings
+- Changes to data structures exposed in public headers (`cpp/include/raft/`, `cpp/include/raft_runtime/`)
+- Breaking changes to algorithm behavior
+
+## HIGH Issues (Comment if Substantial)
+
+### Performance Issues
+- Inefficient GPU kernel launches (low occupancy, poor memory access patterns)
+- Unnecessary host-device synchronization blocking GPU pipeline
+- Suboptimal memory access patterns (non-coalesced, strided, unaligned)
+- Excessive memory allocations in hot paths
+- Warp divergence in compute-heavy kernels
+- Shared memory bank conflicts
+
+### Numerical Stability
+- Floating-point operations prone to catastrophic cancellation
+- Missing checks for division by zero or near-zero values
+- Ill-conditioned matrix operations without preconditioning
+- Accumulation errors in iterative algorithms
+- Unsafe casting between numeric types (double→float with potential precision loss)
+- Missing epsilon comparisons for floating-point equality checks
+- **Numerical edge cases** (near-zero eigenvalues, degenerate matrices, extreme values)
+
+### Concurrency & Thread Safety
+- Race conditions in multi-GPU operations
+- Improper CUDA stream management causing false dependencies
+- Deadlock potential in resource acquisition
+- Thread-unsafe use of global/static variables
+- **Concurrent operations sharing streams incorrectly** (multi-GPU without proper isolation)
+- **Stream reuse across independent operations** (causing unwanted serialization or race conditions)
+
+### Design & Architecture
+- Hard-coded GPU device IDs or resource limits
+- Inappropriate use of exceptions in performance-critical paths
+- Significant code duplication (3+ occurrences). Including in kernel logic.
+- Reinventing functionality already available in RAFT's own primitives (core/linalg/util/...), RMM, libcudacxx, thrust, CUB, cuBLAS, or cuSOLVER
+- **Prefer `raft::resources` over raw handles/streams** in function overloads (see developer_guide.md)
+- **Prefer the public API over `detail`** when re-using functionality, including in tests (see developer_guide.md)
+- **Prefer `raft` mdarray over `rmm::device_uvector`/`std::vector`** for owning data (see developer_guide.md)
+- **Prefer non-deprecated substitutes** over deprecated functions (see developer_guide.md)
+
+### Test Quality
+- Missing validation of numerical correctness
+- **Using external datasets** (tests must not depend on external resources; use synthetic data or bundled datasets)
+
+## MEDIUM Issues (Comment Selectively)
+
+- Missing input validation (negative dimensions, null pointers)
+- Deprecated CUDA API usage
+- **Unclear data format in function parameters** (ambiguous row-major or column-major)
+
+## Review Protocol
+
+1. **CUDA correctness**: Errors checked? Memory safety? Race conditions? Synchronization?
+2. **Algorithm correctness**: Does the kernel logic produce correct results? Numerical stability?
+3. **Resource management**: GPU memory leaks? Stream/event cleanup?
+4. **Performance**: GPU bottlenecks? Unnecessary sync? Memory access patterns?
+5. **API stability**: Breaking changes to C++ APIs?
+6. **Data layout**: Row/column major handled correctly?
+7. **Stream lifecycle**: Are CUDA streams explicitly created/destroyed for concurrent operations?
+8. **Ask, don't tell**: "Have you considered X?" not "You should do X"
+
+## Quality Threshold
+
+Before commenting, ask:
+1. Is this actually wrong/risky, or just different?
+2. Would this cause a real problem (crash, wrong results, leak)?
+3. Does this comment add unique value?
+
+**If no to any: Skip the comment.**
+
+## Output Format
+
+- Use severity labels: CRITICAL, HIGH, MEDIUM
+- Be concise: One-line issue summary + one-line impact
+- Provide code suggestions when you have concrete fixes
+- No preamble or sign-off
+
+## Examples to Follow
+
+**CRITICAL** (GPU memory leak):
+```
+CRITICAL: GPU memory leak in fit()
+
+Issue: Device memory allocated but never freed on error path
+Why: Causes GPU OOM on repeated calls
+
+Suggested fix:
+if (cudaMalloc(&d_data, size) != cudaSuccess) {
+    cudaFree(d_centroids);
+    return ERROR_CODE;
+}
+```
+
+**CRITICAL** (unchecked CUDA error):
+```
+CRITICAL: Unchecked kernel launch
+
+Issue: Kernel launch error not checked
+Why: Subsequent operations assume success, causing silent corruption
+
+Suggested fix:
+myKernel<<<grid, block>>>(args);
+RAFT_CUDA_TRY(cudaGetLastError());
+```
+
+**HIGH** (numerical stability):
+```
+HIGH: Potential division by near-zero
+
+Issue: No epsilon check before division in distance computation
+Why: Can produce Inf/NaN values corrupting results
+Consider: Add epsilon threshold check or use safe division helper
+```
+
+**HIGH** (performance issue):
+```
+HIGH: Unnecessary synchronization in hot path
+
+Issue: cudaDeviceSynchronize() or raft::resource::sync_stream() inside iteration loop
+Why: Blocks GPU pipeline
+Consider: Move sync outside loop or use streams with events
+```
+
+**CRITICAL** (data layout mismatch):
+```
+CRITICAL: Incorrect memory layout assumption in kernel
+
+Issue: Kernel assumes row-major data but input is column-major
+Why: Memory access pattern produces wrong results
+Impact: Silent data corruption
+
+Suggested fix:
+// Check and handle data layout explicitly
+if (input.is_column_major()) {
+    // Use column-major kernel variant
+}
+```
+
+**HIGH** (missing stream isolation):
+```
+HIGH: Multi-GPU operation missing dedicated streams
+
+Issue: Multi-GPU operation uses default stream without per-device streams
+Why: Can cause serialization across devices, race conditions, or deadlocks
+
+Suggested fix:
+cudaStream_t per_device_stream;
+cudaStreamCreate(&per_device_stream);
+// Use per_device_stream for this GPU's operations
+// cudaStreamDestroy(per_device_stream) in cleanup
+```
+
+## Examples to Avoid
+
+**Boilerplate** (avoid):
+- "CUDA Best Practices: Using streams improves concurrency..."
+- "Memory Management: Proper cleanup of GPU resources is important..."
+
+**Subjective style** (ignore):
+- "Consider using auto here instead of explicit type"
+- "This function could be split into smaller functions"
+
+---
+
+## C++/CUDA-Specific Considerations
+
+**Error Handling**:
+- Use RAFT macros: `RAFT_CUDA_TRY`, `RAFT_CUBLAS_TRY`, `RAFT_CUSOLVER_TRY`
+- Every CUDA call must have error checking (kernel launches, memory ops, sync)
+- Use `RAFT_CUDA_TRY_NO_THROW` in destructors
+
+**Memory Management**:
+- Use RMM for device memory allocations where possible
+- Use `raft::resources` for stream and allocator management
+- Prefer owning `raft` mdarray types (`raft::device_mdarray`, `raft::host_mdarray`); use `rmm::device_uvector`/`rmm::device_buffer` only as lower-level RAII when an mdarray does not fit
+
+**Stream Management**:
+- Get streams from `raft::resource::get_cuda_stream(res)`
+- For multi-stream operations, use `get_stream_from_stream_pool(res, idx)` / `get_next_usable_stream(res, idx)`
+- Concurrent operations (multi-GPU, async ops) must have dedicated streams
+- Clearly document stream lifecycle (who creates, who destroys)
+
+**Threading**:
+- Only OpenMP is allowed for host threading
+- Algorithms should be thread-safe with different `raft::resources` instances
+- Use `raft::stream_syncer` for proper stream ordering
+
+**Public API** (`cpp/include/raft/`):
+- Functions must be stateless (POD types, `raft::resources`, pointers to POD, mdspan)
+- Doxygen documentation required for all public functions
+- API changes require deprecation warnings
+
+---
+
+## Common Bug Patterns
+
+### 1. Memory Layout Confusion
+**Pattern**: Incorrect row-major vs column-major assumptions
+
+**Red flags**:
+- Direct pointer access without verifying data layout
+- Kernel assuming row-major when data might be column-major
+- Missing layout parameter in function signatures
+
+### 2. CUDA Stream Lifecycle Issues
+**Pattern**: Missing explicit stream creation for concurrent operations
+
+**Red flags**:
+- Multi-GPU operations without dedicated stream per device
+- Stream creation inside loop but destruction outside loop
+- Using `nullptr` or default stream for operations that need isolation
+- Missing `cudaStreamDestroy` for explicitly created streams
+
+### 3. GPU Memory Leaks
+**Pattern**: Device memory allocated but not properly freed
+
+**Red flags**:
+- cudaMalloc without corresponding cudaFree
+- Temporary GPU buffers allocated per iteration without cleanup
+- Exception paths skipping memory cleanup
+- Missing RAII or smart pointers for GPU memory
+
+### 4. Numerical Instability in Kernels
+**Pattern**: Incorrect floating-point handling in distance/kernel computations
+
+**Red flags**:
+- Division without epsilon check
+- Not handling zero-norm vectors
+- Accumulation without compensation (Kahan summation)
+- Unsafe type casting (double→float)
+
+---
+
+## Code Review Checklists
+
+### When Reviewing CUDA Kernels
+- [ ] Are CUDA errors checked after kernel launch (with peek)?
+- [ ] Is shared memory usage within limits and avoiding bank conflicts?
+- [ ] Is shared memory used when clearly possible?
+- [ ] Is thread synchronization done correctly? Are any __syncthreads call unnecessary, misplaced or missing?
+- [ ] Is memory access coalesced?
+- [ ] Is memory aligned?
+- [ ] Is there serial work inside of a thread?
+- [ ] Are warp divergence issues minimized?
+- [ ] Are grid/block dimensions validated?
+
+### When Reviewing Multi-GPU Operations
+- [ ] Is stream lifecycle clearly documented?
+- [ ] Are independent GPU operations using dedicated streams?
+- [ ] Is `cudaSetDevice` called before device-specific operations?
+- [ ] Are stream errors checked?
+
+### When Reviewing Memory Operations
+- [ ] Is data layout (row-major vs column-major) explicitly handled?
+- [ ] Are device allocations paired with deallocations?
+- [ ] Is RAII used for GPU resources?
+- [ ] Are exception paths cleaning up resources?
+
+### When Reviewing Numerical Computations
+- [ ] Are edge cases handled (zero-norm, identical points)?
+- [ ] Are divisions protected against near-zero denominators?
+- [ ] Are epsilon tolerances used for floating-point comparisons?
+- [ ] Is numerical stability maintained (avoiding overflow/underflow)?
+
+### When Reviewing Tests
+- [ ] Are all datasets synthetic or bundled (no external resource dependencies)?
+- [ ] Is numerical correctness validated?
+- [ ] Are edge cases tested (empty, single element, extreme values)?
+
+---
+
+**Remember**: Focus on correctness and safety. Catch real bugs (crashes, wrong results, leaks),
+ignore style preferences. For RAFT C++: CUDA correctness and numerical stability are paramount.

--- a/docs/source/developer_guide.md
+++ b/docs/source/developer_guide.md
@@ -45,10 +45,10 @@ sync_stream(res);
 
 int n_streams = get_stream_pool_size(res);
 
-#pragma omp parallel for num_threads(n_threads)
+#pragma omp parallel for num_threads(n_streams)
 for(int i = 0; i < n; i++) {
-    int thread_num = omp_get_thread_num() % n_threads;
-    cudaStream_t s = get_stream_from_stream_pool(res, thread_num);
+    int thread_num    = omp_get_thread_num() % n_streams;
+    auto s            = get_stream_from_stream_pool(res, thread_num);  // rmm::cuda_stream_view
     ... possible light cpu pre-processing ...
     my_kernel1<<<b, tpb, 0, s>>>(...);
     ...
@@ -75,7 +75,7 @@ The use of threads in third-party libraries is allowed, though they should still
 
 ### General guidelines
 Functions exposed via the C++ API must be stateless. Things that are OK to be exposed on the interface:
-1. Any [POD](https://en.wikipedia.org/wiki/Passive_data_structure) - see [std::is_pod](https://en.cppreference.com/w/cpp/types/is_pod) as a reference for C++11  POD types.
+1. Any [POD](https://en.wikipedia.org/wiki/Passive_data_structure) type. Since `std::is_pod` is deprecated as of C++20, check for [std::is_standard_layout](https://en.cppreference.com/w/cpp/types/is_standard_layout) together with [std::is_trivial](https://en.cppreference.com/w/cpp/types/is_trivial) as a reference for POD types.
 2. `raft::resources` - since it stores resource-related state which has nothing to do with model/algo state.
 3. Avoid using pointers to POD types (explicitly putting it out, even though it can be considered as a POD) and pass the structures by reference instead.
    Internal to the C++ API, these stateless functions are free to use their own temporary classes, as long as they are not exposed on the interface.
@@ -98,10 +98,10 @@ class ivf_pq {
 
 public:
   ivf_pq(raft::resources const& res);
-  void train(raft::device_matrix<value_t, idx_t, raft::row_major> dataset);
-  void search(raft::device_matrix<value_t, idx_t, raft::row_major> queries,
-              raft::device_matrix<value_t, idx_t, raft::row_major> out_inds,
-              raft::device_matrix<value_t, idx_t, raft::row_major> out_dists);
+  void train(raft::device_matrix_view<const value_t, idx_t, raft::row_major> dataset);
+  void search(raft::device_matrix_view<const value_t, idx_t, raft::row_major> queries,
+              raft::device_matrix_view<idx_t, idx_t, raft::row_major> out_inds,
+              raft::device_matrix_view<value_t, idx_t, raft::row_major> out_dists);
 };
 ```
 
@@ -109,15 +109,15 @@ An alternative correct way to expose this could be:
 ```cpp
 namespace raft::ivf_pq {
 
-template<typename value_t, typename value_idx>
-void ivf_pq_train(raft::resources const& res, const raft::ivf_pq_params &params, raft::ivf_pq_index &index,
-raft::device_matrix<value_t, idx_t, raft::row_major> dataset);
+template<typename value_t, typename idx_t>
+void ivf_pq_train(raft::resources const& res, const raft::ivf_pq_params& params, raft::ivf_pq_index& index,
+raft::device_matrix_view<const value_t, idx_t, raft::row_major> dataset);
 
-template<typename value_t, typename value_idx>
-void ivf_pq_search(raft::resources const& res, raft::ivf_pq_params const&params, raft::ivf_pq_index const & index,
-raft::device_matrix<value_t, idx_t, raft::row_major> queries,
-raft::device_matrix<value_t, idx_t, raft::row_major> out_inds,
-raft::device_matrix<value_t, idx_t, raft::row_major> out_dists);
+template<typename value_t, typename idx_t>
+void ivf_pq_search(raft::resources const& res, raft::ivf_pq_params const& params, raft::ivf_pq_index const& index,
+raft::device_matrix_view<const value_t, idx_t, raft::row_major> queries,
+raft::device_matrix_view<idx_t, idx_t, raft::row_major> out_inds,
+raft::device_matrix_view<value_t, idx_t, raft::row_major> out_dists);
 }
 ```
 
@@ -126,8 +126,8 @@ raft::device_matrix<value_t, idx_t, raft::row_major> out_dists);
 These guidelines also mean that it is the responsibility of C++ API to expose methods to load and store (aka marshalling) such a data structure. Further continuing the IVF-PQ example,  the following methods could achieve this:
 ```cpp
 namespace raft::ivf_pq {
-   void save(raft::ivf_pq_index const& model, std::ostream &os);
-   void load(raft::ivf_pq_index& model, std::istream &is);
+   void save(raft::resources const& res, raft::ivf_pq_index const& model, std::ostream& os);
+   void load(raft::resources const& res, raft::ivf_pq_index& model, std::istream& is);
 }
 ```
 
@@ -230,7 +230,7 @@ Call CUDA APIs via the provided helper macros `RAFT_CUDA_TRY`, `RAFT_CUBLAS_TRY`
 ## Logging
 
 ### Introduction
-Anything and everything about logging is defined inside [logger.hpp](https://github.com/rapidsai/raft/blob/main/cpp/include/raft/core/logger.hpp). It uses [spdlog](https://github.com/gabime/spdlog) underneath, but this information is transparent to all.
+Anything and everything about logging is defined inside [logger.hpp](https://github.com/rapidsai/raft/blob/main/cpp/include/raft/core/logger.hpp). RAFT logging is built on top of [rapids-logger](https://github.com/rapidsai/rapids-logger) (which wraps [spdlog](https://github.com/gabime/spdlog) underneath), but this information is transparent to all. The global logger is obtained via `raft::default_logger()`.
 
 ### Usage
 ```cpp
@@ -279,8 +279,8 @@ Sometimes, we need to temporarily change the log pattern (eg: for reporting deci
 ```
 
 ### Tips
-* Do NOT end your logging messages with a newline! It is automatically added by spdlog.
-* The `RAFT_LOG_TRACE()` is by default not compiled due to the `RAFT_ACTIVE_LEVEL` macro setup, for performance reasons. If you need it to be enabled, change this macro accordingly during compilation time
+* Do NOT end your logging messages with a newline! It is automatically added by the logger.
+* The `RAFT_LOG_TRACE()` is by default not compiled due to the `RAFT_LOG_ACTIVE_LEVEL` macro setup, for performance reasons. If you need it to be enabled, change this macro accordingly during compilation time
 
 ## Common Design Considerations
 
@@ -291,6 +291,29 @@ Sometimes, we need to temporarily change the log pattern (eg: for reporting deci
 3. Documentation for public APIs should be well documented, easy to use, and it is highly preferred that they include usage instructions.
 
 4. Before creating a new primitive, check to see if one exists already. If one exists but the API isn't flexible enough to include your use-case, consider first refactoring the existing primitive. If that is not possible without an extreme number of changes, consider how the public API could be made more flexible. If the new primitive is different enough from all existing primitives, consider whether an existing public API could invoke the new primitive as an option or argument. If the new primitive is different enough from what exists already, add a header for the new public API function to the appropriate subdirectory and namespace.
+
+## Preferred APIs and idioms
+
+When writing new code, re-using functionality, or reviewing changes, prefer:
+
+1. **`raft::resources` over raw handles/streams.** Prefer function overloads that
+   take `const raft::resources&` over overloads that take a raw `cudaStream_t` and/or
+   library handles (cuBLAS, cuSOLVER, etc.). See [Resource Management](#resource-management)
+   and [Asynchronous operations and stream ordering](#asynchronous-operations-and-stream-ordering).
+
+2. **Public API over `detail`.** When re-using functionality or writing tests, call the
+   public API rather than functions in the `detail` namespace, unless you are implementing
+   that public API. Public APIs are thin wrappers over `detail` (see
+   [General guidelines](#general-guidelines)), so tests stay aligned with what users get.
+
+3. **mdarray over raw containers.** Allocate owning data with `raft` mdarray types
+   (`raft::device_mdarray`, `raft::host_mdarray`, etc.) instead of `rmm::device_uvector`
+   or `std::vector` when representing device/multi-dimensional data, and pass views
+   (`raft::mdspan`) across APIs.
+
+4. **Avoid deprecated functions.** Use any reasonable non-deprecated substitute over a
+   deprecated function; when adding a replacement, deprecate the old one per
+   [API stability](#api-stability).
 
 ## Header organization of expensive function templates
 
@@ -402,32 +425,40 @@ All RAFT algorithms should be as asynchronous as possible avoiding the use of th
 
 void foo(const raft::resources& res, ...)
 {
-    cudaStream_t stream = get_cuda_stream(res);
+    auto stream = get_cuda_stream(res);  // rmm::cuda_stream_view
 }
 ```
-When multiple streams are needed, e.g. to manage a pipeline, use the internal streams available in `raft::resources` (see [CUDA Resources](#cuda-resources)). If multiple streams are used all operations still must be ordered according to `raft::resource::get_cuda_stream()` (from `raft/core/resource/cuda_stream.hpp`). Before any operation in any of the internal CUDA streams is started, all previous work in `raft::resource::get_cuda_stream()` must have completed. Any work enqueued in `raft::resource::get_cuda_stream()` after a RAFT function returns should not start before all work enqueued in the internal streams has completed. E.g. if a RAFT algorithm is called like this:
+When multiple streams are needed, e.g. to manage a pipeline, use the internal streams available in `raft::resources` (see [Resource Management](#resource-management)). If multiple streams are used all operations still must be ordered according to `raft::resource::get_cuda_stream()` (from `raft/core/resource/cuda_stream.hpp`). Before any operation in any of the internal CUDA streams is started, all previous work in `raft::resource::get_cuda_stream()` must have completed. Any work enqueued in `raft::resource::get_cuda_stream()` after a RAFT function returns should not start before all work enqueued in the internal streams has completed. E.g. if a RAFT algorithm is called like this:
 ```cpp
+#include <raft/core/copy.hpp>           // raft::copy
+#include <raft/core/device_mdspan.hpp>
+#include <raft/core/host_mdspan.hpp>
 #include <raft/core/resources.hpp>
 #include <raft/core/resource/cuda_stream.hpp>
-void foo(const double* srcdata, double* result)
+
+#include <rmm/cuda_stream.hpp>
+
+void foo(raft::device_vector_view<double> srcdata,
+         raft::device_vector_view<double> result,
+         raft::host_vector_view<const double> h_srcdata,
+         raft::host_vector_view<double> h_result)
 {
-    cudaStream_t stream;
-    CUDA_RT_CALL( cudaStreamCreate( &stream ) );
+    rmm::cuda_stream stream;  // owns the stream; destroyed automatically
     raft::resources res;
-    set_cuda_stream(res, stream);
+    set_cuda_stream(res, stream.view());
 
     ...
 
-    RAFT_CUDA_TRY( cudaMemcpyAsync( srcdata, h_srcdata.data(), n*sizeof(double), cudaMemcpyHostToDevice, stream ) );
+    raft::copy(res, srcdata, h_srcdata );  // host -> device, ordered on res's stream
 
-    raft::algo(raft::resources, dopredict, srcdata, result, ... );
+    raft::algo(res, dopredict, srcdata, result, ... );
 
-    RAFT_CUDA_TRY( cudaMemcpyAsync( h_result.data(), result, m*sizeof(int), cudaMemcpyDeviceToHost, stream ) );
+    raft::copy(res, h_result, result );    // device -> host, ordered on res's stream
 
     ...
 }
 ```
-No work in any stream should start in `raft::algo` before the `cudaMemcpyAsync` in `stream` launched before the call to `raft::algo` is done. And all work in all streams used in `raft::algo` should be done before the `cudaMemcpyAsync` in `stream` launched after the call to `raft::algo` starts.
+No work in any stream should start in `raft::algo` before the `raft::copy` in `stream` launched before the call to `raft::algo` is done. And all work in all streams used in `raft::algo` should be done before the `raft::copy` in `stream` launched after the call to `raft::algo` starts.
 
 This can be ensured by introducing interstream dependencies with CUDA events and `cudaStreamWaitEvent`. For convenience, the header `raft/core/device_resources.hpp` provides the class `raft::stream_syncer` which lets all `raft::resources` internal CUDA streams wait on `raft::resource::get_cuda_stream()` in its constructor and in its destructor and lets `raft::resource::get_cuda_stream()` wait on all work enqueued in the `raft::resources` internal CUDA streams. The intended use would be to create a `raft::stream_syncer` object as the first thing in an entry function of the public RAFT API:
 
@@ -435,7 +466,7 @@ This can be ensured by introducing interstream dependencies with CUDA events and
 namespace raft {
    void algo(const raft::resources& res, ...)
    {
-       raft::streamSyncer _(res);
+       raft::stream_syncer _(res);
    }
 }
 ```
@@ -461,12 +492,12 @@ The resources can be obtained like this
 #include <raft/core/resources.hpp>
 #include <raft/core/resource/cublas_handle.hpp>
 #include <raft/core/resource/cuda_stream_pool.hpp>
-void foo(const raft::resources& h, ...)
+void foo(const raft::resources& res, ...)
 {
-    cublasHandle_t cublasHandle = get_cublas_handle(h);
-    const int num_streams       = get_stream_pool_size(h);
+    cublasHandle_t cublasHandle = get_cublas_handle(res);
+    const int num_streams       = get_stream_pool_size(res);
     const int stream_idx        = ...
-    cudaStream_t stream         = get_stream_from_stream_pool(stream_idx);
+    auto stream                 = get_stream_from_stream_pool(res, stream_idx);  // rmm::cuda_stream_view
     ...
 }
 ```
@@ -488,7 +519,7 @@ int main(int argc, char** argv)
 
 ## Multi-GPU
 
-The multi-GPU paradigm of RAFT is **O**ne **P**rocess per **G**PU (OPG). Each algorithm should be implemented in a way that it can run with a single GPU without any specific dependencies to a particular communication library. A multi-GPU implementation should use the methods offered by the class `raft::comms::comms_t` from [raft/core/comms.hpp] for inter-rank/GPU communication. It is the responsibility of the user of cuML to create an initialized instance of `raft::comms::comms_t`.
+The multi-GPU paradigm of RAFT is **O**ne **P**rocess per **G**PU (OPG). Each algorithm should be implemented in a way that it can run with a single GPU without any specific dependencies to a particular communication library. A multi-GPU implementation should use the methods offered by the class `raft::comms::comms_t` from `raft/core/comms.hpp` for inter-rank/GPU communication. It is the responsibility of the user of RAFT to create an initialized instance of `raft::comms::comms_t`.
 
 E.g. with a CUDA-aware MPI, a RAFT user could use code like this to inject an initialized instance of `raft::comms::mpi_comms` into a `raft::resources`:
 

--- a/python/REVIEW_GUIDELINES.md
+++ b/python/REVIEW_GUIDELINES.md
@@ -1,0 +1,184 @@
+# AI Code Review Guidelines - RAFT Python
+
+**Role**: Act as a principal engineer with 10+ years experience in Python systems programming and GPU memory management. Focus ONLY on CRITICAL and HIGH issues.
+
+**Target**: Sub-3% false positive rate. Be direct, concise, minimal.
+
+**Context**: The RAFT Python layer (pylibraft and raft-dask) provides pythonic interfaces and handle/resource management for RAFT primitives on the GPU. For formatting and pre-commit setup, see the pre-commit section of `docs/source/contributing.md`.
+
+## IGNORE These Issues
+
+- Style/formatting (pre-commit hooks handle this)
+- Minor naming preferences (unless truly misleading)
+- Personal taste on implementation (unless impacts maintainability)
+- Nits that don't affect functionality
+- Already-covered issues (one comment per root cause)
+
+## CRITICAL Issues (Always Comment)
+
+### Memory Safety
+- Memory leaks from improper resource management
+- Use-after-free scenarios in device memory handling
+- Incorrect lifetime management of memory resources
+- **Cython memory management errors** (missing `del`, incorrect reference counting)
+
+### API Breaking Changes
+- Python API changes breaking backward compatibility
+- Changes to public interfaces
+- Removing or renaming public methods/attributes without deprecation
+- We usually require at least one release cycle for deprecations
+
+### Integration Errors
+- Incorrect handling of CuPy/Numba/PyTorch array interfaces
+- Silent data corruption from type coercion
+- Missing validation causing crashes on invalid input
+- **Incorrect CUDA stream handling in Python bindings**
+
+### Resource Management
+- GPU memory leaks from Python objects
+- Missing cleanup in `__del__` or context managers
+- Circular references preventing garbage collection
+- **Incorrect ownership semantics** between Python and C layer
+
+## HIGH Issues (Comment if Substantial)
+
+### Memory Resource Management
+- Incorrect memory resource lifecycle
+- Missing validation of memory resource parameters
+- Improper upstream resource handling in Python
+
+### Input Validation
+- Missing size/type checks
+- Not handling edge cases
+
+### Test Quality
+- Missing edge case coverage (zero-size, alignment)
+- **Using external datasets** (tests must not depend on external resources)
+- Missing tests for different array types (CuPy, Numba)
+- **Using test classes instead of standalone functions** (RAFT prefers `test_foo_bar()` functions over `class TestFoo`)
+
+### Documentation
+- Missing or incorrect docstrings for public methods
+- Parameters not documented
+- Missing usage examples for memory resources
+- **New public API not added to docs**
+
+## MEDIUM Issues (Comment Selectively)
+
+- Edge cases not handled
+- Missing input validation for edge cases
+- Deprecated API usage
+- Minor inefficiencies in non-critical code paths
+
+## Review Protocol
+
+1. **Memory safety**: Resource cleanup correct? Lifetime management?
+2. **API stability**: Breaking changes to Python APIs?
+3. **Integration**: CuPy/Numba compatibility maintained?
+4. **Input validation**: Size/type checks present?
+5. **Documentation**: Public API documented?
+6. **Ask, don't tell**: "Have you considered X?" not "You should do X"
+
+## Quality Threshold
+
+Before commenting, ask:
+1. Is this actually wrong/risky, or just different?
+2. Would this cause a real problem (crash, leak, API break)?
+3. Does this comment add unique value?
+
+**If no to any: Skip the comment.**
+
+## Output Format
+
+- Use severity labels: CRITICAL, HIGH, MEDIUM
+- Be concise: One-line issue summary + one-line impact
+- Provide code suggestions when you have concrete fixes
+- No preamble or sign-off
+
+## Python-Specific Considerations
+
+**Memory Resource Lifecycle**:
+- Memory resources should use context managers where appropriate
+- Ensure proper cleanup in `__del__` methods
+- Document ownership semantics clearly
+
+**Cython Bindings**:
+- Use proper memory management (`__dealloc__`)
+- Handle exceptions correctly across Python/C++ boundary
+- Ensure GIL handling is correct for CUDA operations
+
+**Array Interfaces**:
+- Support `__cuda_array_interface__` for interoperability with CuPy and pytorch
+- Handle different array types (CuPy, Numba DeviceNDArray)
+- Preserve array attributes where appropriate
+
+**Error Messages**:
+- Error messages must be clear and actionable for users
+- Include expected vs actual values where helpful
+
+**Testing**:
+- Test different array types
+- Use standalone `test_foo_bar()` functions, not test classes
+- Use synthetic data, never external resources
+
+---
+
+## Common Bug Patterns
+
+### 1. Resource Cleanup Issues
+**Pattern**: GPU memory not properly released
+
+**Red flags**:
+- Missing `__del__` or `__dealloc__` methods
+- Cleanup not happening on exception paths
+- Circular references preventing garbage collection
+
+### 2. Array Interface Errors
+**Pattern**: Incorrect `__cuda_array_interface__` implementation
+
+**Red flags**:
+- Wrong shape/strides in interface dict
+- Missing required keys
+- Incorrect data pointer
+
+### 3. Lifetime Management
+**Pattern**: Python object outliving underlying C++ resource
+
+**Red flags**:
+- Weak references to memory resources
+- Callbacks holding stale references
+- Missing ref-counting in Cython
+
+### 4. Stream Handling
+**Pattern**: Incorrect stream semantics in Python bindings
+
+**Red flags**:
+- Missing stream parameter propagation
+- Incorrect stream synchronization
+- Default stream used when explicit stream expected
+
+---
+
+## Code Review Checklists
+
+### When Reviewing Memory Resource Classes
+- [ ] Is cleanup implemented in `__del__` or context manager?
+- [ ] Is ownership clearly documented?
+- [ ] Are edge cases handled (zero-size)?
+- [ ] Is the API consistent with existing RAFT patterns?
+
+### When Reviewing Cython Code
+- [ ] Is `__dealloc__` implemented correctly?
+- [ ] Are exceptions handled across the Python/C++ boundary?
+- [ ] Is GIL handling correct?
+- [ ] Is memory management correct (no leaks, no double-free)?
+- [ ] Are errors from C/C++ calls checked and surfaced as Python exceptions?
+
+### When Reviewing Tests
+- [ ] Are different array types tested?
+- [ ] Are tests written as standalone functions?
+
+---
+
+**Remember**: Focus on correctness and API compatibility. Catch real bugs (leaks, crashes, API
+breaks), ignore style preferences. For RAFT Python: memory safety and proper resource lifecycle are paramount.


### PR DESCRIPTION
Following on the work of https://github.com/rapidsai/rmm/pull/2244, https://github.com/rapidsai/cuml/pull/7725, and https://github.com/rapidsai/cuvs/pull/1908 this enables general instructions and configuration to enable coderabbit codereviews on raft.

Also updates the `developer_guide.md` to be more in-sync with the current state of raft, so that the reviewer bot can refer to this guideline file.
