### PR TITLE
Revert "Temporarily increase `max_days_without_success`"

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,8 +68,6 @@ jobs:
         with:
           repo: ${{ github.repository }}
           target-branch: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
-          # Tracking Issue: https://github.com/rapidsai/raft/issues/3037
-          max-days-without-success: 30
   changed-files:
     needs: telemetry-setup
     permissions:


### PR DESCRIPTION
Reverts NVIDIA/raft#3038, since https://github.com/NVIDIA/raft/pull/3046 was merged.