### PR TITLE
Re-enable Python code coverage

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -275,7 +275,6 @@ jobs:
     if: fromJSON(needs.changed-files.outputs.changed_file_groups).test_python_conda
     with:
       build_type: pull-request
-      run_codecov: false
       script: ci/test_python.sh
   docs-build:
     needs: [conda-python-build, changed-files]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,7 +68,6 @@ jobs:
       build_type: ${{ inputs.build_type }}
       branch: ${{ inputs.branch }}
       date: ${{ inputs.date }}
-      run_codecov: false
       script: ci/test_python.sh
       sha: ${{ inputs.sha }}
   wheel-tests-pylibraft:


### PR DESCRIPTION
Contributes to: https://github.com/rapidsai/build-infra/issues/372

We've finally found a `CODECOV_TOKEN` secret value and added it as a repo-scoped secret.

Let's turn code coverage back on for Python tests.