### PR TITLE
fix(clang-format): update comment pragmas for copyright notice

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -56,7 +56,7 @@ BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
 ColumnLimit: 100
-CommentPragmas: '^ IWYU pragma:'
+CommentPragmas: '^ ?[*]? ?(IWYU pragma:|SPDX-)'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 # Kept the below 2 to be the same as `IndentWidth` to keep everything uniform


### PR DESCRIPTION
After adding `All rights reserved.` to the end of the SPDX Copyright Header, the line is now too long and so `clang-format` wraps it, which then breaks the `verify-copyright` pre-commit hook.

Adding `SPDX` to the list of `CommentPragmas` so `clang-format` ignores them
