### PR TITLE
Make permute deterministic given a seed

### DIFF
--- a/cpp/include/raft/random/detail/make_regression.cuh
+++ b/cpp/include/raft/random/detail/make_regression.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -24,6 +24,7 @@
 #include <rmm/device_uvector.hpp>
 
 #include <algorithm>
+#include <random>
 
 namespace raft {
 namespace random {
@@ -240,8 +241,9 @@ void make_regression_caller(raft::resources const& handle,
   }
 
   if (shuffle) {
-    // creates shared generator. pulls 2 random numbers from
-    // internal sequence to generate a and b, remembers it gave out those numbers
+    // One generator shared by both shuffles below: each consumes distinct draws
+    // from its sequence, so the sample and feature permutations stay independent
+    // while remaining reproducible for a given seed.
     std::mt19937_64 gen(seed);
 
     rmm::device_uvector<DataT> tmp_out(n_rows * n_cols, stream);
@@ -251,14 +253,8 @@ void make_regression_caller(raft::resources const& handle,
     constexpr IdxT Nthreads = 256;
 
     // Shuffle the samples from out to tmp_out
-    raft::random::detail::permute<DataT, IdxT, IdxT>(perms_samples.data(),
-                                                     tmp_out.data(),
-                                                     out,
-                                                     n_cols,
-                                                     n_rows,
-                                                     true,
-                                                     stream,
-                                                     gen);  // now passes generator rather than seed
+    raft::random::detail::permute<DataT, IdxT, IdxT>(
+      perms_samples.data(), tmp_out.data(), out, n_cols, n_rows, true, stream, gen);
     IdxT nblks_rows = raft::ceildiv<IdxT>(n_rows, Nthreads);
     _gather2d_kernel<<<nblks_rows, Nthreads, 0, stream>>>(
       values, _values, perms_samples.data(), n_rows, n_targets);

--- a/cpp/include/raft/random/detail/make_regression.cuh
+++ b/cpp/include/raft/random/detail/make_regression.cuh
@@ -248,7 +248,7 @@ void make_regression_caller(raft::resources const& handle,
 
     // Shuffle the samples from out to tmp_out
     raft::random::permute<DataT, IdxT, IdxT>(
-      perms_samples.data(), tmp_out.data(), out, n_cols, n_rows, true, stream);
+      perms_samples.data(), tmp_out.data(), out, n_cols, n_rows, true, stream, seed);
     IdxT nblks_rows = raft::ceildiv<IdxT>(n_rows, Nthreads);
     _gather2d_kernel<<<nblks_rows, Nthreads, 0, stream>>>(
       values, _values, perms_samples.data(), n_rows, n_targets);
@@ -256,7 +256,14 @@ void make_regression_caller(raft::resources const& handle,
 
     // Shuffle the features from tmp_out to out
     raft::random::permute<DataT, IdxT, IdxT>(
-      perms_features.data(), out, tmp_out.data(), n_rows, n_cols, false, stream);
+      perms_features.data(),
+      out,
+      tmp_out.data(),
+      n_rows,
+      n_cols,
+      false,
+      stream,
+      seed + 1);  // different derived seed for feature shuffle keeps sample and feature independent
 
     // Shuffle the coefficients accordingly
     if (coef != nullptr) {

--- a/cpp/include/raft/random/detail/make_regression.cuh
+++ b/cpp/include/raft/random/detail/make_regression.cuh
@@ -240,6 +240,10 @@ void make_regression_caller(raft::resources const& handle,
   }
 
   if (shuffle) {
+    // creates shared generator. pulls 2 random numbers from
+    // internal sequence to generate a and b, remembers it gave out those numbers
+    std::mt19937_64 gen(seed);
+
     rmm::device_uvector<DataT> tmp_out(n_rows * n_cols, stream);
     rmm::device_uvector<IdxT> perms_samples(n_rows, stream);
     rmm::device_uvector<IdxT> perms_features(n_cols, stream);
@@ -247,23 +251,22 @@ void make_regression_caller(raft::resources const& handle,
     constexpr IdxT Nthreads = 256;
 
     // Shuffle the samples from out to tmp_out
-    raft::random::permute<DataT, IdxT, IdxT>(
-      perms_samples.data(), tmp_out.data(), out, n_cols, n_rows, true, stream, seed);
+    raft::random::detail::permute<DataT, IdxT, IdxT>(perms_samples.data(),
+                                                     tmp_out.data(),
+                                                     out,
+                                                     n_cols,
+                                                     n_rows,
+                                                     true,
+                                                     stream,
+                                                     gen);  // now passes generator rather than seed
     IdxT nblks_rows = raft::ceildiv<IdxT>(n_rows, Nthreads);
     _gather2d_kernel<<<nblks_rows, Nthreads, 0, stream>>>(
       values, _values, perms_samples.data(), n_rows, n_targets);
     RAFT_CUDA_TRY(cudaPeekAtLastError());
 
     // Shuffle the features from tmp_out to out
-    raft::random::permute<DataT, IdxT, IdxT>(
-      perms_features.data(),
-      out,
-      tmp_out.data(),
-      n_rows,
-      n_cols,
-      false,
-      stream,
-      seed + 1);  // different derived seed for feature shuffle keeps sample and feature independent
+    raft::random::detail::permute<DataT, IdxT, IdxT>(
+      perms_features.data(), out, tmp_out.data(), n_rows, n_cols, false, stream, gen);
 
     // Shuffle the coefficients accordingly
     if (coef != nullptr) {

--- a/cpp/include/raft/random/detail/permute.cuh
+++ b/cpp/include/raft/random/detail/permute.cuh
@@ -13,6 +13,7 @@
 #include <cooperative_groups.h>
 
 #include <memory>
+#include <random>
 
 namespace raft {
 namespace random {
@@ -120,15 +121,22 @@ void permute(IntType* perms,
              IntType D,
              IntType N,
              bool rowMajor,
-             cudaStream_t stream)
+             cudaStream_t stream,
+             uint64_t seed)
 {
   auto nblks = raft::ceildiv(N, (IntType)TPB);
 
-  // always keep 'a' to be coprime to N
-  IdxType a = rand() % N;
+  // gen seeded once, deterministically, from seed param
+  std::mt19937_64 gen(seed);
+  // maps gen's raw bit stream to a uniform integer
+  std::uniform_int_distribution<IdxType> dist(0, N - 1);
+
+  // a must be coprime to N, otherwise (a * tid) % N does not hit every row exactly once
+  IdxType a = dist(gen);
   while (raft::gcd(a, N) != 1)
     a = (a + 1) % N;
-  IdxType b = rand() % N;
+  // additive offset
+  IdxType b = dist(gen);
 
   if (rowMajor) {
     permute_impl_t<Type,

--- a/cpp/include/raft/random/detail/permute.cuh
+++ b/cpp/include/raft/random/detail/permute.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -122,7 +122,7 @@ void permute(IntType* perms,
              IntType N,
              bool rowMajor,
              cudaStream_t stream,
-             std::mt19937_64& gen)  // switched from uint64_t seed
+             std::mt19937_64& gen)
 {
   auto nblks = raft::ceildiv(N, (IntType)TPB);
 

--- a/cpp/include/raft/random/detail/permute.cuh
+++ b/cpp/include/raft/random/detail/permute.cuh
@@ -122,12 +122,10 @@ void permute(IntType* perms,
              IntType N,
              bool rowMajor,
              cudaStream_t stream,
-             uint64_t seed)
+             std::mt19937_64& gen)  // switched from uint64_t seed
 {
   auto nblks = raft::ceildiv(N, (IntType)TPB);
 
-  // gen seeded once, deterministically, from seed param
-  std::mt19937_64 gen(seed);
   // maps gen's raw bit stream to a uniform integer
   std::uniform_int_distribution<IdxType> dist(0, N - 1);
 

--- a/cpp/include/raft/random/permute.cuh
+++ b/cpp/include/raft/random/permute.cuh
@@ -16,6 +16,7 @@
 #include <raft/core/resources.hpp>
 
 #include <optional>
+#include <random>
 #include <type_traits>
 
 namespace raft {
@@ -91,7 +92,7 @@ void permute(raft::resources const& handle,
              raft::device_matrix_view<const InputOutputValueType, IdxType, Layout> in,
              std::optional<raft::device_vector_view<IntType, IdxType>> permsOut,
              std::optional<raft::device_matrix_view<InputOutputValueType, IdxType, Layout>> out,
-             uint64_t seed = 0ULL)
+             std::optional<uint64_t> seed = std::nullopt)
 {
   static_assert(std::is_integral_v<IntType>,
                 "permute: The type of each element "
@@ -121,14 +122,17 @@ void permute(raft::resources const& handle,
   if (permsOut_ptr != nullptr || out_ptr != nullptr) {
     const IdxType N = in.extent(0);
     const IdxType D = in.extent(1);
-    detail::permute<InputOutputValueType, IntType, IdxType>(permsOut_ptr,
-                                                            out_ptr,
-                                                            in.data_handle(),
-                                                            D,
-                                                            N,
-                                                            is_row_major,
-                                                            resource::get_cuda_stream(handle),
-                                                            seed);
+    std::mt19937_64 gen(seed.has_value() ? *seed
+                                         : rand());  // use the given seed, else a random one
+    detail::permute<InputOutputValueType, IntType, IdxType>(
+      permsOut_ptr,
+      out_ptr,
+      in.data_handle(),
+      D,
+      N,
+      is_row_major,
+      resource::get_cuda_stream(handle),
+      gen);  // switched from seed for deterministic swap
   }
 }
 
@@ -193,9 +197,11 @@ void permute(IntType* perms,
              IntType N,
              bool rowMajor,
              cudaStream_t stream,
-             uint64_t seed = 0ULL)  // default seed
+             std::optional<uint64_t> seed = std::nullopt)
 {
-  detail::permute<Type, IntType, IdxType, TPB>(perms, out, in, D, N, rowMajor, stream, seed);
+  std::mt19937_64 gen(seed.has_value() ? *seed : rand());
+  // generator build and passed
+  detail::permute<Type, IntType, IdxType, TPB>(perms, out, in, D, N, rowMajor, stream, gen);
 }
 
 };  // namespace random

--- a/cpp/include/raft/random/permute.cuh
+++ b/cpp/include/raft/random/permute.cuh
@@ -90,7 +90,8 @@ template <typename InputOutputValueType, typename IntType, typename IdxType, typ
 void permute(raft::resources const& handle,
              raft::device_matrix_view<const InputOutputValueType, IdxType, Layout> in,
              std::optional<raft::device_vector_view<IntType, IdxType>> permsOut,
-             std::optional<raft::device_matrix_view<InputOutputValueType, IdxType, Layout>> out)
+             std::optional<raft::device_matrix_view<InputOutputValueType, IdxType, Layout>> out,
+             uint64_t seed = 0ULL)
 {
   static_assert(std::is_integral_v<IntType>,
                 "permute: The type of each element "
@@ -126,7 +127,8 @@ void permute(raft::resources const& handle,
                                                             D,
                                                             N,
                                                             is_row_major,
-                                                            resource::get_cuda_stream(handle));
+                                                            resource::get_cuda_stream(handle),
+                                                            seed);
   }
 }
 
@@ -190,9 +192,10 @@ void permute(IntType* perms,
              IntType D,
              IntType N,
              bool rowMajor,
-             cudaStream_t stream)
+             cudaStream_t stream,
+             uint64_t seed = 0ULL)  // default seed
 {
-  detail::permute<Type, IntType, IdxType, TPB>(perms, out, in, D, N, rowMajor, stream);
+  detail::permute<Type, IntType, IdxType, TPB>(perms, out, in, D, N, rowMajor, stream, seed);
 }
 
 };  // namespace random

--- a/cpp/include/raft/random/permute.cuh
+++ b/cpp/include/raft/random/permute.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,6 +23,12 @@ namespace raft {
 namespace random {
 
 namespace permute_impl {
+
+inline std::mt19937_64 make_permute_generator(std::optional<uint64_t> seed)
+{
+  // use the given seed, else a random one
+  return std::mt19937_64(seed.has_value() ? *seed : std::random_device{}());
+}
 
 template <typename T, typename InputOutputValueType, typename IdxType, typename Layout>
 struct perms_out_view {};
@@ -76,8 +82,8 @@ using perms_out_view_t = typename perms_out_view<T, InputOutputValueType, IdxTyp
  *   permuted rows of the input matrix `in`.  (Not providing this
  *   is only useful if you provide `permsOut`.)
  * @param[in] seed If provided, seeds the permutation so that it is
- *   reproducible; if not provided, falls back to a non-deterministic
- *   `rand()`-derived seed (matching this function's legacy behavior).
+ *   reproducible; if not provided, falls back to a non-deterministic,
+ *   thread-safe `std::random_device`-derived seed.
  *
  * @pre If `permsOut.has_value()` is `true`,
  *   then `(*permsOut).extent(0) == in.extent(0)` is `true`.
@@ -123,19 +129,17 @@ void permute(raft::resources const& handle,
   InputOutputValueType* out_ptr = out_has_value ? (*out).data_handle() : nullptr;
 
   if (permsOut_ptr != nullptr || out_ptr != nullptr) {
-    const IdxType N = in.extent(0);
-    const IdxType D = in.extent(1);
-    std::mt19937_64 gen(seed.has_value() ? *seed
-                                         : rand());  // use the given seed, else a random one
-    detail::permute<InputOutputValueType, IntType, IdxType>(
-      permsOut_ptr,
-      out_ptr,
-      in.data_handle(),
-      D,
-      N,
-      is_row_major,
-      resource::get_cuda_stream(handle),
-      gen);  // switched from seed for deterministic swap
+    const IdxType N     = in.extent(0);
+    const IdxType D     = in.extent(1);
+    std::mt19937_64 gen = permute_impl::make_permute_generator(seed);
+    detail::permute<InputOutputValueType, IntType, IdxType>(permsOut_ptr,
+                                                            out_ptr,
+                                                            in.data_handle(),
+                                                            D,
+                                                            N,
+                                                            is_row_major,
+                                                            resource::get_cuda_stream(handle),
+                                                            gen);
   }
 }
 
@@ -144,8 +148,8 @@ void permute(raft::resources const& handle,
  *   for either or both of `permsOut` and `out`.
  *
  * @param[in] seed If provided, seeds the permutation so that it is
- *   reproducible; if not provided, falls back to a non-deterministic
- *   `rand()`-derived seed (matching this function's legacy behavior).
+ *   reproducible; if not provided, falls back to a non-deterministic,
+ *   thread-safe `std::random_device`-derived seed.
  */
 template <typename InputOutputValueType,
           typename IdxType,
@@ -197,8 +201,8 @@ void permute(raft::resources const& handle,
  *   false if they are column major
  * @param[in] stream CUDA stream on which to run
  * @param[in] seed If provided, seeds the permutation so that it is
- *   reproducible; if not provided, falls back to a non-deterministic
- *   `rand()`-derived seed (matching this function's legacy behavior).
+ *   reproducible; if not provided, falls back to a non-deterministic,
+ *   thread-safe `std::random_device`-derived seed.
  */
 template <typename Type, typename IntType = int, typename IdxType = int, int TPB = 256>
 void permute(IntType* perms,
@@ -210,8 +214,7 @@ void permute(IntType* perms,
              cudaStream_t stream,
              std::optional<uint64_t> seed = std::nullopt)
 {
-  std::mt19937_64 gen(seed.has_value() ? *seed : rand());
-  // generator build and passed
+  std::mt19937_64 gen = permute_impl::make_permute_generator(seed);
   detail::permute<Type, IntType, IdxType, TPB>(perms, out, in, D, N, rowMajor, stream, gen);
 }
 

--- a/cpp/include/raft/random/permute.cuh
+++ b/cpp/include/raft/random/permute.cuh
@@ -75,6 +75,9 @@ using perms_out_view_t = typename perms_out_view<T, InputOutputValueType, IdxTyp
  * @param[out] out If provided, the output matrix, containing the
  *   permuted rows of the input matrix `in`.  (Not providing this
  *   is only useful if you provide `permsOut`.)
+ * @param[in] seed If provided, seeds the permutation so that it is
+ *   reproducible; if not provided, falls back to a non-deterministic
+ *   `rand()`-derived seed (matching this function's legacy behavior).
  *
  * @pre If `permsOut.has_value()` is `true`,
  *   then `(*permsOut).extent(0) == in.extent(0)` is `true`.
@@ -139,6 +142,10 @@ void permute(raft::resources const& handle,
 /**
  * @brief Overload of `permute` that compiles if users pass in `std::nullopt`
  *   for either or both of `permsOut` and `out`.
+ *
+ * @param[in] seed If provided, seeds the permutation so that it is
+ *   reproducible; if not provided, falls back to a non-deterministic
+ *   `rand()`-derived seed (matching this function's legacy behavior).
  */
 template <typename InputOutputValueType,
           typename IdxType,
@@ -148,7 +155,8 @@ template <typename InputOutputValueType,
 void permute(raft::resources const& handle,
              raft::device_matrix_view<const InputOutputValueType, IdxType, Layout> in,
              PermsOutType&& permsOut,
-             OutType&& out)
+             OutType&& out,
+             std::optional<uint64_t> seed = std::nullopt)
 {
   // If PermsOutType is std::optional<device_vector_view<T, IdxType>>
   // for some T, then that type T need not be related to any of the
@@ -165,7 +173,7 @@ void permute(raft::resources const& handle,
 
   std::optional<perms_out_view_type> permsOut_arg = std::forward<PermsOutType>(permsOut);
   std::optional<out_view_type> out_arg            = std::forward<OutType>(out);
-  permute(handle, in, permsOut_arg, out_arg);
+  permute(handle, in, permsOut_arg, out_arg, seed);
 }
 
 /** @} */
@@ -188,6 +196,9 @@ void permute(raft::resources const& handle,
  * @param[in] rowMajor true if the matrices are row major,
  *   false if they are column major
  * @param[in] stream CUDA stream on which to run
+ * @param[in] seed If provided, seeds the permutation so that it is
+ *   reproducible; if not provided, falls back to a non-deterministic
+ *   `rand()`-derived seed (matching this function's legacy behavior).
  */
 template <typename Type, typename IntType = int, typename IdxType = int, int TPB = 256>
 void permute(IntType* perms,

--- a/cpp/tests/random/permute.cu
+++ b/cpp/tests/random/permute.cu
@@ -344,6 +344,9 @@ INSTANTIATE_TEST_CASE_P(PermMdspanTests, PermMdspanTestD, ::testing::ValuesIn(in
 // seed must yield identical permutation indices across calls.
 template <typename T>
 class PermSeedTest : public ::testing::TestWithParam<PermInputs<T>> {
+ public:
+  using test_data_type = T;
+
  protected:
   PermSeedTest()
     : in(0, resource::get_cuda_stream(handle)),
@@ -385,8 +388,9 @@ class PermSeedTest : public ::testing::TestWithParam<PermInputs<T>> {
 using PermSeedTestF = PermSeedTest<float>;
 TEST_P(PermSeedTestF, SameSeedIsDeterministic)
 {
-  auto stream = resource::get_cuda_stream(handle);
-  int N       = params.N;
+  using test_data_type = PermSeedTestF::test_data_type;
+  auto stream          = resource::get_cuda_stream(handle);
+  int N                = params.N;
   std::vector<int> h1(N), h2(N);
   raft::update_host(h1.data(), perms1.data(), N, stream);
   raft::update_host(h2.data(), perms2.data(), N, stream);
@@ -398,7 +402,7 @@ TEST_P(PermSeedTestF, SameSeedIsDeterministic)
   // collision is astronomically unlikely.
   if (N >= 1024) {
     rmm::device_uvector<int> perms3(N, stream);
-    permute<float, int, int>(
+    permute<test_data_type, int, int>(
       perms3.data(), out.data(), in.data(), params.D, N, params.rowMajor, stream, params.seed + 1);
     resource::sync_stream(handle);
     std::vector<int> h3(N);

--- a/cpp/tests/random/permute.cu
+++ b/cpp/tests/random/permute.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2024, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -337,6 +337,77 @@ TEST_P(PermMdspanTestD, Result)
   _PERMTEST_BODY(test_data_type);
 }
 INSTANTIATE_TEST_CASE_P(PermMdspanTests, PermMdspanTestD, ::testing::ValuesIn(inputsd));
+
+// Determinism test for the seeded `permute` overload (cuML issue #7871:
+// make_regression was not reproducible with shuffle=True because permute
+// drew its affine coefficients from the unseeded global rand()). The same
+// seed must yield identical permutation indices across calls.
+template <typename T>
+class PermSeedTest : public ::testing::TestWithParam<PermInputs<T>> {
+ protected:
+  PermSeedTest()
+    : in(0, resource::get_cuda_stream(handle)),
+      out(0, resource::get_cuda_stream(handle)),
+      perms1(0, resource::get_cuda_stream(handle)),
+      perms2(0, resource::get_cuda_stream(handle))
+  {
+  }
+
+  void SetUp() override
+  {
+    auto stream = resource::get_cuda_stream(handle);
+    params      = ::testing::TestWithParam<PermInputs<T>>::GetParam();
+    int N       = params.N;
+    int D       = params.D;
+    int len     = N * D;
+    raft::random::RngState r(params.seed);
+    in.resize(len, stream);
+    out.resize(len, stream);
+    perms1.resize(N, stream);
+    perms2.resize(N, stream);
+    uniform(handle, r, in.data(), len, T(-1.0), T(1.0));
+
+    // Same seed twice -> the two permutations must be identical.
+    permute<T, int, int>(
+      perms1.data(), out.data(), in.data(), D, N, params.rowMajor, stream, params.seed);
+    permute<T, int, int>(
+      perms2.data(), out.data(), in.data(), D, N, params.rowMajor, stream, params.seed);
+    resource::sync_stream(handle);
+  }
+
+ protected:
+  raft::resources handle;
+  PermInputs<T> params;
+  rmm::device_uvector<T> in, out;
+  rmm::device_uvector<int> perms1, perms2;
+};
+
+using PermSeedTestF = PermSeedTest<float>;
+TEST_P(PermSeedTestF, SameSeedIsDeterministic)
+{
+  auto stream = resource::get_cuda_stream(handle);
+  int N       = params.N;
+  std::vector<int> h1(N), h2(N);
+  raft::update_host(h1.data(), perms1.data(), N, stream);
+  raft::update_host(h2.data(), perms2.data(), N, stream);
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+  ASSERT_EQ(h1, h2);
+
+  // Different seeds should produce different permutations. Only checked for
+  // larger N, where the space of affine permutations is large enough that a
+  // collision is astronomically unlikely.
+  if (N >= 1024) {
+    rmm::device_uvector<int> perms3(N, stream);
+    permute<float, int, int>(
+      perms3.data(), out.data(), in.data(), params.D, N, params.rowMajor, stream, params.seed + 1);
+    resource::sync_stream(handle);
+    std::vector<int> h3(N);
+    raft::update_host(h3.data(), perms3.data(), N, stream);
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+    ASSERT_NE(h1, h3);
+  }
+}
+INSTANTIATE_TEST_CASE_P(PermSeedTests, PermSeedTestF, ::testing::ValuesIn(inputsf));
 
 }  // end namespace random
 }  // end namespace raft

--- a/cpp/tests/random/permute.cu
+++ b/cpp/tests/random/permute.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -411,7 +411,37 @@ TEST_P(PermSeedTestF, SameSeedIsDeterministic)
     ASSERT_NE(h1, h3);
   }
 }
+
 INSTANTIATE_TEST_CASE_P(PermSeedTests, PermSeedTestF, ::testing::ValuesIn(inputsf));
+
+using PermSeedTestD = PermSeedTest<double>;
+TEST_P(PermSeedTestD, SameSeedIsDeterministic)
+{
+  using test_data_type = PermSeedTestD::test_data_type;
+  auto stream          = resource::get_cuda_stream(handle);
+  int N                = params.N;
+  std::vector<int> h1(N), h2(N);
+  raft::update_host(h1.data(), perms1.data(), N, stream);
+  raft::update_host(h2.data(), perms2.data(), N, stream);
+  RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+  ASSERT_EQ(h1, h2);
+
+  // Different seeds should produce different permutations. Only checked for
+  // larger N, where the space of affine permutations is large enough that a
+  // collision is astronomically unlikely.
+  if (N >= 1024) {
+    rmm::device_uvector<int> perms3(N, stream);
+    permute<test_data_type, int, int>(
+      perms3.data(), out.data(), in.data(), params.D, N, params.rowMajor, stream, params.seed + 1);
+    resource::sync_stream(handle);
+    std::vector<int> h3(N);
+    raft::update_host(h3.data(), perms3.data(), N, stream);
+    RAFT_CUDA_TRY(cudaStreamSynchronize(stream));
+    ASSERT_NE(h1, h3);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(PermSeedTests, PermSeedTestD, ::testing::ValuesIn(inputsd));
 
 }  // end namespace random
 }  // end namespace raft


### PR DESCRIPTION
## Summary
`raft::random::permute` drew the coefficients of its affine permutation
from the unseeded global C `rand()`, so results were not reproducible
across calls. This surfaced in cuML as rapidsai/cuml#7871:
`make_regression(..., shuffle=True)` returned different data on repeated
calls with the same `random_state`.

## Changes
- Add a `seed` parameter to `permute` that derives the permutation
  coefficients from a local `std::mt19937_64`, replacing the global `rand()`.
- Thread the existing `make_regression` seed through both the sample and
  feature shuffles (a distinct derived seed each, so the two shuffles stay
  independent).
- The public `permute` overloads default `seed = 0`, so existing callers
  are unaffected.
- Add `PermSeedTest` verifying the same seed yields identical permutations
  and different seeds yield different ones.

## Testing
All 667 tests in `RANDOM_TEST` pass locally (RTX 2060, CUDA arch 75).

Relates to rapidsai/cuml#7871