### PR TITLE
Pin CMake to < 4.4

### DIFF
--- a/conda/environments/all_cuda-129_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-129_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools=20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools=20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=12.9.2,<13.0
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-133_arch-aarch64.yaml
+++ b/conda/environments/all_cuda-133_arch-aarch64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools=20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -9,7 +9,7 @@ dependencies:
 - c-compiler
 - clang-tools=20.1.8
 - clang==20.1.8
-- cmake>=4.0
+- cmake>=4.0,<4.4
 - cuda-bindings>=13.0.1,<14.0
 - cuda-nvcc
 - cuda-nvtx-dev

--- a/conda/recipes/libraft/conda_build_config.yaml
+++ b/conda/recipes/libraft/conda_build_config.yaml
@@ -14,7 +14,7 @@ c_stdlib_version:
   - "2.28"
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 nccl_version:
   - ">=2.19"

--- a/conda/recipes/pylibraft/conda_build_config.yaml
+++ b/conda/recipes/pylibraft/conda_build_config.yaml
@@ -14,4 +14,4 @@ c_stdlib_version:
   - "2.28"
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"

--- a/conda/recipes/raft-dask/conda_build_config.yaml
+++ b/conda/recipes/raft-dask/conda_build_config.yaml
@@ -14,7 +14,7 @@ c_stdlib_version:
   - "2.28"
 
 cmake_version:
-  - ">=4.0"
+  - ">=4.0,<4.4"
 
 nccl_version:
   - ">=2.19"

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -191,7 +191,7 @@ dependencies:
     common:
       - output_types: [conda, requirements, pyproject]
         packages:
-          - &cmake_ver cmake>=4.0
+          - &cmake_ver cmake>=4.0,<4.4
           - ninja
       - output_types: [conda]
         packages:

--- a/python/libraft/pyproject.toml
+++ b/python/libraft/pyproject.toml
@@ -65,7 +65,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "librmm==26.8.*,>=0.0.0a0",
     "ninja",
     "rapids-logger==0.2.*,>=0.0.0a0",

--- a/python/pylibraft/pyproject.toml
+++ b/python/pylibraft/pyproject.toml
@@ -84,7 +84,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "cuda-bindings>=13.0.1,<14.0",
     "cython>=3.2.2",
     "libraft==26.8.*,>=0.0.0a0",

--- a/python/raft-dask/pyproject.toml
+++ b/python/raft-dask/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
@@ -83,7 +83,7 @@ regex = "(?P<value>.*)"
 [tool.rapids-build-backend]
 build-backend = "scikit_build_core.build"
 requires = [
-    "cmake>=4.0",
+    "cmake>=4.0,<4.4",
     "cython>=3.2.2",
     "libraft==26.8.*,>=0.0.0a0",
     "librmm==26.8.*,>=0.0.0a0",


### PR DESCRIPTION
## Description

rapids-cmake is currently broken by CMake 4.4, so pin CMake until we have a fix.

Issue: https://github.com/rapidsai/build-planning/issues/302
