### PR TITLE
Fix missing nvtx stack and host mem resource by exporting the symbols

### DIFF
--- a/cpp/include/raft/core/detail/nvtx_range_stack.hpp
+++ b/cpp/include/raft/core/detail/nvtx_range_stack.hpp
@@ -76,7 +76,7 @@ struct nvtx_range_name_stack {
   std::shared_ptr<current_range> current_{std::make_shared<current_range>()};
 };
 
-inline thread_local nvtx_range_name_stack range_name_stack_instance{};
+RAFT_EXPORT inline thread_local nvtx_range_name_stack range_name_stack_instance{};
 
 }  // namespace detail
 
@@ -85,7 +85,7 @@ inline thread_local nvtx_range_name_stack range_name_stack_instance{};
  * Pass the returned shared_ptr to another thread to read this thread's current NVTX range name at
  * any time.
  */
-inline auto thread_local_current_range() -> std::shared_ptr<const current_range>
+RAFT_EXPORT inline auto thread_local_current_range() -> std::shared_ptr<const current_range>
 {
   return detail::range_name_stack_instance.current();
 }

--- a/cpp/include/raft/core/detail/nvtx_range_stack.hpp
+++ b/cpp/include/raft/core/detail/nvtx_range_stack.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once

--- a/cpp/include/raft/mr/host_memory_resource.hpp
+++ b/cpp/include/raft/mr/host_memory_resource.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 #pragma once
@@ -69,7 +69,8 @@ RAFT_EXPORT inline auto get_default_host_resource() -> raft::mr::host_resource_r
  * @param res The resource to install.
  * @return The previous default host resource.
  */
-RAFT_EXPORT inline auto set_default_host_resource(raft::mr::host_resource res) -> raft::mr::host_resource
+RAFT_EXPORT inline auto set_default_host_resource(raft::mr::host_resource res)
+  -> raft::mr::host_resource
 {
   return detail::default_host_resource_holder_.set(res);
 }

--- a/cpp/include/raft/mr/host_memory_resource.hpp
+++ b/cpp/include/raft/mr/host_memory_resource.hpp
@@ -46,7 +46,7 @@ struct default_host_resource_holder {
   }
 };
 
-inline default_host_resource_holder default_host_resource_holder_{};
+RAFT_EXPORT inline default_host_resource_holder default_host_resource_holder_{};
 
 }  // namespace detail
 
@@ -56,7 +56,7 @@ inline default_host_resource_holder default_host_resource_holder_{};
  * Returns raft::mr::host_resource_ref pointing to the resource installed
  * via set_default_host_resource(), or new_delete_resource() if none was set.
  */
-inline auto get_default_host_resource() -> raft::mr::host_resource_ref
+RAFT_EXPORT inline auto get_default_host_resource() -> raft::mr::host_resource_ref
 {
   return detail::default_host_resource_holder_.get();
 }
@@ -69,7 +69,7 @@ inline auto get_default_host_resource() -> raft::mr::host_resource_ref
  * @param res The resource to install.
  * @return The previous default host resource.
  */
-inline auto set_default_host_resource(raft::mr::host_resource res) -> raft::mr::host_resource
+RAFT_EXPORT inline auto set_default_host_resource(raft::mr::host_resource res) -> raft::mr::host_resource
 {
   return detail::default_host_resource_holder_.set(res);
 }


### PR DESCRIPTION
<!--

Thank you for contributing to RAFT :)

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present) and replace
   it with `[REVIEW]`. If assistance is required to complete the functionality,
   for example when the C/C++ code of a feature is complete but Python bindings
   are still required, then add the label `[HELP-REQ]` so that others can triage
   and assist. The additional changes then can be implemented on top of the
   same PR. If the assistance is done by members of the rapidsAI team, then no
   additional actions are required by the creator of the original PR for this,
   otherwise the original author of the PR needs to give permission to the
   person(s) assisting to commit to their personal fork of the project. If that
   doesn't happen then a new PR based on the code of the original PR can be
   opened by the person assisting, which then will be the PR that will be
   merged.

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please do not
   rebase your branch on master/force push/rewrite history, doing any of these
   causes the context of any comments made by reviewers to be lost. If
   conflicts occur against master they should be resolved by merging master
   into the branch used for making the pull request.

Many thanks in advance for your cooperation!

-->

This https://github.com/NVIDIA/cuvs/pull/2052 changes default symbol visibility to cuvs from public to hidden. The `raft::memory_tracking_resources` introduced in raft earlier now has the host memory resource and nvtx stack range symbols switched to hidden (i.e. private within libcuvs.so). This led to empty nvtx stack name and missing host memory allocations in the .csv file produced by `raft::memory_tracking_resources`, because two DSO's kept two separate symbols.

The current PR explicitly exports those symbols again and fixes the issue.

**Analysis**

Before the changes, the symbols in the example and in the libcuvs.so are two different entities with different addresses.
```
default_host_resource_holder_ address (CAGRA_HNSW_ACE_BUILD_EXAMPLE): 0x63a2ff1cfa20
range_name_stack_instance address (CAGRA_HNSW_ACE_BUILD_EXAMPLE): 0x7fabe9d2f030

default_host_resource_holder_ address (libcuvs.so): 0x7fabed9fb7e0
range_name_stack_instance address (libcuvs.so): 0x7fabe9d2d010

$ nm -C /opt/conda/envs/cuvs/lib/libcuvs.so 
00000000036827e0 b raft::mr::detail::default_host_resource_holder_
0000000000001010 b raft::common::nvtx::detail::range_name_stack_instance
```
After exporting,
```
default_host_resource_holder_ addr (exe):        0x64a7d9f4ca20
range_name_stack_instance addr (exe, this thread): 0x740c67dfb030

default_host_resource_holder_ addr (libcuvs):        0x64a7d9f4ca20
range_name_stack_instance addr (libcuvs, this thread): 0x740c67dfb030

$ nm -C /opt/conda/envs/cuvs/lib/libcuvs.so 
000000000367f7e0 u raft::mr::detail::default_host_resource_holder_
0000000000001010 u raft::common::nvtx::detail::range_name_stack_instance
```