### PR TITLE
fix(pre-commit): normalize SPDX handling

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -56,7 +56,7 @@ BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
 ColumnLimit: 100
-CommentPragmas: '^ ?[*]? ?(IWYU pragma:|SPDX-)'
+CommentPragmas: '(IWYU pragma:|SPDX-)'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 # Kept the below 2 to be the same as `IndentWidth` to keep everything uniform


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/303.

Standardizes clang-format's SPDX protection and ensures the repository uses `rapidsai/pre-commit-hooks` `v1.6.0`. It also restores malformed SPDX headers where present.

Validated with `pre-commit run --all-files`.
