### PR TITLE
Remove legacy RAPIDS docs theme assets

### DIFF
--- a/cpp/doxygen/header.html
+++ b/cpp/doxygen/header.html
@@ -17,10 +17,6 @@ $mathjax
 <link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
 $extrastylesheet
 
-<!-- RAPIDS CUSTOM JS & CSS: START, Please add these two lines back after every version upgrade -->
-<script defer src="https://docs.rapids.ai/assets/js/custom.js"></script>
-<link rel="stylesheet" href="https://docs.rapids.ai/assets/css/custom.css">
-<!-- RAPIDS CUSTOM JS & CSS: END -->
 
 </head>
 <body>

--- a/docs/source/_static/references.css
+++ b/docs/source/_static/references.css
@@ -1,15 +1,4 @@
 
-/* Constrain navbar logo size and add spacing */
-.navbar-brand.logo .logo__image {
-  height: 32px !important;
-  width: auto !important;
-  margin-right: 0.75rem;
-}
-
-.navbar-brand.logo {
-  padding: 0.5rem 0;
-}
-
 /* Fix references to not look like parameters */
 dl.citation > dt.label {
   display: unset !important;

--- a/docs/source/_templates/navbar-logo.html
+++ b/docs/source/_templates/navbar-logo.html
@@ -1,4 +1,0 @@
-<a class="navbar-brand logo" href="{{ pathto(root_doc) }}">
-  <img src="{{ logo_url }}" class="logo__image" alt="{{ docstitle }} - Home"/>
-  <p class="title logo__title">{{ docstitle }}</p>
-</a>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime
@@ -201,10 +201,6 @@ numpydoc_class_members_toctree = False
 
 def setup(app):
     app.add_css_file("references.css")
-    app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
-    app.add_js_file(
-        "https://docs.rapids.ai/assets/js/custom.js", loading_method="defer"
-    )
     app.add_js_file("collapse_overloads.js")
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,7 +105,6 @@ todo_include_todos = False
 #
 
 html_theme = "nvidia_sphinx_theme"
-html_favicon = "../../img/icon-512x512.png"
 
 
 # Theme options are theme-specific and customize the look and feel of a theme
@@ -114,10 +113,14 @@ html_favicon = "../../img/icon-512x512.png"
 #
 html_theme_options = {
     "external_links": [],
-    # https://github.com/pydata/pydata-sphinx-theme/issues/1220
-    "icon_links": [],
-    "github_url": "https://github.com/rapidsai/raft",
-    "twitter_url": "https://twitter.com/rapidsai",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/NVIDIA/raft",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+    ],
     "show_toc_level": 1,
     "navbar_align": "right",
 }
@@ -158,7 +161,7 @@ latex_documents = [
     (
         master_doc,
         "raft.tex",
-        "RAFT Documentation",
+        f"{project} Documentation",
         "NVIDIA Corporation",
         "manual",
     ),
@@ -168,7 +171,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "raft", "RAFT Documentation", [author], 1)]
+man_pages = [(master_doc, "raft", f"{project} Documentation", [author], 1)]
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -179,7 +182,7 @@ texinfo_documents = [
     (
         master_doc,
         "raft",
-        "RAFT Documentation",
+        f"{project} Documentation",
         author,
         "raft",
         "One line description of project.",
@@ -206,7 +209,7 @@ def setup(app):
 # The following is used by sphinx.ext.linkcode to provide links to github
 linkcode_resolve = make_linkcode_resolve(
     "pylibraft",
-    "https://github.com/rapidsai/raft"
+    "https://github.com/NVIDIA/raft"
     "/blob/{revision}/python/pylibraft/"
     "{package}/{path}#L{lineno}",
 )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,7 +105,6 @@ todo_include_todos = False
 #
 
 html_theme = "nvidia_sphinx_theme"
-html_logo = "../../img/logo-purple-bg-white-text.svg"
 html_favicon = "../../img/icon-512x512.png"
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
 master_doc = "index"
 
 # General information about the project.
-project = "RAFT"
+project = "NVIDIA RAFT"
 copyright = f"2023-{datetime.datetime.today().year}, NVIDIA Corporation"
 author = "NVIDIA Corporation"
 

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -23,7 +23,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/raft)
+1. Read the project's [README.md](https://github.com/NVIDIA/raft)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/RAFT/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/RAFT/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels

--- a/docs/source/developer_guide.md
+++ b/docs/source/developer_guide.md
@@ -187,7 +187,7 @@ RAFT relies on `clang-format` to enforce code style across all C++ and CUDA sour
 1. Do not split empty functions/records/namespaces.
 2. Two-space indentation everywhere, including the line continuations.
 3. Disable reflowing of comments.
-   The reasons behind these deviations from the Google style guide are given in comments [here](https://github.com/rapidsai/raft/blob/main/cpp/.clang-format).
+   The reasons behind these deviations from the Google style guide are given in comments [here](https://github.com/NVIDIA/raft/blob/main/cpp/.clang-format).
 
 [`doxygen`](https://doxygen.nl/) is used as documentation generator and also as a documentation linter.
 In order to run doxygen as a linter on C++/CUDA code, run
@@ -205,7 +205,7 @@ you can run  `codespell -i 3 -w .` from the repository root directory.
 This will bring up an interactive prompt to select which spelling fixes to apply.
 
 ### #include style
-[include_checker.py](https://github.com/rapidsai/raft/blob/main/cpp/scripts/include_checker.py) is used to enforce the include style as follows:
+[include_checker.py](https://github.com/NVIDIA/raft/blob/main/cpp/scripts/include_checker.py) is used to enforce the include style as follows:
 1. `#include "..."` should be used for referencing local files only. It is acceptable to be used for referencing files in a sub-folder/parent-folder of the same algorithm, but should never be used to include files in other algorithms or between algorithms and the primitives or other dependencies.
 2. `#include <...>` should be used for referencing everything else
 
@@ -230,7 +230,7 @@ Call CUDA APIs via the provided helper macros `RAFT_CUDA_TRY`, `RAFT_CUBLAS_TRY`
 ## Logging
 
 ### Introduction
-Anything and everything about logging is defined inside [logger.hpp](https://github.com/rapidsai/raft/blob/main/cpp/include/raft/core/logger.hpp). RAFT logging is built on top of [rapids-logger](https://github.com/rapidsai/rapids-logger) (which wraps [spdlog](https://github.com/gabime/spdlog) underneath), but this information is transparent to all. The global logger is obtained via `raft::default_logger()`.
+Anything and everything about logging is defined inside [logger.hpp](https://github.com/NVIDIA/raft/blob/main/cpp/include/raft/core/logger.hpp). RAFT logging is built on top of [rapids-logger](https://github.com/rapidsai/rapids-logger) (which wraps [spdlog](https://github.com/gabime/spdlog) underneath), but this information is transparent to all. The global logger is obtained via `raft::default_logger()`.
 
 ### Usage
 ```cpp
@@ -396,7 +396,7 @@ template void raft::expensive<float>(float);
 
 **Design considerations**:
 
-1. In the `-ext.cuh` header, do not include implementation headers. Only include function parameter types and types that are used to instantiate the templates. If a primitive takes custom parameter types, define them in a separate header called `<primitive_name>_types.hpp`. (see [Common Design Considerations](https://github.com/rapidsai/raft/blob/7b065aff81a0b1976e2a9e2f3de6690361a1111b/docs/source/developer_guide.md#common-design-considerations)).
+1. In the `-ext.cuh` header, do not include implementation headers. Only include function parameter types and types that are used to instantiate the templates. If a primitive takes custom parameter types, define them in a separate header called `<primitive_name>_types.hpp`. (see [Common Design Considerations](https://github.com/NVIDIA/raft/blob/7b065aff81a0b1976e2a9e2f3de6690361a1111b/docs/source/developer_guide.md#common-design-considerations)).
 
 2. Keep docstrings in the `-inl.cuh` header, as it is closer to the code. Remove docstrings from template definitions in the `-ext.cuh` header. Make sure to explicitly include public APIs in the RAFT API docs. That is, add `#include <raft/expensive.cuh>` to the docs in `docs/source/cpp_api/expensive.rst` (instead of `#include <raft/expensive-inl.cuh>`).
 
@@ -404,7 +404,7 @@ template void raft::expensive<float>(float);
 
 4. If a header file defines multiple expensive templates, it can be that one of them is not instantiated. In this case, **do define** the template with `RAFT_EXPLICIT` in the `-ext` header. This way, when the template is instantiated, the developer gets a helpful error message instead of a confusing "function not found".
 
-This header structure was proposed in [issue #1416](https://github.com/rapidsai/raft/issues/1416), which contains more background on the motivation of this structure and the mechanics of C++ template instantiation.
+This header structure was proposed in [issue #1416](https://github.com/NVIDIA/raft/issues/1416), which contains more background on the motivation of this structure and the mechanics of C++ template instantiation.
 
 ## Testing
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,8 +12,8 @@ Useful Resources
 .. _raft_reference: https://docs.rapids.ai/api/raft/stable/
 
 - `RAPIDS Community <https://rapids.ai/community.html>`_: Get help, contribute, and collaborate.
-- `GitHub repository <https://github.com/rapidsai/raft>`_: Download the RAFT source code.
-- `Issue tracker <https://github.com/rapidsai/raft/issues>`_: Report issues or request features.
+- `GitHub repository <https://github.com/NVIDIA/raft>`_: Download the RAFT source code.
+- `Issue tracker <https://github.com/NVIDIA/raft/issues>`_: Report issues or request features.
 
 
 What is NVIDIA RAFT?

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
-RAFT: Reusable Accelerated Functions and Tools
-================================================================================
+NVIDIA RAFT Documentation
+=========================
 
 .. image:: ../../img/raft-tech-stack.svg
   :width: 800
@@ -16,10 +16,10 @@ Useful Resources
 - `Issue tracker <https://github.com/rapidsai/raft/issues>`_: Report issues or request features.
 
 
-What is RAFT?
-#############
+What is NVIDIA RAFT?
+####################
 
-RAFT contains fundamental widely-used algorithms and primitives for machine learning and information retrieval. The algorithms are CUDA-accelerated and form building blocks for more easily writing high performance applications.
+NVIDIA RAFT contains fundamental widely-used algorithms and primitives for machine learning and information retrieval. The algorithms are CUDA-accelerated and form building blocks for more easily writing high performance applications.
 
 By taking a primitives-based approach to algorithm development, RAFT
 


### PR DESCRIPTION
## Description

Removes the legacy shared RAPIDS CSS/JavaScript injection from RAFT's Sphinx configuration and Doxygen header.

RAFT already uses `nvidia_sphinx_theme`; removing these legacy assets lets the NVIDIA theme provide the default left navigation and styling without the previous RAPIDS overrides.

Contributes to rapidsai/build-planning#300.

## Validation

- Commit-time pre-commit hooks passed.
- Doxygen completed and `sphinx-build -b dirhtml source _html` passed in the CUDA 13.3 devcontainer with published nightly Python packages.
- Rendered HTML loads the NVIDIA theme, uses the default full left navigation, and contains no legacy shared RAPIDS asset URLs.

