### PR TITLE
Bump rapidsai/pre-commit-hooks to v1.6.0, re-enable verify-codeowners

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
                   (?x)
                     ^CHANGELOG[.]md$|
       - repo: https://github.com/rapidsai/pre-commit-hooks
-        rev: v1.4.2
+        rev: v1.6.0
         hooks:
           - id: verify-copyright
             name: verify-copyright-raft
@@ -144,9 +144,8 @@ repos:
                 cpp/include/raft/core/detail/mdspan_numpy_serializer[.]hpp$
               )
           - id: verify-alpha-spec
-          # TODO: Re-enable once verify-codeowners supports --org parameter
-          # - id: verify-codeowners
-          #   args: [--fix, --org=NVIDIA, --project-prefix=raft]
+          - id: verify-codeowners
+            args: [--fix, --org=NVIDIA, --project-prefix=raft]
           - id: verify-hardcoded-version
             exclude: |
               (?x)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
@@ -171,7 +171,7 @@ repos:
                 ^conda/environments/|
                 (^|/)UCXX_BRANCH$|
                 (^|/)RAPIDS_BRANCH$|
-                [.](md|rst)$
+                [.](md|rst|svg)$
           - id: verify-pyproject-license
             # ignore the top-level pyproject.toml, which doesn't
             # have or need a [project] table


### PR DESCRIPTION
https://github.com/rapidsai/pre-commit-hooks/releases/tag/v1.6.0 now supports parameterizing the repo org for its `verify-codeowners` check.

Let's bump the version and re-enable the check.

XREF: https://github.com/rapidsai/build-infra/issues/372