### PR TITLE
Update CODEOWNERS team names for rapidsai->NVIDIA migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,30 +1,30 @@
 #cpp code owners
-cpp/               @rapidsai/raft-cpp-codeowners
+cpp/               @NVIDIA/raft-cpp-codeowners
 
 #python code owners
-python/            @rapidsai/raft-python-codeowners
+python/            @NVIDIA/raft-python-codeowners
 
 #cmake code owners
-CMakeLists.txt     @rapidsai/raft-cmake-codeowners
-**/cmake/          @rapidsai/raft-cmake-codeowners
-*.cmake            @rapidsai/raft-cmake-codeowners
-python/setup.py    @rapidsai/raft-cmake-codeowners
-build.sh           @rapidsai/raft-cmake-codeowners
-**/build.sh        @rapidsai/raft-cmake-codeowners
+CMakeLists.txt     @NVIDIA/raft-cmake-codeowners
+**/cmake/          @NVIDIA/raft-cmake-codeowners
+*.cmake            @NVIDIA/raft-cmake-codeowners
+python/setup.py    @NVIDIA/raft-cmake-codeowners
+build.sh           @NVIDIA/raft-cmake-codeowners
+**/build.sh        @NVIDIA/raft-cmake-codeowners
 
 #CI code owners
-/.github/                @rapidsai/ci-codeowners
-/ci/                     @rapidsai/ci-codeowners
-/.shellcheckrc           @rapidsai/ci-codeowners
-/.coderabbit.yaml        @rapidsai/ci-codeowners
+/.github/                @NVIDIA/adi-ci-codeowners
+/ci/                     @NVIDIA/adi-ci-codeowners
+/.shellcheckrc           @NVIDIA/adi-ci-codeowners
+/.coderabbit.yaml        @NVIDIA/adi-ci-codeowners
 
 #packaging code owners
-/.pre-commit-config.yaml @rapidsai/packaging-codeowners
-/.devcontainer/          @rapidsai/packaging-codeowners
-/conda/                  @rapidsai/packaging-codeowners
-dependencies.yaml        @rapidsai/packaging-codeowners
-/build.sh                @rapidsai/packaging-codeowners
-pyproject.toml           @rapidsai/packaging-codeowners
+/.pre-commit-config.yaml @NVIDIA/adi-packaging-codeowners
+/.devcontainer/          @NVIDIA/adi-packaging-codeowners
+/conda/                  @NVIDIA/adi-packaging-codeowners
+dependencies.yaml        @NVIDIA/adi-packaging-codeowners
+/build.sh                @NVIDIA/adi-packaging-codeowners
+pyproject.toml           @NVIDIA/adi-packaging-codeowners
 
 # Ops code owners
-/SECURITY.md             @rapidsai/ops-codeowners
+/SECURITY.md             @NVIDIA/adi-ops-codeowners

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,7 +145,7 @@ repos:
               )
           - id: verify-alpha-spec
           - id: verify-codeowners
-            args: [--fix, --project-prefix=raft]
+            args: [--fix, --org=NVIDIA, --project-prefix=raft]
           - id: verify-hardcoded-version
             exclude: |
               (?x)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -144,8 +144,9 @@ repos:
                 cpp/include/raft/core/detail/mdspan_numpy_serializer[.]hpp$
               )
           - id: verify-alpha-spec
-          - id: verify-codeowners
-            args: [--fix, --org=NVIDIA, --project-prefix=raft]
+          # TODO: Re-enable once verify-codeowners supports --org parameter
+          # - id: verify-codeowners
+          #   args: [--fix, --org=NVIDIA, --project-prefix=raft]
           - id: verify-hardcoded-version
             exclude: |
               (?x)


### PR DESCRIPTION
XREF: https://github.com/rapidsai/build-infra/issues/372

CODEOWNER teams must be in the same org as the repo. Let's update them now that we've migrated to the NVIDIA org.

This is blocked on the next release of https://github.com/rapidsai/pre-commit-hooks